### PR TITLE
Phase 5.4-N → main: tier mislabel fix + r8 band-aware calibration

### DIFF
--- a/scripts/probes/calibrate-r8-bands-from-supabase.ts
+++ b/scripts/probes/calibrate-r8-bands-from-supabase.ts
@@ -1,0 +1,283 @@
+/**
+ * Phase 5.4-N r8: band-fit the 12 categories that were single-multiplier
+ * in v6, using the Supabase H10 corpus.
+ *
+ * Mirrors `calibrate-from-csv-folder.ts` band-fitting math but pulls
+ * samples from `submissions.submission_data.productData.competitors`
+ * (the v3 H10 corpus, ~3000 ASINs across 185 submissions). No new CSVs
+ * needed — the same data the v3 single-mult fit ran on.
+ *
+ * The 6 categories already band-fit in v6 (Beauty, H&H, Cell Phones,
+ * Automotive, Home & Kitchen, Musical Instruments) are SKIPPED — those
+ * fits used per-category H10 batches, not the in-Supabase corpus, and
+ * shouldn't be regressed.
+ *
+ * Output: prints a paste-ready snippet per category for hand-editing
+ * into bsrCategoryMultipliers.ts. Does NOT auto-overwrite the file.
+ *
+ * Run: `npx tsx scripts/probes/calibrate-r8-bands-from-supabase.ts`
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { bsrToMonthlyUnits } from '../../src/lib/extension/bsrSalesCurve';
+
+try {
+  const t = fs.readFileSync(path.join(process.cwd(), '.env.local'), 'utf8');
+  for (const l of t.split('\n')) {
+    const m = l.match(/^\s*([A-Z0-9_]+)=(.*)$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+  }
+} catch {}
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+);
+
+// 12 v6 single-multiplier categories that need band fits.
+// Baby + Baby Products are aliases — fit Baby, copy to Baby Products.
+const TARGET_CATEGORIES = new Set([
+  'Kitchen & Dining',
+  'Sports & Outdoors',
+  'Pet Supplies',
+  'Toys & Games',
+  'Office Products',
+  'Patio, Lawn & Garden',
+  'Tools & Home Improvement',
+  'Baby',
+  'Arts, Crafts & Sewing',
+  'Electronics',
+  'Industrial & Scientific',
+]);
+
+// Locked 2026-05-06, see project_calibration_vision.md.
+const BANDS: Array<[number, number, string]> = [
+  [0,         4_000,    '0-4k'],
+  [4_000,    15_000,    '4k-15k'],
+  [15_000,   60_000,    '15k-60k'],
+  [60_000,  200_000,    '60k-200k'],
+  [200_000, Infinity,   '200k+'],
+];
+
+const MIN_SAMPLES_PER_BAND = 30;
+const MIN_SAMPLES_FOR_CATEGORY = 50;
+
+type Sample = { asin: string; bsr: number; monthlySales: number; ratio: number; source: 'csv' | 'submission' };
+
+// JSONL corpus from scripts/probes/data/h10-extra-corpus.jsonl — same
+// dataset v6 (recalibrate-base-curve.ts) trained on. Mostly popular-BSR
+// cleanly-parent-child products. Without this the Supabase-only fit
+// loses ~50% of training samples for several categories.
+function loadCsvCorpus(): Map<string, Sample[]> {
+  const byCat = new Map<string, Sample[]>();
+  const p = path.join(process.cwd(), 'scripts/probes/data/h10-extra-corpus.jsonl');
+  if (!fs.existsSync(p)) return byCat;
+  const lines = fs.readFileSync(p, 'utf8').split('\n').filter(Boolean);
+  let count = 0;
+  for (const l of lines) {
+    const r = JSON.parse(l);
+    if (!r.asin || !r.bsr || !r.category || !r.parentSales) continue;
+    if (!TARGET_CATEGORIES.has(r.category)) continue;
+    const expected = bsrToMonthlyUnits(r.bsr);
+    if (expected == null || expected <= 0) continue;
+    if (!byCat.has(r.category)) byCat.set(r.category, []);
+    byCat.get(r.category)!.push({
+      asin: r.asin,
+      bsr: r.bsr,
+      monthlySales: r.parentSales,
+      ratio: r.parentSales / expected,
+      source: 'csv',
+    });
+    count++;
+  }
+  console.log(`CSV corpus: ${count} samples in target categories.`);
+  return byCat;
+}
+
+const median = (n: number[]): number => {
+  if (!n.length) return 0;
+  const s = [...n].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+const pct = (a: number[], p: number): number => {
+  if (!a.length) return 0;
+  const s = [...a].sort((x, y) => x - y);
+  return s[Math.min(s.length - 1, Math.floor((s.length - 1) * p))];
+};
+
+async function loadCorpus(): Promise<Map<string, Sample[]>> {
+  const byCat = new Map<string, Sample[]>();
+  const CHUNK = 10;
+  let offset = 0;
+  let totalSubs = 0;
+  let totalSamples = 0;
+
+  while (true) {
+    const { data: rows, error } = await supabase
+      .from('submissions')
+      .select('id, submission_data')
+      .range(offset, offset + CHUNK - 1)
+      .order('id', { ascending: true });
+    if (error) throw error;
+    if (!rows || rows.length === 0) break;
+
+    for (const row of rows) {
+      totalSubs++;
+      const competitors: any[] =
+        (row as any).submission_data?.productData?.competitors ?? [];
+      for (const c of competitors) {
+        // Mirror recalibrate-base-curve.ts: only single-variation rows.
+        // For multi-variation products monthlySales is ambiguous (parent
+        // vs child) and would bias the ratio. Single-variation = parent
+        // = child, no ambiguity.
+        const v = c?.variations;
+        const isSingle = v === 'No' || v === 'no' || v === 1 || v === '1' || v === 'N/A';
+        if (!isSingle) continue;
+        const bsr = Number(c?.bsr);
+        const monthlySales = Number(c?.monthlySales);
+        const category = String(c?.category ?? '').trim();
+        const asin = String(c?.asin ?? '').trim();
+        if (!bsr || !monthlySales || !category || !asin) continue;
+        if (bsr <= 0 || monthlySales <= 0) continue;
+        if (!TARGET_CATEGORIES.has(category)) continue;
+        const expected = bsrToMonthlyUnits(bsr);
+        if (expected == null || expected <= 0) continue;
+        const ratio = monthlySales / expected;
+        if (!byCat.has(category)) byCat.set(category, []);
+        byCat.get(category)!.push({ asin, bsr, monthlySales, ratio, source: 'submission' });
+        totalSamples++;
+      }
+    }
+    process.stdout.write(
+      `  offset=${String(offset).padStart(4)} subs=${rows.length} cumulative_target_samples=${totalSamples}\n`
+    );
+    offset += CHUNK;
+    if (rows.length < CHUNK) break;
+  }
+
+  console.log(`\nSupabase: ${totalSamples} raw samples (${totalSubs} submissions scanned).`);
+  return byCat;
+}
+
+function mergeCorpora(
+  supabase: Map<string, Sample[]>,
+  csv: Map<string, Sample[]>,
+): Map<string, Sample[]> {
+  const cats = new Set<string>([...supabase.keys(), ...csv.keys()]);
+  const merged = new Map<string, Sample[]>();
+  for (const cat of cats) {
+    const subs = supabase.get(cat) ?? [];
+    const csvs = csv.get(cat) ?? [];
+    // Dedupe by ASIN. CSV wins per recalibrate-base-curve.ts (newer +
+    // cleaner schema). Insert submissions first, then CSV overwrites.
+    const byAsin = new Map<string, Sample>();
+    for (const s of subs) byAsin.set(s.asin, s);
+    for (const s of csvs) byAsin.set(s.asin, s);
+    merged.set(cat, [...byAsin.values()]);
+  }
+  return merged;
+}
+
+function fitCategory(cat: string, samples: Sample[]): string {
+  const ratios = samples.map(s => s.ratio);
+  const def = median(ratios);
+  const lines: string[] = [];
+
+  lines.push(`  // ${cat}`);
+  lines.push(
+    `  //   n=${samples.length}  default(median)=${def.toFixed(3)}x  ` +
+    `IQR=[${pct(ratios, 0.25).toFixed(2)}, ${pct(ratios, 0.75).toFixed(2)}]  ` +
+    `P10-P90=[${pct(ratios, 0.10).toFixed(2)}, ${pct(ratios, 0.90).toFixed(2)}]`
+  );
+
+  const bandLines: string[] = [];
+  for (const [lo, hi, label] of BANDS) {
+    const inBand = samples.filter(s => s.bsr >= lo && s.bsr < hi);
+    if (inBand.length < MIN_SAMPLES_PER_BAND) {
+      lines.push(
+        `  //   band ${label.padEnd(9)} n=${String(inBand.length).padStart(3)}  ` +
+        `-> dropped (n<${MIN_SAMPLES_PER_BAND}, falls back to default)`
+      );
+      continue;
+    }
+    const r = inBand.map(s => s.ratio);
+    const m = median(r);
+    lines.push(
+      `  //   band ${label.padEnd(9)} n=${String(inBand.length).padStart(3)}  ` +
+      `median=${m.toFixed(3)}x  IQR=[${pct(r, 0.25).toFixed(2)}, ${pct(r, 0.75).toFixed(2)}]`
+    );
+    const hiStr = hi === Infinity ? 'Infinity' : String(hi);
+    bandLines.push(`      { bsrMin: ${lo}, bsrMax: ${hiStr}, mult: ${m.toFixed(3)}, n: ${inBand.length} },`);
+  }
+
+  lines.push(`  "${cat}": {`);
+  lines.push(`    default: ${def.toFixed(3)},`);
+  lines.push(`    n: ${samples.length},`);
+  lines.push(`    fitDate: "${new Date().toISOString().slice(0, 10)}",`);
+  if (bandLines.length) {
+    lines.push(`    bands: [`);
+    for (const b of bandLines) lines.push(b);
+    lines.push(`    ],`);
+  }
+  lines.push(`  },`);
+  return lines.join('\n');
+}
+
+async function main() {
+  console.log('=== Phase 5.4-N r8: band-fit 12 v6 single-mult categories ===');
+  console.log(`Targets: ${[...TARGET_CATEGORIES].join(', ')}\n`);
+  console.log(`Bands: ${BANDS.map(b => b[2]).join('  /  ')}`);
+  console.log(`Min samples per band: ${MIN_SAMPLES_PER_BAND}    Min samples per category: ${MIN_SAMPLES_FOR_CATEGORY}\n`);
+
+  const supabaseCorpus = await loadCorpus();
+  const csvCorpus = loadCsvCorpus();
+  const byCat = mergeCorpora(supabaseCorpus, csvCorpus);
+  if (!byCat.size) {
+    console.error('no usable rows found in target categories');
+    process.exit(1);
+  }
+
+  const totalAfterMerge = [...byCat.values()].reduce((a, b) => a + b.length, 0);
+  console.log(`Merged corpus (CSV-wins dedup by ASIN): ${totalAfterMerge} samples across ${byCat.size} categories.\n`);
+
+  const cats = Array.from(byCat.entries()).sort((a, b) => b[1].length - a[1].length);
+
+  // Print a summary table first so Dave can eyeball n-distributions
+  // before scanning the per-category fits.
+  console.log('Pre-fit summary:');
+  console.log(`${'Category'.padEnd(28)} | ${'n'.padEnd(5)} | ${'0-4k'.padEnd(6)} | ${'4k-15k'.padEnd(6)} | ${'15k-60k'.padEnd(7)} | ${'60k-200k'.padEnd(8)} | ${'200k+'.padEnd(6)}`);
+  console.log('-'.repeat(84));
+  for (const [cat, list] of cats) {
+    const counts = BANDS.map(([lo, hi]) =>
+      list.filter(s => s.bsr >= lo && s.bsr < hi).length
+    );
+    console.log(
+      `${cat.padEnd(28)} | ${String(list.length).padEnd(5)} | ` +
+      counts.map((c, i) => String(c).padEnd([6, 6, 7, 8, 6][i])).join(' | ')
+    );
+  }
+  console.log();
+
+  console.log('=== Per-category fits (paste-ready) ===\n');
+  for (const [cat, list] of cats) {
+    if (list.length < MIN_SAMPLES_FOR_CATEGORY) {
+      console.log(`SKIP "${cat}" — n=${list.length} below threshold ${MIN_SAMPLES_FOR_CATEGORY}\n`);
+      continue;
+    }
+    console.log(fitCategory(cat, list));
+    console.log();
+  }
+
+  // Note about Baby Products alias
+  if (byCat.has('Baby')) {
+    console.log('// NOTE: Baby Products is an alias of Baby — copy the same fit to both.\n');
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -53,7 +53,7 @@ import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import { checkCap } from '@/lib/subscription';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -150,14 +150,11 @@ export async function POST(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/funnel-asins/route.ts
+++ b/src/app/api/extension/funnel-asins/route.ts
@@ -25,7 +25,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -50,14 +50,11 @@ export async function GET(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/markets/route.ts
+++ b/src/app/api/extension/markets/route.ts
@@ -33,7 +33,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -58,14 +58,11 @@ export async function GET(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canVetMarket) {
       return withCors(
         request,

--- a/src/app/api/extension/me/route.ts
+++ b/src/app/api/extension/me/route.ts
@@ -24,6 +24,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
+  deriveEffectiveLensTier,
   deriveLensTier,
   extensionResponse,
   lensFeatures,
@@ -61,7 +62,7 @@ export async function GET(request: NextRequest) {
       supabaseAdmin.auth.admin.getUserById(resolved.userId),
       supabaseAdmin
         .from('profiles')
-        .select('subscription_status, subscription_type, full_name')
+        .select('tier, subscription_status, subscription_type, trial_ends_at, full_name')
         .eq('id', resolved.userId)
         .maybeSingle(),
       supabaseAdmin
@@ -81,11 +82,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
-    const features = lensFeatures(tier);
+    // Display tier (popup badge). Rule #14: stored tier, not effective.
+    const tier = deriveLensTier(profile ?? null);
+    // Features tier respects trial → pro elevation. Server-side gates
+    // (Save Funnel / Analyze Market / CSV) read this branch.
+    const features = lensFeatures(deriveEffectiveLensTier(profile ?? null));
 
     const searchesUsedThisMonth = searchCountResp.count ?? 0;
     const searchLimitReached =

--- a/src/app/api/extension/save-funnel/route.ts
+++ b/src/app/api/extension/save-funnel/route.ts
@@ -33,7 +33,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import {
   corsPreflight,
-  deriveLensTier,
+  deriveEffectiveLensTier,
   extensionResponse,
   lensFeatures,
   resolveExtensionToken,
@@ -84,14 +84,11 @@ export async function POST(request: NextRequest) {
 
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('subscription_status, subscription_type')
+      .select('tier, subscription_status, trial_ends_at')
       .eq('id', resolved.userId)
       .maybeSingle();
 
-    const tier = deriveLensTier(
-      profile?.subscription_status ?? null,
-      profile?.subscription_type ?? null
-    );
+    const tier = deriveEffectiveLensTier(profile ?? null);
     if (!lensFeatures(tier).canSaveFunnel) {
       return withCors(
         request,

--- a/src/lib/extension/bsrCategoryMultipliers.ts
+++ b/src/lib/extension/bsrCategoryMultipliers.ts
@@ -1,6 +1,17 @@
-// Hand-edited 2026-05-06 (v6) on top of recalibrate-base-curve.ts output.
-// Re-run the harness to regenerate the v3 multipliers; manually re-add
-// the v6 entries below if it overwrites this file.
+// Hand-edited 2026-05-08 (v7) — adds band-aware fits to the 12 categories
+// that were single-multiplier in v6. Source: scripts/probes/calibrate-r8-
+// bands-from-supabase.ts run against merged corpus (Supabase submissions
+// + scripts/probes/data/h10-extra-corpus.jsonl, 2,506 deduped samples).
+// Defaults landed within ±13% of v6 across all 11 categories, validating
+// corpus stability. 10 of 11 picked up at least one fitted band (n>=30).
+//
+// v6 r7 entries (Beauty, Health & Household, Cell Phones, Automotive,
+// Home & Kitchen, Musical Instruments) preserved as-is — those used
+// fresh per-category H10 batches and shouldn't be regressed.
+//
+// Re-run the harness to regenerate proposed multipliers; manually re-
+// edit this file (do not auto-overwrite) to keep the per-category
+// notes that aren't reproducible from the data alone.
 //
 // Per-Amazon-root-category multipliers applied on top of the v1.2.0 base
 // BSR curve. Trained against H10 Xray CSV exports stored either in the
@@ -30,7 +41,7 @@
 // Categories not in this table fall back to 1.0x (the universal curve).
 // That's safer than guessing.
 
-export const CATEGORY_CALIBRATION_VERSION = 'v6-2026-05-06-band-aware-r7';
+export const CATEGORY_CALIBRATION_VERSION = 'v7-2026-05-08-band-aware-r8';
 
 export type CategoryBand = {
   /** Inclusive lower bound. */
