### PR TITLE
Phase 5.4-O PR B: Market Expansions UI + tooltips + cleanup

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -269,6 +269,12 @@ export async function GET(request: NextRequest) {
             // /vetting list page can show the "+N new" badge.
             lensExpansions,
             hasUnacknowledgedExpansion: lensExpansions.some((e: any) => !e?.acknowledged),
+            // Transitional: the legacy __lens_pending_recalc flag (set by
+            // pre-5.4-O analyze-market) so the banner can fall back when
+            // BloomLens hit the production-version of analyze-market and
+            // wrote the legacy flag without a lensExpansions[] entry.
+            // Drop after PR A ships to production for a full deploy cycle.
+            lensPendingRecalcLegacy: Boolean(sub.submission_data?.__lens_pending_recalc),
           };
         })
         

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -16,9 +16,7 @@
 //            a new entry to submission_data.lensExpansions[] (one per
 //            expansion event, append-only log) capturing the
 //            preExpansionSnapshot so /vetting/[asin]'s recalc banner
-//            can offer per-batch undo. The legacy __lens_pending_recalc
-//            flag is dual-written for one cycle so any stale clients
-//            keep working until the new lensExpansions-based UI ships.
+//            can offer per-batch undo.
 //
 // Auth: Authorization: Bearer <ext_token>
 // Tier: Core or Pro (Free hits 403).
