### PR TITLE
Phase 5.4-N: extension tier mislabel — same effectiveTier ≠ tier bug as web

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -53,7 +53,7 @@ import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import { checkCap } from '@/lib/subscription';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -150,14 +150,11 @@ export async function POST(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/funnel-asins/route.ts
+++ b/src/app/api/extension/funnel-asins/route.ts
@@ -25,7 +25,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -50,14 +50,11 @@ export async function GET(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/markets/route.ts
+++ b/src/app/api/extension/markets/route.ts
@@ -33,7 +33,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -58,14 +58,11 @@ export async function GET(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/me/route.ts
+++ b/src/app/api/extension/me/route.ts
@@ -24,6 +24,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
+  deriveEffectiveLensTier,
   deriveLensTier,
   extensionResponse,
   lensFeatures,
@@ -61,7 +62,7 @@ export async function GET(request: NextRequest) {
       supabaseAdmin.auth.admin.getUserById(resolved.userId),
       supabaseAdmin
         .from('profiles')
-        .select('subscription_status, subscription_type, full_name')
+        .select('tier, subscription_status, subscription_type, trial_ends_at, full_name')
         .eq('id', resolved.userId)
         .maybeSingle(),
       supabaseAdmin
@@ -81,11 +82,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
-    const features = lensFeatures(tier);
+    // Display tier (popup badge). Rule #14: stored tier, not effective.
+    const tier = deriveLensTier(profile ?? null);
+    // Features tier respects trial → pro elevation. Server-side gates
+    // (Save Funnel / Analyze Market / CSV) read this branch.
+    const features = lensFeatures(deriveEffectiveLensTier(profile ?? null));
 
     const searchesUsedThisMonth = searchCountResp.count ?? 0;
     const searchLimitReached =

--- a/src/app/api/extension/save-funnel/route.ts
+++ b/src/app/api/extension/save-funnel/route.ts
@@ -33,7 +33,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -84,14 +84,11 @@ export async function POST(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canSaveFunnel) {
       return withCors(
         request,

--- a/src/lib/extensionAuth.ts
+++ b/src/lib/extensionAuth.ts
@@ -15,6 +15,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createHash, randomBytes } from 'node:crypto';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
+import type { Tier } from './subscription/tiers';
 
 // -----------------------------------------------------------------------------
 // CORS
@@ -250,16 +251,47 @@ export type LensFeatures = {
   searchesPerMonth: number | null; // null = unlimited
 };
 
-export function deriveLensTier(
-  subscriptionStatus: string | null,
-  subscriptionType: string | null
-): LensTier {
-  // Per the Phase 5.4 plan: Core = MONTHLY paid, Pro = YEARLY paid.
-  // ACTIVE or TRIALING both grant full access; CANCELED or null = free.
-  if (subscriptionStatus === 'ACTIVE' || subscriptionStatus === 'TRIALING') {
-    return subscriptionType === 'YEARLY' ? 'pro' : 'core';
-  }
-  return 'free';
+// Minimum profile shape needed to derive a Lens tier. All five
+// /api/extension/* routes that gate behavior must select these columns.
+export type LensProfileFields = {
+  tier: Tier | null;
+  subscription_status: string | null;
+  trial_ends_at: string | null;
+};
+
+/**
+ * Display tier — what the popup badge shows ("Free" / "Core" / "Pro").
+ *
+ * Rule #14: this is the user's stored tier, NOT effectiveTier. A user
+ * mid-trial on the Core plan sees "Core" here, not "Pro" — the trial
+ * grants Pro *features* but the customer purchased Core. Only callers
+ * that need to gate features should use `deriveEffectiveLensTier`.
+ *
+ * Returns 'free' when the user has no active subscription regardless
+ * of stored tier — a canceled-but-was-Pro user should see the upsell.
+ */
+export function deriveLensTier(profile: LensProfileFields | null): LensTier {
+  if (!profile) return 'free';
+  const isPaying =
+    profile.subscription_status === 'ACTIVE' ||
+    profile.subscription_status === 'TRIALING';
+  if (!isPaying) return 'free';
+  return profile.tier ?? 'core';
+}
+
+/**
+ * Effective tier — what governs feature gating. Mirrors
+ * `getTierState().effectiveTier` from src/lib/subscription/state.ts:
+ * users in an active trial get Pro features regardless of stored tier.
+ * Used by all server-side gates (Save to Funnel, Analyze Market, CSV
+ * export). Never use this for display copy.
+ */
+export function deriveEffectiveLensTier(profile: LensProfileFields | null): LensTier {
+  if (!profile) return 'free';
+  const trialEndsAt = profile.trial_ends_at ? new Date(profile.trial_ends_at) : null;
+  const isInTrial = !!(trialEndsAt && trialEndsAt.getTime() > Date.now());
+  if (isInTrial) return 'pro';
+  return deriveLensTier(profile);
 }
 
 export function lensFeatures(tier: LensTier): LensFeatures {


### PR DESCRIPTION
## Summary

- `deriveLensTier()` was running stale Phase 5.4 logic that mapped `subscription_type` → tier (YEARLY=pro, MONTHLY=core). Sprint D split tier from billing interval — they're now independent axes (rule #14).
- Fix mirrors yesterday's two website-side fixes (`7be42a0` `/subscription`, `c2b450e` `/profile`). Replaces `deriveLensTier(status, type)` with `deriveLensTier(profile)` reading the new `tier` column. Adds `deriveEffectiveLensTier(profile)` for trial→pro elevation in feature gating.
- Five extension routes updated; response shape unchanged; no extension version bump or Web Store re-upload needed.

## Real-customer impact post-launch

| Customer | Before fix | After fix |
|---|---|---|
| Pro monthly (`tier=pro`, `subscription_type=MONTHLY`) | popup says "Core" | popup says "Pro" |
| Core yearly (`tier=core`, `subscription_type=YEARLY`) | popup says "Pro" | popup says "Core" |
| Trial users | no trial→pro elevation in feature derivation | gets Pro features via `effectiveTier` |
| Mentorship Pro (post-`b4922a3` migration) | popup says "Core" | popup says "Pro" |

Functional impact was limited because `lensFeatures(core)` and `lensFeatures(pro)` are identical for everything that's gated (same `canSaveFunnel`, `canVetMarket`, `canExportCsv`, unlimited searches). The popup tier badge was just lying to users.

## Test plan

- [ ] Verify Vercel preview build succeeds
- [ ] Sign Test Tesy (Core trial) in to extension popup on preview build → badge says "Core" (not "Pro" — trial users see purchased tier per rule #14)
- [ ] After deploy to main, verify `/api/extension/me` returns `plan.tier='pro'` for the 13 mentorship clients (was returning 'core')
- [ ] No regression in Save to Funnel / Analyze Market / Export CSV gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)