### PR TITLE
Market Climate v2 polish — Pass C (headline + narrative + demand fallback)

### DIFF
--- a/src/components/Keepa/PreVettingTabs.tsx
+++ b/src/components/Keepa/PreVettingTabs.tsx
@@ -1215,11 +1215,25 @@ const buildPriceBigPictureFallback = (set: CompetitorProfileSet): string => {
 const buildRankBigPictureFallback = (set: CompetitorProfileSet): string => {
   const bp = set.bigPicture.rank;
   if (bp.avgYearlyBsr === null) return 'Limited rank data across competitors.';
-  return `The top competitors average ${formatBsr(
-    bp.avgYearlyBsr
-  )} BSR over the year — the strongest sustained rank seen was ${formatBsr(
-    bp.bestYearlyBsr
-  )}, the worst ${formatBsr(bp.worstYearlyBsr)}. Demand is ${bp.bsrConsistency.replace(/-/g, ' ')}.`;
+  // Demand strength = how strong the category sells overall (BSR floor).
+  // Rank consistency = how lumpy day-to-day sales are. Two different axes —
+  // never collapse them. Prior version said "Demand is {bsrConsistency}"
+  // which produced "Demand is mixed" on markets with strong year-average
+  // BSRs. The wording must reflect demandStrength for the demand call.
+  const demandLabel: Record<typeof bp.demandStrength, string> = {
+    strong: 'Demand is strong',
+    moderate: 'Demand is moderate',
+    weak: 'Demand is thin',
+    unknown: 'Demand quality is unclear from the available data'
+  };
+  const consistencyLabel: Record<typeof bp.bsrConsistency, string> = {
+    consistent: 'and rank holds steady day-to-day',
+    mixed: 'though day-to-day rank swings noticeably',
+    'highly-volatile': 'with very lumpy day-to-day rank movement',
+    unknown: ''
+  };
+  const tail = consistencyLabel[bp.bsrConsistency] ? `, ${consistencyLabel[bp.bsrConsistency]}` : '';
+  return `Top competitors average ${formatBsr(bp.avgYearlyBsr)} BSR over the year — the strongest sustained rank seen was ${formatBsr(bp.bestYearlyBsr)}, the worst ${formatBsr(bp.worstYearlyBsr)}. ${demandLabel[bp.demandStrength]}${tail}.`;
 };
 
 export default PreVettingTabs;

--- a/src/services/marketClimateNarration.ts
+++ b/src/services/marketClimateNarration.ts
@@ -114,7 +114,18 @@ Big-picture summaries (one per lens, after the per-competitor narratives):
   • bsrConsistency describes how stable rank is day-to-day, NOT demand strength. A market can have strong demand AND volatile rank (lumpy day-to-day sales but real demand overall).
   • When summarizing: lead with demandStrength, then use bsrConsistency to color the day-to-day picture.
 
-For every competitor, also write a one-sentence "headline" that summarizes their full read in 14–22 words. Used in the collapsed list view.`;
+For every competitor, also write a one-sentence "headline" that summarizes their full read in 14–22 words. Used in the collapsed list view.
+
+REPETITION RULE — applies across every string you produce:
+- The collapsed row already shows: stat columns (Avg BSR · Last 12mo, Current BSR, Buy Box Avg · Last 12mo, Buy Box Now, Launched, On Amazon), tenure pill, and the Quick/Slow/Established/Volatile/Frequent-Stockouts badges.
+- The HEADLINE is an INSIGHT, not a measurement. Do NOT restate any number that already appears in the stats or pills. Say what the numbers MEAN for a new seller.
+  • Bad: "Established seller, on the market for 5.3y. Buy box currently $27.99." (both numbers visible already)
+  • Good: "Defensive operator with reliable supply — expect them to react quickly to undercutting." (interprets behavior)
+- The LENS NARRATIVE (expanded view) is ADDITIVE detail — surface numbers that are NOT in the stat columns or headline:
+  • Launch lens: launch list price + advertised discount, daysToFirstSale, daysToTraction.
+  • Price & Supply lens: priceFloor / priceCeiling range, priceChangesPerMonth, stockout details (cumulative days, longest run, daysSinceLast).
+  • Rank lens: bsrFloor / bsrCeiling, bsrAvg30d / bsrAvg90d short-window trend, volatilityPct, currentVsYearAverage interpretation.
+  • Pull at least one number that wasn't visible in the collapsed row. Do not begin the narrative by restating the year-average BSR or current buy-box — the stats column already shows those.`;
 
 // ============================================================
 // Tool schema
@@ -151,22 +162,22 @@ const MARKET_CLIMATE_TOOL = {
                 headline: {
                   type: 'string',
                   description:
-                    "14–22 word scannable summary of this competitor's read. Used in the collapsed list view. Example: 'Established seller with steady supply, but year-average BSR ~80K means recent good month is the exception, not the norm.'"
+                    "14–22 word scannable summary that INTERPRETS this competitor for a new seller. Do NOT restate numbers already shown in the stat columns (Avg BSR, Current BSR, Buy Box Avg, Buy Box Now, Launched, On Amazon) or in pills (Established / Quick traction / Frequent stockouts / Volatile). The headline must add a READ on those numbers. Bad: 'Established seller for 5.3y. Buy box $27.99.' Good: 'Defensive operator with reliable supply — expect them to react quickly to undercutting.' or 'Recent rank is misleading — year average is 80K, current good month is the exception.'"
                 },
                 launchNarrative: {
                   type: 'string',
                   description:
-                    "30–60 words on this competitor's launch story (when they entered, their playbook, time to gain traction). Reference the daysOnMarket / launchedOnSale / daysToTraction signals. If the competitor is established (well outside the analysis window), still note their tenure briefly and call out anything notable about their original launch playbook if knowable; otherwise just state how long they've been on the market and move on."
+                    "30–60 words on this competitor's launch story. ADDITIVE detail only — do not restate Launched / On Amazon (already in the stat columns). Pull from launchListPrice + launchBuyBoxPrice + launchDiscountPct (advertised discount %), daysToFirstSale, daysToTraction. Tell the seller what the launch playbook reveals about the category. If the competitor is established (outside the analysis window), keep this short — note tenure context and move on; do not invent launch detail you don't have."
                 },
                 priceSupplyNarrative: {
                   type: 'string',
                   description:
-                    "40–70 words on this competitor's pricing rhythm AND supply discipline together (they're entangled — when supply runs out, price often spikes first). Reference floor/ceiling/current, priceActivityLevel, stockout history. Tell the seller what to expect from this competitor: will they get undercut, are they reliable inventory-wise."
+                    "40–70 words on pricing rhythm + supply discipline together. ADDITIVE detail only — do not begin by restating Buy Box Avg / Buy Box Now (already in the stats). Pull from priceFloor / priceCeiling (the trading range, which is NEW info), priceChangesPerMonth, stockout history (cumulative days, longest single stockout, daysSinceLastStockout). Tell the seller what to expect from this competitor: will they get undercut, are they reliable inventory-wise, is the price ceiling a sign that premium pricing works."
                 },
                 rankNarrative: {
                   type: 'string',
                   description:
-                    "40–70 words on rank trajectory — the truth-teller of how this listing actually sells over the long haul. Lead with the all-year BSR average. Then the floor (best they've done) and ceiling (worst). Then how the CURRENT BSR compares to their year average — is recent BSR a fluke or the norm? Soft-framed conclusion about what a new seller should expect."
+                    "40–70 words on rank trajectory. ADDITIVE detail only — do not begin by restating Avg BSR or Current BSR (those numbers are already in the stat columns). Pull from bsrFloor (best rank ever seen) and bsrCeiling (worst), bsrAvg30d / bsrAvg90d (short-window trend), volatilityPct, currentVsYearAverage interpretation. The point is to tell the seller whether recent BSR is a fluke or the norm, and how lumpy day-to-day sales likely are."
                 }
               },
               required: ['asin', 'headline', 'launchNarrative', 'priceSupplyNarrative', 'rankNarrative']


### PR DESCRIPTION
Stacks on Pass B (#19). Items #3, #4, #7.

- **#3 Headline restating stats** — System prompt + tool-schema description rewritten to forbid restating numbers already shown in stat columns / pills. Headline must INTERPRET, not measure.
- **#4 Expanded card** — Per-lens narrative descriptions now list which numbers are NOT in the stat columns and must be surfaced (price floor/ceiling, price-change rhythm, stockout details, BSR floor/ceiling, short-window trend, volatility, current-vs-year-average).
- **#7 Big-picture demand call** — `buildRankBigPictureFallback()` was emitting "Demand is {bsrConsistency}", collapsing demand strength and rank stability into one phrase. Now reads `demandStrength` for the demand call and uses `bsrConsistency` separately for the rank-stability clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)