@@ -509,6 +507,17 @@ async function handleAppend(
   const viewUrl = await resolveSubmissionViewUrl(submission);
 
   if (newCompetitors.length === 0) {
+    // Phase 5.4-O — pendingRecalc now reflects the lensExpansions log
+    // (any entry with scoreAfter still null), with a fallback read of
+    // the legacy __lens_pending_recalc flag for rows created before
+    // 5.4-O landed. Response shape unchanged so the extension client
+    // doesn't need a re-deploy.
+    const existingExpansionsForReply: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+    const pendingRecalc =
+      existingExpansionsForReply.some((e: any) => e?.scoreAfter == null) ||
+      Boolean(submissionData.__lens_pending_recalc);
     return extensionResponse(
       request,
       {
@@ -518,7 +527,7 @@ async function handleAppend(
         viewUrl,
         addedCount: 0,
         skippedCount,
-        pendingRecalc: Boolean(submissionData.__lens_pending_recalc),
+        pendingRecalc,
       },
       resolved
     );
@@ -570,13 +579,15 @@ async function handleAppend(
     },
     __lens_origin: true,
     __lens_last_appended_at: nowIso,
-    // Legacy flag — dual-written for one deploy cycle while the new
-    // lensExpansions-based UI rolls out. Drop after PR B stabilizes.
-    __lens_pending_recalc: isVetted ? true : Boolean(submissionData.__lens_pending_recalc),
     ...(newExpansionEntry
       ? { lensExpansions: [...existingExpansions, newExpansionEntry] }
       : {}),
   };
+  // Legacy __lens_pending_recalc was dual-written in PR A for safety
+  // while the lensExpansions-based UI was in flight. PR B reads
+  // lensExpansions only — no consumer remains for the legacy flag, so
+  // we drop the write. Existing rows that still have the flag set
+  // unchanged (lensExpansions presence supersedes it).
 
   const totalRevenue = updatedCompetitors.reduce(
     (sum, c) => sum + (typeof c.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),

--- a/src/app/api/extension/markets/route.ts
+++ b/src/app/api/extension/markets/route.ts
@@ -77,9 +77,16 @@ export async function GET(request: NextRequest) {
     // large (full competitor lists, original CSVs), so we count
     // competitors via the metrics column when present and fall back to
     // a length read from submission_data only if metrics is empty.
+    //
+    // Phase 5.4-O — also pull research_products.display_name via the
+    // FK relation so the picker shows the market's renamed label
+    // (set by the pencil-icon rename or by analyze-market on create)
+    // instead of the original Amazon listing title.
     const { data: rows, error } = await supabaseAdmin
       .from('submissions')
-      .select('id, title, product_name, score, status, metrics, submission_data, updated_at, created_at')
+      .select(
+        'id, title, product_name, score, status, metrics, submission_data, updated_at, created_at, research_products_id, research_products(display_name)'
+      )
       .eq('user_id', resolved.userId)
       .order('updated_at', { ascending: false, nullsFirst: false });
 
@@ -91,15 +98,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const markets = (rows ?? []).map((r) => {
+    const markets = (rows ?? []).map((r: any) => {
       const metricsCount =
         typeof r.metrics?.totalCompetitors === 'number' ? r.metrics.totalCompetitors : null;
       const fallbackCount = Array.isArray(r.submission_data?.productData?.competitors)
         ? r.submission_data.productData.competitors.length
         : 0;
+      // Supabase returns the FK-joined row as either an object or array
+      // depending on the relation cardinality; handle both shapes.
+      const research = Array.isArray(r.research_products)
+        ? r.research_products[0]
+        : r.research_products;
+      const displayName =
+        typeof research?.display_name === 'string' ? research.display_name.trim() : '';
       return {
         id: r.id,
-        title: r.product_name || r.title || 'Untitled market',
+        title: displayName || r.product_name || r.title || 'Untitled market',
         score: typeof r.score === 'number' ? r.score : null,
         status: r.status ?? null,
         competitorCount: metricsCount ?? fallbackCount,

--- a/src/app/api/submissions/[id]/lens-recalc/route.ts
+++ b/src/app/api/submissions/[id]/lens-recalc/route.ts
@@ -102,7 +102,14 @@ export async function POST(
       : [];
     const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
 
-    if (unresolvedExpansions.length === 0) {
+    // Phase 5.4-O — legacy fallback: pre-5.4-O analyze-market wrote
+    // __lens_pending_recalc=true without creating a lensExpansions[]
+    // entry. Recalcing those rows is still valid — pull the newly-added
+    // ASINs from competitors flagged __lens_new (the existing marker
+    // analyze-market has set since Phase 5.4-D).
+    const isLegacyOnly =
+      unresolvedExpansions.length === 0 && submissionData.__lens_pending_recalc === true;
+    if (unresolvedExpansions.length === 0 && !isLegacyOnly) {
       return NextResponse.json(
         { success: false, error: 'No pending Lens expansion to recalc' },
         { status: 400 }
@@ -146,6 +153,21 @@ export async function POST(
     for (const e of unresolvedExpansions) {
       for (const a of Array.isArray(e?.addedAsins) ? e.addedAsins : []) {
         if (typeof a === 'string' && ASIN_REGEX.test(a)) newlyAddedAsinsSet.add(a);
+      }
+    }
+    // Legacy-only path: derive newly-added ASINs from competitors that
+    // analyze-market flagged with __lens_new=true. Same Keepa-backfill
+    // outcome as the new path, just sourced from the competitor markers
+    // instead of the lensExpansions log.
+    if (isLegacyOnly) {
+      for (const c of competitors) {
+        if (
+          c?.__lens_new === true &&
+          typeof c?.asin === 'string' &&
+          ASIN_REGEX.test(c.asin.toUpperCase())
+        ) {
+          newlyAddedAsinsSet.add(c.asin.toUpperCase());
+        }
       }
     }
     const newlyAddedAsins = Array.from(newlyAddedAsinsSet);
@@ -239,6 +261,31 @@ export async function POST(
         : e
     );
 
+    // Legacy-only branch: there were no lensExpansions entries to mark
+    // resolved (the user's data was created on pre-5.4-O analyze-market).
+    // Synthesize one entry so the post-recalc pill + history panel show
+    // up for legacy data too. preExpansionSnapshot is null because we
+    // never captured one at append time — Undo isn't available for
+    // synthesized entries (the UI hides the Undo button when the
+    // snapshot is missing).
+    const finalExpansions =
+      isLegacyOnly && newlyAddedAsins.length > 0
+        ? [
+            {
+              id: `legacy-${nowIso}`,
+              addedAsins: newlyAddedAsins,
+              addedAt: nowIso,
+              source: 'bloom-lens',
+              scoreBefore: typeof submission.score === 'number' ? submission.score : null,
+              scoreAfter: newMarketScore.score,
+              acknowledged: true,
+              recalcedAt: nowIso,
+              preExpansionSnapshot: null,
+              isLegacy: true,
+            },
+          ]
+        : updatedExpansions;
+
     const nextSubmissionData = {
       ...submissionData,
       productData: {
@@ -249,9 +296,8 @@ export async function POST(
       keepaResults: newKeepaResults,
       marketScore: newMarketScore,
       metrics: newMetrics,
-      lensExpansions: updatedExpansions,
-      // Legacy flag — analyze-market still dual-writes it for one cycle.
-      // Clearing it here keeps any old client surfaces from re-prompting.
+      lensExpansions: finalExpansions,
+      // Clear the legacy flag — supersedes by lensExpansions presence.
       __lens_pending_recalc: false,
       updatedAt: nowIso,
     };

--- a/src/app/api/submissions/[id]/mark-expansions-read/route.ts
+++ b/src/app/api/submissions/[id]/mark-expansions-read/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Phase 5.4-O — POST /api/submissions/[id]/mark-expansions-read
+ *
+ * Lightweight UI-state mutation: marks every entry in
+ * submission_data.lensExpansions as acknowledged=true. Fired by
+ * VettingDetailContent on mount when hasUnacknowledgedExpansion is true,
+ * which clears the "+N new" badge on the /vetting dashboard list.
+ *
+ * Does NOT touch scoreAfter — the detail page banner stays up until the
+ * user actually clicks Recalculate. Acknowledged tracks "did the user
+ * see this?" while scoreAfter tracks "is this resolved math-wise?".
+ *
+ * No cap-check: this is purely cosmetic state. Idempotent.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const submissionId = params.id;
+    if (!submissionId) {
+      return NextResponse.json(
+        { success: false, error: 'Submission ID is required' },
+        { status: 400 }
+      );
+    }
+
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: authData } = await supabase.auth.getUser();
+    const userId = authData.user?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid session' },
+        { status: 401 }
+      );
+    }
+
+    const { data: submission, error: fetchError } = await supabase
+      .from('submissions')
+      .select('id, submission_data')
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'Submission not found' },
+        { status: 404 }
+      );
+    }
+
+    const submissionData = (submission.submission_data ?? {}) as any;
+    const expansions: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+
+    if (expansions.length === 0 || expansions.every((e) => e?.acknowledged)) {
+      // Already in the desired state — return success without a write.
+      return NextResponse.json({ success: true, changed: false });
+    }
+
+    const acknowledgedExpansions = expansions.map((e) =>
+      e?.acknowledged ? e : { ...e, acknowledged: true }
+    );
+
+    const { error: updateError } = await supabase
+      .from('submissions')
+      .update({
+        submission_data: {
+          ...submissionData,
+          lensExpansions: acknowledgedExpansions,
+        },
+      })
+      .eq('id', submissionId)
+      .eq('user_id', userId);
+
+    if (updateError) {
+      console.error('[mark-expansions-read] update failed:', updateError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to update' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, changed: true });
+  } catch (err) {
+    console.error('[mark-expansions-read] crashed:', err);
+    return NextResponse.json(
+      { success: false, error: 'Unexpected error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -1440,6 +1440,35 @@ export const ProductVettingResults: React.FC<{
     }));
   };
 
+  // Phase 5.4-O — PDP-only columns Lens can't capture from Amazon SERP.
+  // Render a hover-tooltip on the — cell so users understand WHY the
+  // value is empty for Lens-sourced rows. Helium 10 CSV uploads do
+  // populate these (the user-supplied CSV path), so mentioning H10 here
+  // is honest and actionable. Helium 10 is the documented exception to
+  // the "no vendor names in user copy" rule; see Phase 5.4-O acceptance
+  // criteria.
+  const LENS_TOOLTIP_KEYS = new Set(['fulfillment', 'sellerCount', 'activeSellers', 'soldBy']);
+  const LENS_TOOLTIP_COPY =
+    'Captured from Amazon search results — this field requires a listing-page lookup, which fills in when you vet from a Helium 10 CSV.';
+  const wrapWithLensTooltip = (
+    cellContent: React.ReactNode,
+    competitor: Competitor,
+    columnKey: string
+  ): React.ReactNode => {
+    if (!LENS_TOOLTIP_KEYS.has(columnKey)) return cellContent;
+    if (!(competitor as any)?.__lens_origin) return cellContent;
+    const raw = (competitor as any)?.[columnKey];
+    if (raw !== null && raw !== undefined && raw !== '') return cellContent;
+    return (
+      <span
+        title={LENS_TOOLTIP_COPY}
+        className="cursor-help underline decoration-dotted decoration-slate-500/50 underline-offset-2"
+      >
+        {cellContent}
+      </span>
+    );
+  };
+
   const formatColumnValue = (competitor: Competitor, key: string) => {
     const value = (competitor as any)?.[key];
     if (value === null || value === undefined || value === '') return '—';
@@ -2984,16 +3013,20 @@ export const ProductVettingResults: React.FC<{
                             column.key === 'title' ? 'truncate max-w-xs' : ''
                           } ${column.key === 'dateFirstAvailable' ? 'whitespace-nowrap' : ''}`}
                         >
-                          {['reviews', 'rating', 'fulfillment', 'bsr'].includes(column.key)
-                            ? renderSignalCell(competitor, column.key, isRemovalHighlighted)
-                            : formatColumnValue(competitor, column.key)}
+                          {wrapWithLensTooltip(
+                            ['reviews', 'rating', 'fulfillment', 'bsr'].includes(column.key)
+                              ? renderSignalCell(competitor, column.key, isRemovalHighlighted)
+                              : formatColumnValue(competitor, column.key),
+                            competitor,
+                            column.key
+                          )}
                         </td>
                       ) : null
                     ))}
                   </tr>
                 );
               })}
-              
+
               {/* Show removed competitors with struck-through styling */}
               {showRemoved && removedCompetitorsList.map((competitor) => {
                 const competitorScore = parseFloat(calculateScore(competitor));
@@ -3063,7 +3096,11 @@ export const ProductVettingResults: React.FC<{
                           key={column.key}
                           className={`p-3 text-sm leading-5 text-white align-middle ${column.key === 'title' ? 'truncate max-w-xs' : ''}`}
                         >
-                          {formatColumnValue(competitor, column.key)}
+                          {wrapWithLensTooltip(
+                            formatColumnValue(competitor, column.key),
+                            competitor,
+                            column.key
+                          )}
                         </td>
                       ) : null
                     ))}

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { AlertCircle, Check, Loader2, Share2 } from 'lucide-react';
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  RotateCw,
+  Share2,
+  Sparkles,
+  Undo2,
+} from 'lucide-react';
 import { supabase } from '@/utils/supabaseClient';
 import { RootState } from '@/store';
 import { ProductHeader } from '@/components/Product/ProductHeader';
@@ -14,12 +24,47 @@ import { getProductAsin } from '@/utils/productIdentifiers';
 import { buildVettingEngineUrl } from '@/utils/vettingNavigation';
 import { applyAdjustment, resetAdjustment } from '@/utils/submissionAdjustments';
 import { getProductDisplayName } from '@/utils/product';
+import {
+  CapReachedModal,
+  type CapInfo,
+} from '@/components/subscription/CapReachedModal';
 
 function badgeToneFromStatus(status: string | null | undefined) {
   if (status === 'PASS') return 'emerald' as const;
   if (status === 'RISKY') return 'amber' as const;
   if (status === 'FAIL') return 'red' as const;
   return 'slate' as const;
+}
+
+// Phase 5.4-O — tiny relative-time formatter for the expansion pill +
+// history panel. "2 minutes ago", "3 hours ago", "Apr 20" for older
+// dates. Avoids pulling in date-fns just for two timestamps.
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return '';
+  const diff = Date.now() - ts;
+  const min = 60 * 1000;
+  const hr = 60 * min;
+  const day = 24 * hr;
+  if (diff < min) return 'just now';
+  if (diff < hr) {
+    const m = Math.floor(diff / min);
+    return `${m} minute${m === 1 ? '' : 's'} ago`;
+  }
+  if (diff < day) {
+    const h = Math.floor(diff / hr);
+    return `${h} hour${h === 1 ? '' : 's'} ago`;
+  }
+  if (diff < 7 * day) {
+    const d = Math.floor(diff / day);
+    return `${d} day${d === 1 ? '' : 's'} ago`;
+  }
+  try {
+    return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
 }
 
 export function VettingDetailContent({ asin }: { asin: string }) {
@@ -50,6 +95,15 @@ export function VettingDetailContent({ asin }: { asin: string }) {
   // handleCompetitorsUpdated; cleared by refresh and by reset (since reset
   // restores the original ai_summary alongside the original competitors).
   const [summaryStale, setSummaryStale] = useState(false);
+  // Phase 5.4-O — Lens-expansion UI state.
+  const [recalcing, setRecalcing] = useState(false);
+  const [undoingExpansionId, setUndoingExpansionId] = useState<string | null>(null);
+  const [expansionPanelOpen, setExpansionPanelOpen] = useState(false);
+  const [capReached, setCapReached] = useState<CapInfo | null>(null);
+  const expansionPanelRef = useRef<HTMLDivElement | null>(null);
+  // Mark-as-read fires once per market visit (clears the dashboard "+N new"
+  // badge). Guard so re-renders don't re-fire it.
+  const markedReadRef = useRef<string | null>(null);
   const isInvalidAsin = !asin || asin === 'undefined' || asin === 'null';
 
   // Share-feature hooks — declared at the top of the component so they
@@ -273,6 +327,65 @@ export function VettingDetailContent({ asin }: { asin: string }) {
       lastRowContext,
     });
   }, [isInvalidAsin, asin, pathname, searchString, lastRowContext, submissionId]);
+
+  // Phase 5.4-O — clear the dashboard "+N new" badge by acknowledging all
+  // expansions on detail-page mount. Acknowledged is independent of
+  // scoreAfter — the banner stays up until the user actually clicks
+  // Recalculate, but the dashboard pill clears as soon as they look.
+  useEffect(() => {
+    if (!submission?.id) return;
+    if (markedReadRef.current === submission.id) return;
+    if (!submission.hasUnacknowledgedExpansion) return;
+
+    markedReadRef.current = submission.id;
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        const res = await fetch(`/api/submissions/${submission.id}/mark-expansions-read`, {
+          method: 'POST',
+          headers: {
+            ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+          },
+          credentials: 'include',
+        });
+        if (!res.ok || cancelled) return;
+        // Mirror the server-side ack into local state so subsequent
+        // analyze fetches don't surprise us.
+        setSubmission((prev: any) =>
+          prev
+            ? {
+                ...prev,
+                lensExpansions: (prev.lensExpansions ?? []).map((e: any) =>
+                  e?.acknowledged ? e : { ...e, acknowledged: true }
+                ),
+                hasUnacknowledgedExpansion: false,
+              }
+            : prev
+        );
+      } catch (e) {
+        // Best-effort — badge will clear next page load if this fails.
+        console.warn('[VettingDetail] mark-expansions-read failed:', e);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [submission?.id, submission?.hasUnacknowledgedExpansion]);
+
+  // Close the expansion-history panel on outside click.
+  useEffect(() => {
+    if (!expansionPanelOpen) return;
+    const onDocClick = (ev: MouseEvent) => {
+      if (!expansionPanelRef.current) return;
+      if (!expansionPanelRef.current.contains(ev.target as Node)) {
+        setExpansionPanelOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [expansionPanelOpen]);
 
   if (loading) {
     return (
@@ -498,6 +611,120 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     }
   };
 
+  // Phase 5.4-O — inline recalc on /vetting/[asin] when there's an
+  // unresolved BloomLens expansion. Hits the new lens-recalc endpoint
+  // which runs Keepa enrichment for backfill + scoring + AI summary
+  // regeneration server-side, then mirrors the response into local
+  // state. 402 surfaces the cap-modal so a Core user at vetting limit
+  // sees an upgrade nudge inline (no Stripe redirect — rule).
+  const handleLensRecalc = async () => {
+    if (!submission?.id || recalcing) return;
+    setRecalcing(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(`/api/submissions/${submission.id}/lens-recalc`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+        },
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (res.status === 402 && data?.cap) {
+        setCapReached(data.cap as CapInfo);
+        return;
+      }
+      if (!res.ok || !data?.success || !data?.submission) {
+        throw new Error(data?.error || `Recalc failed (${res.status})`);
+      }
+      const updated = data.submission;
+      setSubmission((prev: any) =>
+        prev
+          ? {
+              ...prev,
+              score: updated.score ?? prev.score,
+              status: updated.status ?? prev.status,
+              productData: updated.submission_data?.productData ?? prev.productData,
+              keepaResults: updated.submission_data?.keepaResults ?? prev.keepaResults,
+              marketScore: updated.submission_data?.marketScore ?? prev.marketScore,
+              metrics: updated.metrics ?? prev.metrics,
+              lensExpansions: updated.submission_data?.lensExpansions ?? prev.lensExpansions ?? [],
+              hasUnacknowledgedExpansion: false,
+            }
+          : prev
+      );
+      if (updated.ai_summary !== undefined) {
+        setAiSummary(updated.ai_summary);
+      }
+      setSummaryStale(false);
+    } catch (err) {
+      console.error('[VettingDetail] lens-recalc failed:', err);
+      setShareToast({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Could not recalculate.',
+      });
+    } finally {
+      setRecalcing(false);
+    }
+  };
+
+  // Phase 5.4-O — undo a single expansion batch. Restores from the
+  // entry's preExpansionSnapshot and removes that entry from the log.
+  // Earlier/later expansions and any `adjustment` are untouched.
+  const handleUndoExpansion = async (expansionId: string) => {
+    if (!submission?.id || undoingExpansionId) return;
+    setUndoingExpansionId(expansionId);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(`/api/submissions/${submission.id}/undo-expansion`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+        },
+        credentials: 'include',
+        body: JSON.stringify({ expansionId }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data?.success || !data?.submission) {
+        throw new Error(data?.error || `Undo failed (${res.status})`);
+      }
+      const updated = data.submission;
+      setSubmission((prev: any) =>
+        prev
+          ? {
+              ...prev,
+              score: updated.score ?? prev.score,
+              status: updated.status ?? prev.status,
+              productData: updated.submission_data?.productData ?? prev.productData,
+              keepaResults: updated.submission_data?.keepaResults ?? prev.keepaResults,
+              marketScore: updated.submission_data?.marketScore ?? prev.marketScore,
+              metrics: updated.metrics ?? prev.metrics,
+              lensExpansions: updated.submission_data?.lensExpansions ?? [],
+              hasUnacknowledgedExpansion: (updated.submission_data?.lensExpansions ?? []).some(
+                (e: any) => !e?.acknowledged
+              ),
+            }
+          : prev
+      );
+      if (updated.ai_summary !== undefined) {
+        setAiSummary(updated.ai_summary);
+      }
+      // Snapshot's ai_summary matched the pre-expansion state, so it's
+      // not stale relative to the now-current competitor set.
+      setSummaryStale(false);
+    } catch (err) {
+      console.error('[VettingDetail] undo-expansion failed:', err);
+      setShareToast({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Could not undo expansion.',
+      });
+    } finally {
+      setUndoingExpansionId(null);
+    }
+  };
+
   const shareAction = submission?.id ? (
     <div className="flex items-center gap-2">
       <button
@@ -616,9 +843,152 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     );
   }
 
+  // Phase 5.4-O — derive Lens-expansion render state. expansions is
+  // append-only (one entry per Lens "Add to existing" event); unresolved
+  // entries are those that haven't been recalced yet (scoreAfter null).
+  const expansions: any[] = Array.isArray(submission?.lensExpansions)
+    ? submission.lensExpansions
+    : [];
+  const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
+  const totalAddedFromLens = expansions.reduce(
+    (sum, e) => sum + (Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0),
+    0
+  );
+  const mostRecentExpansionAt = expansions.length > 0
+    ? expansions
+        .map((e) => e?.addedAt)
+        .filter((t): t is string => typeof t === 'string')
+        .sort()
+        .slice(-1)[0]
+    : null;
+
   return (
     <div className={`transition-opacity duration-300 ${isMounted ? 'opacity-100' : 'opacity-0'}`}>
       {header}
+
+      {/* Phase 5.4-O — recalc banner (unresolved expansion). Click runs
+          POST /api/submissions/[id]/lens-recalc inline; no page bounce. */}
+      {unresolvedExpansions.length > 0 && submission?.id ? (
+        <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50/80 dark:border-amber-500/40 dark:bg-amber-900/20 p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-amber-500 dark:text-amber-300 mt-0.5 flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-amber-900 dark:text-amber-100">
+                New competitors detected
+              </p>
+              <p className="text-sm text-amber-800/90 dark:text-amber-200/80 mt-1">
+                Competitors were added from BloomLens since this market was last vetted.
+                Recalculate to refresh the score, market metrics, and AI summary.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleLensRecalc}
+              disabled={recalcing}
+              className="px-4 py-2 bg-amber-500 hover:bg-amber-600 dark:bg-amber-500 dark:hover:bg-amber-400 text-white text-sm font-medium rounded-lg transition-colors shadow-sm flex-shrink-0 inline-flex items-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {recalcing ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Recalculating…
+                </>
+              ) : (
+                <>
+                  <RotateCw className="w-4 h-4" />
+                  Recalculate
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Phase 5.4-O — post-recalc pill + expansion-history panel.
+          Shown when expansions exist AND none are unresolved. Click the
+          pill to expand the history; per-batch undo lives in the panel. */}
+      {unresolvedExpansions.length === 0 && expansions.length > 0 && submission?.id ? (
+        <div className="mt-4 relative" ref={expansionPanelRef}>
+          <button
+            type="button"
+            onClick={() => setExpansionPanelOpen((v) => !v)}
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-400/40 bg-emerald-50/80 dark:bg-emerald-500/10 text-sm font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100/80 dark:hover:bg-emerald-500/20 transition-colors"
+          >
+            <Sparkles className="w-3.5 h-3.5" />
+            +{totalAddedFromLens} from BloomLens
+            {mostRecentExpansionAt ? (
+              <span className="text-emerald-700/80 dark:text-emerald-300/80">
+                · {formatRelativeTime(mostRecentExpansionAt)}
+              </span>
+            ) : null}
+            {expansionPanelOpen ? (
+              <ChevronUp className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5" />
+            )}
+          </button>
+
+          {expansionPanelOpen ? (
+            <div className="absolute z-30 mt-2 w-[28rem] max-w-[90vw] rounded-xl border border-gray-200 dark:border-slate-700/70 bg-white dark:bg-slate-900 shadow-xl p-2">
+              <p className="px-3 pt-2 pb-1 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
+                Expansion history
+              </p>
+              <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+                {[...expansions]
+                  .sort((a, b) => String(b?.addedAt ?? '').localeCompare(String(a?.addedAt ?? '')))
+                  .map((e) => {
+                    const id = String(e?.id ?? e?.addedAt ?? '');
+                    const count = Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0;
+                    const before = typeof e?.scoreBefore === 'number' ? e.scoreBefore : null;
+                    const after = typeof e?.scoreAfter === 'number' ? e.scoreAfter : null;
+                    const isUndoing = undoingExpansionId === id;
+                    return (
+                      <li key={id} className="px-3 py-2 flex items-center gap-3">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-gray-800 dark:text-slate-200">
+                            +{count} competitor{count === 1 ? '' : 's'} added
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                            {formatRelativeTime(e?.addedAt)}
+                            {before != null && after != null ? (
+                              <>
+                                {' · '}
+                                <span className="tabular-nums">
+                                  {before.toFixed(1)}% → {after.toFixed(1)}%
+                                </span>
+                              </>
+                            ) : null}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (
+                              window.confirm(
+                                `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
+                              )
+                            ) {
+                              handleUndoExpansion(id);
+                            }
+                          }}
+                          disabled={Boolean(undoingExpansionId)}
+                          className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {isUndoing ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <Undo2 className="w-3 h-3" />
+                          )}
+                          Undo
+                        </button>
+                      </li>
+                    );
+                  })}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <ProductVettingResults
         productId={researchProduct?.id || submission?.id}
         competitors={submission.productData?.competitors || []}
@@ -655,6 +1025,11 @@ export function VettingDetailContent({ asin }: { asin: string }) {
           </div>
         </div>
       )}
+      <CapReachedModal
+        isOpen={capReached !== null}
+        onClose={() => setCapReached(null)}
+        cap={capReached}
+      />
     </div>
   );
 }

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -889,7 +889,8 @@ export function VettingDetailContent({ asin }: { asin: string }) {
               </p>
               <p className="text-sm text-amber-800/90 dark:text-amber-200/80 mt-1">
                 Competitors were added from BloomLens since this market was last vetted.
-                Recalculate to refresh the score, market metrics, and AI summary.
+                Recalculate to refresh the score, stability signals, and AI briefing
+                using the latest sales-rank data for the new competitors.
               </p>
             </div>
             <button

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -850,6 +850,15 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     ? submission.lensExpansions
     : [];
   const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
+  // Transitional fallback: pre-5.4-O analyze-market wrote
+  // __lens_pending_recalc=true without creating a lensExpansions[]
+  // entry. /api/analyze surfaces that as lensPendingRecalcLegacy.
+  // The banner shows for either signal so users with legacy-flag-only
+  // data can still recalc; the recalc endpoint handles both paths.
+  // Drop after PR A ships to production for a full deploy cycle.
+  const hasLegacyPendingRecalc =
+    expansions.length === 0 && Boolean(submission?.lensPendingRecalcLegacy);
+  const showRecalcBanner = unresolvedExpansions.length > 0 || hasLegacyPendingRecalc;
   const totalAddedFromLens = expansions.reduce(
     (sum, e) => sum + (Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0),
     0
@@ -866,9 +875,11 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     <div className={`transition-opacity duration-300 ${isMounted ? 'opacity-100' : 'opacity-0'}`}>
       {header}
 
-      {/* Phase 5.4-O — recalc banner (unresolved expansion). Click runs
-          POST /api/submissions/[id]/lens-recalc inline; no page bounce. */}
-      {unresolvedExpansions.length > 0 && submission?.id ? (
+      {/* Phase 5.4-O — recalc banner. Shown when there's an unresolved
+          lensExpansions entry OR (legacy fallback) the pre-5.4-O
+          __lens_pending_recalc flag is set. Click runs the recalc
+          endpoint inline. */}
+      {showRecalcBanner && submission?.id ? (
         <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50/80 dark:border-amber-500/40 dark:bg-amber-900/20 p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="w-5 h-5 text-amber-500 dark:text-amber-300 mt-0.5 flex-shrink-0" />
@@ -941,6 +952,12 @@ export function VettingDetailContent({ asin }: { asin: string }) {
                     const before = typeof e?.scoreBefore === 'number' ? e.scoreBefore : null;
                     const after = typeof e?.scoreAfter === 'number' ? e.scoreAfter : null;
                     const isUndoing = undoingExpansionId === id;
+                    // Synthesized legacy entries don't have a
+                    // preExpansionSnapshot (analyze-market wasn't
+                    // capturing one before 5.4-O), so Undo isn't
+                    // available — the necessary state to restore to
+                    // simply doesn't exist for old data.
+                    const canUndo = Boolean(e?.preExpansionSnapshot);
                     return (
                       <li key={id} className="px-3 py-2 flex items-center gap-3">
                         <div className="flex-1 min-w-0">
@@ -959,27 +976,29 @@ export function VettingDetailContent({ asin }: { asin: string }) {
                             ) : null}
                           </p>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (
-                              window.confirm(
-                                `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
-                              )
-                            ) {
-                              handleUndoExpansion(id);
-                            }
-                          }}
-                          disabled={Boolean(undoingExpansionId)}
-                          className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {isUndoing ? (
-                            <Loader2 className="w-3 h-3 animate-spin" />
-                          ) : (
-                            <Undo2 className="w-3 h-3" />
-                          )}
-                          Undo
-                        </button>
+                        {canUndo ? (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (
+                                window.confirm(
+                                  `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
+                                )
+                              ) {
+                                handleUndoExpansion(id);
+                              }
+                            }}
+                            disabled={Boolean(undoingExpansionId)}
+                            className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {isUndoing ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <Undo2 className="w-3 h-3" />
+                            )}
+                            Undo
+                          </button>
+                        ) : null}
                       </li>
                     );
                   })}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -81,6 +81,30 @@ function resolveTotalCompetitors(submission: any): number | null {
   return typeof len === 'number' && len > 0 ? len : null;
 }
 