@@ -56,23 +67,165 @@ export type CategoryCalibration = {
 };
 
 export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
-  // v3 — high-confidence (median in 0.5x-2.0x band against in-Supabase
-  // H10 corpus). No band breakdown yet — Phase 5.4-I roadmap calls for
-  // re-running the calibration harness against the existing corpus to
-  // emit per-band multipliers for these categories.
-  "Kitchen & Dining":         { default: 0.853, n: 488, fitDate: "2026-05-04" },
-  "Sports & Outdoors":        { default: 0.758, n: 280, fitDate: "2026-05-04" },
-  "Pet Supplies":             { default: 0.611, n: 217, fitDate: "2026-05-04" },
-  "Toys & Games":             { default: 1.199, n: 202, fitDate: "2026-05-04" },
-  "Office Products":          { default: 1.288, n: 172, fitDate: "2026-05-04" },
-  "Patio, Lawn & Garden":     { default: 0.635, n: 166, fitDate: "2026-05-04" },
-  "Tools & Home Improvement": { default: 1.614, n: 164, fitDate: "2026-05-04" },
-  "Baby":                     { default: 0.925, n: 115, fitDate: "2026-05-04" },
-  // alias — Keepa returns "Baby Products" for the same root
-  "Baby Products":            { default: 0.925, n: 115, fitDate: "2026-05-04" },
-  "Arts, Crafts & Sewing":    { default: 0.579, n: 104, fitDate: "2026-05-04" },
-  "Electronics":              { default: 0.624, n: 92,  fitDate: "2026-05-04" },
-  "Industrial & Scientific":  { default: 0.523, n: 70,  fitDate: "2026-05-04" },
+  // Phase 5.4-N r8 (2026-05-08) — band-aware fits replacing v6's single-
+  // multiplier "v3" block. Same merged corpus as v6 (Supabase + JSONL),
+  // refit against the v1.2.0 base curve. Defaults within ±13% of v6.
+
+  // Kitchen & Dining — n=480. All 5 bands fit. Top movers (1.14x) and
+  // hunt-low (1.39x) higher than default; long tail (0.41x) much lower.
+  // The single 0.853x default was splitting a 3.4x range across bands.
+  "Kitchen & Dining": {
+    default: 0.935,
+    n: 480,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 1.141, n: 103 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 1.393, n: 63 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 0.836, n: 125 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 0.731, n: 129 },
+      { bsrMin: 200_000,  bsrMax: Infinity, mult: 0.406, n: 60 },
+    ],
+  },
+
+  // Sports & Outdoors — n=329. All 5 bands fit. Top movers undershoot
+  // default (0.47x); hunt-mid is at parity (1.01x); long tail back to
+  // default. Reasonable spread, supports the band-aware approach.
+  "Sports & Outdoors": {
+    default: 0.750,
+    n: 329,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 0.470, n: 51 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 0.714, n: 50 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 1.011, n: 103 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 0.657, n: 71 },
+      { bsrMin: 200_000,  bsrMax: Infinity, mult: 0.717, n: 54 },
+    ],
+  },
+
+  // Pet Supplies — n=231. 3 hunt-zone bands (4k-200k). Top + deep-tail
+  // bands have <30 samples, fall back to default 0.59x.
+  "Pet Supplies": {
+    default: 0.592,
+    n: 231,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 0.743, n: 47 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.651, n: 104 },
+      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.450, n: 62 },
+    ],
+  },
+
+  // Toys & Games — n=249. Top 3 bands fit (0-60k); tail falls back. T&G
+  // is a hunt-zone-heavy category, so the default 1.20x and the bands
+  // (1.09x / 1.37x / 1.48x) are tightly clustered — the band-aware fit
+  // doesn't change much here, but it's now band-aware for consistency.
+  "Toys & Games": {
+    default: 1.198,
+    n: 249,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0,       bsrMax: 4_000,   mult: 1.087, n: 127 },
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 1.368, n: 54 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 1.475, n: 41 },
+    ],
+  },
+
+  // Office Products — n=198. Top 3 bands fit. Higher-than-1.0x in the
+  // hunt zone (1.16x → 1.57x → 1.63x), undercutting the 1.29x v6 default
+  // for top movers and overshooting it for hunt-mid.
+  "Office Products": {
+    default: 1.262,
+    n: 198,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0,       bsrMax: 4_000,   mult: 1.161, n: 86 },
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 1.567, n: 34 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 1.633, n: 52 },
+    ],
+  },
+
+  // Patio, Lawn & Garden — n=208. 3 bands fit (4k-200k). Hunt-low band
+  // (4k-15k) is dramatically lower than mid (0.32x vs 0.74x) — likely
+  // seasonal/niche-product noise. IQR for that band is wide.
+  "Patio, Lawn & Garden": {
+    default: 0.676,
+    n: 208,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 0.317, n: 30 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.738, n: 93 },
+      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.683, n: 48 },
+    ],
+  },
+
+  // Tools & Home Improvement — n=339. 4 bands fit. Strong band structure:
+  // top movers undershoot (1.24x), hunt-mid spikes (2.41x), tail back to
+  // default. Doubles the v6 sample count thanks to the merged corpus.
+  "Tools & Home Improvement": {
+    default: 1.626,
+    n: 339,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0,       bsrMax: 4_000,   mult: 1.243, n: 90 },
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 1.857, n: 66 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 2.407, n: 81 },
+      { bsrMin: 60_000,  bsrMax: 200_000, mult: 1.757, n: 73 },
+    ],
+  },
+
+  // Baby — n=145. Only 1 band qualifies (0-4k); higher BSRs sparse.
+  // Baby Products is an alias — Keepa returns it for the same Amazon
+  // root. Both entries kept identical so leaf-first lookup hits either.
+  "Baby": {
+    default: 0.926,
+    n: 145,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0, bsrMax: 4_000, mult: 1.175, n: 88 },
+    ],
+  },
+  "Baby Products": {
+    default: 0.926,
+    n: 145,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0, bsrMax: 4_000, mult: 1.175, n: 88 },
+    ],
+  },
+
+  // Arts, Crafts & Sewing — n=126. 2 bands fit (15k-200k). Hunt-mid at
+  // 0.74x, long-tail collapses to 0.35x — typical pattern for craft
+  // products where deep-tail BSRs have very low velocity.
+  "Arts, Crafts & Sewing": {
+    default: 0.582,
+    n: 126,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.742, n: 56 },
+      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.345, n: 30 },
+    ],
+  },
+
+  // Electronics — n=116. Only 1 band qualifies (0-4k). The corpus is
+  // weighted toward popular electronics; hunt zones thin out fast.
+  "Electronics": {
+    default: 0.665,
+    n: 116,
+    fitDate: "2026-05-08",
+    bands: [
+      { bsrMin: 0, bsrMax: 4_000, mult: 0.705, n: 78 },
+    ],
+  },
+
+  // Industrial & Scientific — n=85. No bands meet the n>=30 threshold;
+  // default-only fit. Niche category — would need fresh per-category
+  // batches to band-fit cleanly.
+  "Industrial & Scientific": {
+    default: 0.590,
+    n: 85,
+    fitDate: "2026-05-08",
+  },
 
   // Phase 5.4-I r7 (2026-05-06) — band-aware fits from fresh per-category
   // H10 batches. Total new samples: 2,304 ASINs across 6 categories.

