### PR TITLE
Market Climate v2 polish — Pass A (column headers + BSR axis)

### DIFF
--- a/src/components/Keepa/PreVettingTabs.tsx
+++ b/src/components/Keepa/PreVettingTabs.tsx
@@ -512,6 +512,14 @@ const SparkPopover: React.FC<{
               tickLine={false}
               width={48}
               domain={['auto', 'auto']}
+              // Explicit standard orientation: low values at the bottom,
+              // high at the top. For BSR (lower = better rank) the line
+              // visually drops as a competitor improves — counter-
+              // intuitive at first glance, but the "lower is better"
+              // caption underneath the chart frames it. This matches
+              // how the small inline sparkline renders by default, so
+              // they read consistently.
+              reversed={false}
             />
             <RechartsTooltip
               contentStyle={{
@@ -817,11 +825,13 @@ const CompetitorThumbnail: React.FC<{ imageUrl: string | null }> = ({ imageUrl }
 };
 
 /* ----------------------------------------------------------------------------
- * Column headers (right-aligned strip above the cards). All metrics are on
- * a 12-month window so the period qualifier is implicit. Launches gets no
- * sparkline column — for established listings the launch ramp data is
- * mostly empty, and even when present the 120-day-post-launch view isn't
- * intuitive. The QUICK / SLOW TRACTION badge does the at-a-glance work.
+ * Column headers (right-aligned strip above the cards). All non-tenure
+ * metrics are on a 12-month window — the headers carry the period
+ * explicitly so each row's pill label can stay terse (e.g. "Avg" instead
+ * of "Year avg"). Launches gets no sparkline column — for established
+ * listings the launch ramp data is mostly empty, and even when present
+ * the 120-day-post-launch view isn't intuitive. The QUICK / SLOW
+ * TRACTION badge does the at-a-glance work.
  * --------------------------------------------------------------------------*/
 
 interface LensHeaders {
@@ -831,8 +841,14 @@ interface LensHeaders {
 
 const COLUMN_HEADERS_BY_LENS: Record<LensId, LensHeaders> = {
   launch: { sparkLabel: null, statLabels: ['Launched', 'On Amazon'] },
-  'price-supply': { sparkLabel: 'Yearly trend', statLabels: ['Buy box avg', 'Buy box now'] },
-  rank: { sparkLabel: 'Yearly trend', statLabels: ['Avg BSR', 'Current BSR'] }
+  'price-supply': {
+    sparkLabel: 'Trend · Last 12mo',
+    statLabels: ['Buy Box Avg · Last 12mo', 'Buy Box Now']
+  },
+  rank: {
+    sparkLabel: 'Trend · Last 12mo',
+    statLabels: ['Avg BSR · Last 12mo', 'Current BSR']
+  }
 };
 
 const ColumnHeaders: React.FC<{ activeTab: LensId }> = ({ activeTab }) => {
@@ -1066,9 +1082,11 @@ const lensStats = (
       { label: 'Buy box now', value: formatCurrency(c.priceSupply.currentBuyBox) }
     ];
   }
+  // Column header carries "Last 12mo" / "Current BSR" — keep pill
+  // labels terse here so they don't restate the period.
   return [
     {
-      label: 'Year avg',
+      label: 'Avg',
       value: formatBsr(c.rank.bsrAvg365d),
       tone: toneForBsr(c.rank.bsrAvg365d)
     },


### PR DESCRIPTION
Pass A of the 7-item Pre-Vetting Reports punch list (`project_market_climate_v2_polish.md`). Items #5 and #6.

## Changes
- Column headers above the stat strip carry the period explicitly (`Trend · Last 12mo`, `Avg BSR · Last 12mo`, `Buy Box Avg · Last 12mo`). Row pills drop the now-redundant "Year" qualifier (`Year avg` → `Avg`).
- Popover YAxis pinned with explicit `reversed={false}`. Sparkline already reads low-at-bottom by default; this keeps the popover consistent so the two charts always read the same direction. "Lower is better" caption unchanged.

## Test plan
- [ ] Open Pre-Vetting Reports → Rank lens. Header row reads `Trend · Last 12mo / Avg BSR · Last 12mo / Current BSR`.
- [ ] Pills under each row read `Avg / Current` instead of `Year avg / Current`.
- [ ] Hover a sparkline — the popover BSR axis has low at the bottom, high at top (matching the inline sparkline).

Pass B (established-listing differentiation + 120-day popover framing) and Pass C (headline / expanded card / narration prompt tightening) come in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)