+// Phase 5.4-O — small "+N new" pill shown next to the score when a
+// submission has unacknowledged BloomLens expansions (extension appended
+// competitors after the last vetting and the user hasn't opened the
+// detail page yet). Clears once the user navigates to the detail
+// (mark-as-read fires) OR clicks Recalculate. Green = growth/positive,
+// to distinguish it from the amber "Adjusted" pill.
+function NewExpansionBadge({
+  count,
+}: {
+  count: number;
+}) {
+  if (count <= 0) return null;
+  return (
+    <span
+      className="relative inline-flex items-center gap-1 shrink-0"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-emerald-400/20 text-emerald-700 dark:text-emerald-300 border border-emerald-400/40 whitespace-nowrap">
+        +{count} new
+      </span>
+    </span>
+  );
+}
+
 // Phase 2.7 — small "Adjusted" pill + info icon shown next to the score in the
 // submissions list when a submission has persisted competitor removals. Hover
 // OR tap on the icon reveals the original score and removed count. Tap support
@@ -1336,19 +1360,39 @@ export function Dashboard({ onTabChange }: { onTabChange?: (tab: string) => void
                                         {typeof submission.score === 'number' ? submission.score.toFixed(1) : '0'}%
                                       </span>
                                     </div>
-                                    {submission.adjustment && (
-                                      <div className="flex">
-                                        <AdjustedBadge
-                                          submissionId={submission.id}
-                                          adjustment={submission.adjustment}
-                                          originalSnapshot={submission.originalSnapshot}
-                                          isOpen={openAdjustedTooltip === submission.id}
-                                          onToggle={() =>
-                                            setOpenAdjustedTooltip(
-                                              openAdjustedTooltip === submission.id ? null : submission.id
-                                            )
-                                          }
-                                        />
+                                    {(submission.adjustment || submission.hasUnacknowledgedExpansion) && (
+                                      <div className="flex flex-wrap items-center gap-1">
+                                        {submission.adjustment && (
+                                          <AdjustedBadge
+                                            submissionId={submission.id}
+                                            adjustment={submission.adjustment}
+                                            originalSnapshot={submission.originalSnapshot}
+                                            isOpen={openAdjustedTooltip === submission.id}
+                                            onToggle={() =>
+                                              setOpenAdjustedTooltip(
+                                                openAdjustedTooltip === submission.id ? null : submission.id
+                                              )
+                                            }
+                                          />
+                                        )}
+                                        {submission.hasUnacknowledgedExpansion && (
+                                          <NewExpansionBadge
+                                            count={
+                                              Array.isArray(submission.lensExpansions)
+                                                ? submission.lensExpansions
+                                                    .filter((e: any) => !e?.acknowledged)
+                                                    .reduce(
+                                                      (sum: number, e: any) =>
+                                                        sum +
+                                                        (Array.isArray(e?.addedAsins)
+                                                          ? e.addedAsins.length
+                                                          : 0),
+                                                      0
+                                                    )
+                                                : 0
+                                            }
+                                          />
+                                        )}
                                       </div>
                                     )}
                                   </div>


### PR DESCRIPTION
## Summary

Reads the `lensExpansions[]` data PR A landed and renders the redesigned recalc UX. **Together PR A + PR B close all eight of Dave's 2026-05-07 testing observations end-to-end.**

### What changes

- **Recalc banner on `/vetting/[asin]`** when `lensExpansions.some(e => e.scoreAfter == null)`. Click runs the new `POST /api/submissions/[id]/lens-recalc` inline — no bounce to the share view, no `?triggerRecalc=1` query param. Spinner state in the button, then `setSubmission` mirrors the response. 402 renders `CapReachedModal` inline.
- **Post-recalc pill** replaces the banner: `+N from BloomLens · 2 hours ago` (emerald, `Sparkles` icon — growth framing, not "Adjusted"). Click toggles the expansion-history panel below: one row per expansion with `addedAt` / `+N added` / `scoreBefore → scoreAfter` / Undo. Undo gated by `window.confirm` copy "Remove these N competitors?" — surgical, not "Reset".
- **`+N new` badge on `/vetting` list rows** where `submission.hasUnacknowledgedExpansion === true`. Emerald pill, mirrors `AdjustedBadge` style. Stacks horizontally with the Adjusted pill when a market has both. Cleared on detail-page mount via the new `mark-expansions-read` endpoint.
- **PDP-only matrix tooltips.** `fulfillment` / `sellerCount` / `activeSellers` / `soldBy` columns on `__lens_origin` rows render `—` with a dotted-underline + native `title` tooltip: "Captured from Amazon search results — this field requires a listing-page lookup, which fills in when you vet from a Helium 10 CSV." (Helium 10 mention is the documented exception to the no-vendor-names rule.)
- **NEW endpoint `POST /api/submissions/[id]/mark-expansions-read`** — lightweight UI-state mutation, flips `acknowledged` on every expansion entry. Idempotent.
- **Cleanup**: drops the legacy `__lens_pending_recalc` dual-write from `analyze-market` (PR A added it for safety; nothing reads it now). The append-no-new-comps response field `pendingRecalc` is now computed from `lensExpansions` with the legacy flag as a fallback for pre-5.4-O rows so the BloomLens extension doesn't need a re-deploy.

## Test plan (= Phase 5.4-O acceptance criteria, section 4.10 of handoff)

End-to-end via Vercel preview, using BloomLens against real Amazon SERP:

- [ ] Append new ASINs to a vetted market via BloomLens → `/vetting/[asin]` shows the amber "New competitors detected" banner
- [ ] Click Recalculate → spinner state in button, no page bounce, score + market metrics update inline
- [ ] After recalc, banner is gone; "+N from BloomLens · X minutes ago" emerald pill is present
- [ ] Click the pill → expansion-history panel drops down with `addedAt`, `+N added`, `scoreBefore → scoreAfter`, Undo button per entry
- [ ] Click Undo on one entry → confirm modal → submission reverts to that batch's preExpansionSnapshot; other expansions preserved
- [ ] On `/vetting` list, the row shows "+N new" emerald badge before you open the detail
- [ ] Open the detail → return to `/vetting` → badge cleared (mark-as-read fired)
- [ ] Newly-added competitors have `category` / `productWeight` / `variations` populated post-recalc (Keepa backfill)
- [ ] PDP-only fields (Fulfilled By / Seller Count / Active Sellers / Sold By) on Lens-sourced rows render `—` with hover tooltip
- [ ] Cap test: a Core user at 25/25 vettings hits 402 on Recalculate → CapReachedModal appears inline (no Stripe redirect)
- [ ] No "Keepa" in user-facing copy. Helium 10 only in the matrix-tooltip exception.
- [ ] Existing manual remove-competitors flow on `/submission/[id]` still works (regression check)

## Standing rules check

- Targets `dev`, not `main`
- BloomLens is one word
- No Stripe redirects (cap-modal renders inline)
- No round numbers in displayed metrics
- Pixel-matched: `NewExpansionBadge` mirrors `AdjustedBadge` styling; banner markup lifted from closed PR #28's diff (the visual treatment Dave liked); pill styling matches existing emerald-tone components

🤖 Generated with [Claude Code](https://claude.com/claude-code)