--- a/src/lib/extensionAuth.ts
+++ b/src/lib/extensionAuth.ts
@@ -15,6 +15,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createHash, randomBytes } from 'node:crypto';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
+import type { Tier } from './subscription/tiers';
 
 // -----------------------------------------------------------------------------
 // CORS
@@ -250,16 +251,47 @@ export type LensFeatures = {
   searchesPerMonth: number | null; // null = unlimited
 };
 
-export function deriveLensTier(
-  subscriptionStatus: string | null,
-  subscriptionType: string | null
-): LensTier {
-  // Per the Phase 5.4 plan: Core = MONTHLY paid, Pro = YEARLY paid.
-  // ACTIVE or TRIALING both grant full access; CANCELED or null = free.
-  if (subscriptionStatus === 'ACTIVE' || subscriptionStatus === 'TRIALING') {
-    return subscriptionType === 'YEARLY' ? 'pro' : 'core';
-  }
-  return 'free';
+// Minimum profile shape needed to derive a Lens tier. All five
+// /api/extension/* routes that gate behavior must select these columns.
+export type LensProfileFields = {
+  tier: Tier | null;
+  subscription_status: string | null;
+  trial_ends_at: string | null;
+};
+
+/**
+ * Display tier — what the popup badge shows ("Free" / "Core" / "Pro").
+ *
+ * Rule #14: this is the user's stored tier, NOT effectiveTier. A user
+ * mid-trial on the Core plan sees "Core" here, not "Pro" — the trial
+ * grants Pro *features* but the customer purchased Core. Only callers
+ * that need to gate features should use `deriveEffectiveLensTier`.
+ *
+ * Returns 'free' when the user has no active subscription regardless
+ * of stored tier — a canceled-but-was-Pro user should see the upsell.
+ */
+export function deriveLensTier(profile: LensProfileFields | null): LensTier {
+  if (!profile) return 'free';
+  const isPaying =
+    profile.subscription_status === 'ACTIVE' ||
+    profile.subscription_status === 'TRIALING';
+  if (!isPaying) return 'free';
+  return profile.tier ?? 'core';
+}
+
+/**
+ * Effective tier — what governs feature gating. Mirrors
+ * `getTierState().effectiveTier` from src/lib/subscription/state.ts:
+ * users in an active trial get Pro features regardless of stored tier.
+ * Used by all server-side gates (Save to Funnel, Analyze Market, CSV
+ * export). Never use this for display copy.
+ */
+export function deriveEffectiveLensTier(profile: LensProfileFields | null): LensTier {
+  if (!profile) return 'free';
+  const trialEndsAt = profile.trial_ends_at ? new Date(profile.trial_ends_at) : null;
+  const isInTrial = !!(trialEndsAt && trialEndsAt.getTime() > Date.now());
+  if (isInTrial) return 'pro';
+  return deriveLensTier(profile);
 }
 
 export function lensFeatures(tier: LensTier): LensFeatures {


### PR DESCRIPTION
Promotes Phase 5.4-N work from dev to main. Both PRs already merged + validated on dev preview.

## Includes

- **#25** Phase 5.4-N: extension /api/me tier mislabel
  - Same `effectiveTier ≠ tier` bug pattern as yesterday's two web-side fixes
  - Replaces stale `deriveLensTier(status, type)` (read `subscription_type`) with `deriveLensTier(profile)` (reads new `tier` column)
  - Adds `deriveEffectiveLensTier()` for trial→pro elevation in feature gating
  - Five extension routes updated; response shape unchanged; no extension version bump

- **#26** Phase 5.4-N r8: band-fit the 12 v6 single-multiplier categories
  - Re-fits 11 categories against same merged corpus v6 used (Supabase + JSONL, 2,506 deduped samples)
  - 10 of 11 picked up at least one fitted band (n≥30); Industrial & Scientific stays default-only
  - Defaults within ±13% of v6 across all 11 categories — corpus is stable
  - Notable: Tools & Home Improvement hunt-mid spikes to 2.41x (was masked by 1.63x default), Kitchen & Dining spans 3.4x range across bands
  - Version stamp: `v6-2026-05-06-band-aware-r7` → `v7-2026-05-08-band-aware-r8`

## Test plan

- [x] Vercel preview build green on dev
- [ ] Production webhook signing secret verification (Test Tesy resume → cancel cycle)
- [ ] Spot-check `/api/extension/me` returns `plan.tier='pro'` for mentorship clients
- [ ] Spot-check Lens enrichment uses r8 multipliers for affected categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)