### PR TITLE
Phase 5.4-O: ship Market Expansions to production (PR A + PR B)

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -269,6 +269,12 @@ export async function GET(request: NextRequest) {
             // /vetting list page can show the "+N new" badge.
             lensExpansions,
             hasUnacknowledgedExpansion: lensExpansions.some((e: any) => !e?.acknowledged),
+            // Transitional: the legacy __lens_pending_recalc flag (set by
+            // pre-5.4-O analyze-market) so the banner can fall back when
+            // BloomLens hit the production-version of analyze-market and
+            // wrote the legacy flag without a lensExpansions[] entry.
+            // Drop after PR A ships to production for a full deploy cycle.
+            lensPendingRecalcLegacy: Boolean(sub.submission_data?.__lens_pending_recalc),
           };
         })
         

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -242,25 +242,35 @@ export async function GET(request: NextRequest) {
 
       if (submissions && submissions.length > 0) {
         // Transform Supabase data to match the expected format
-        const transformedSubmissions = submissions.map(sub => ({
-          id: sub.id,
-          userId: sub.user_id,
-          title: sub.title,
-          score: sub.score,
-          status: sub.status,
-          productName: sub.product_name,
-          createdAt: sub.created_at,
-          productData: sub.submission_data?.productData || {},
-          keepaResults: sub.submission_data?.keepaResults || [],
-          marketScore: sub.submission_data?.marketScore || {},
-          metrics: sub.metrics || {},
-          research_product_id: sub.research_products_id || null,
-          is_public: Boolean(sub.is_public),
-          public_shared_at: sub.public_shared_at || null,
-          aiSummary: sub.ai_summary || null,
-          adjustment: sub.submission_data?.adjustment || null,
-          originalSnapshot: sub.submission_data?.originalSnapshot || null
-        }))
+        const transformedSubmissions = submissions.map(sub => {
+          const lensExpansions = Array.isArray(sub.submission_data?.lensExpansions)
+            ? sub.submission_data.lensExpansions
+            : [];
+          return {
+            id: sub.id,
+            userId: sub.user_id,
+            title: sub.title,
+            score: sub.score,
+            status: sub.status,
+            productName: sub.product_name,
+            createdAt: sub.created_at,
+            productData: sub.submission_data?.productData || {},
+            keepaResults: sub.submission_data?.keepaResults || [],
+            marketScore: sub.submission_data?.marketScore || {},
+            metrics: sub.metrics || {},
+            research_product_id: sub.research_products_id || null,
+            is_public: Boolean(sub.is_public),
+            public_shared_at: sub.public_shared_at || null,
+            aiSummary: sub.ai_summary || null,
+            adjustment: sub.submission_data?.adjustment || null,
+            originalSnapshot: sub.submission_data?.originalSnapshot || null,
+            // Phase 5.4-O — surface the Lens-expansion log so /vetting/[asin]
+            // can render the recalc banner + per-batch undo, and the
+            // /vetting list page can show the "+N new" badge.
+            lensExpansions,
+            hasUnacknowledgedExpansion: lensExpansions.some((e: any) => !e?.acknowledged),
+          };
+        })
         
         console.log(`Retrieved ${transformedSubmissions.length} submissions from Supabase`);
         return NextResponse.json({

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -12,9 +12,13 @@
 //            productData.competitors with new competitors (deduped by
 //            ASIN). New rows are flagged __lens_new + __lens_added_at
 //            so /submission/[id]'s adjusted view can highlight them.
-//            For vetted markets (score IS NOT NULL), submission_data.
-//            __lens_pending_recalc is set to true so the page can show
-//            the "New Competitors Detected — Recalculate?" pill.
+//            For vetted markets (score IS NOT NULL), Phase 5.4-O appends
+//            a new entry to submission_data.lensExpansions[] (one per
+//            expansion event, append-only log) capturing the
+//            preExpansionSnapshot so /vetting/[asin]'s recalc banner
+//            can offer per-batch undo. The legacy __lens_pending_recalc
+//            flag is dual-written for one cycle so any stale clients
+//            keep working until the new lensExpansions-based UI ships.
 //
 // Auth: Authorization: Bearer <ext_token>
 // Tier: Core or Pro (Free hits 403).
@@ -93,6 +97,13 @@ type ScrapedRow = {
 // scoring.ts/calculateMarketScore + the submission detail page expect.
 // Lens doesn't surface fulfillment / dateFirstAvailable depth — those
 // gaps fill in when the user runs Keepa enrichment on BloomEngine.
+//
+// Phase 5.4-O — also write `productWeight` and `variations` aliases so
+// the matrix on /vetting/[asin] reads them (column keys are
+// `productWeight` and `variations`, but Lens scrape gives us
+// `weightLb` and `variationCount`). Without the aliases these cells
+// rendered `—` even though we had the data, which surfaced as Dave's
+// "missing matrix columns" testing feedback.
 function scrapedRowToCompetitor(row: ScrapedRow, opts: { isNew: boolean; addedAt: string }) {
   return {
     asin: row.asin,
@@ -108,8 +119,10 @@ function scrapedRowToCompetitor(row: ScrapedRow, opts: { isNew: boolean; addedAt
     dateFirstAvailable: row.listingCreatedAt ?? null,
     fulfillment: null,
     weight: row.weightLb ?? null,
+    productWeight: row.weightLb ?? null,
     sizeTier: row.sizeTier ?? null,
     variationCount: row.variationCount ?? null,
+    variations: row.variationCount ?? null,
     fbaFee: row.fbaFee ?? null,
     dimensions: row.dimensions ?? null,
     seller: row.seller ?? null,
@@ -446,7 +459,7 @@ async function handleAppend(
 
   const { data: submission, error: fetchErr } = await supabaseAdmin
     .from('submissions')
-    .select('id, user_id, score, submission_data, research_products_id')
+    .select('id, user_id, score, status, metrics, ai_summary, submission_data, research_products_id')
     .eq('id', submissionId)
     .eq('user_id', resolved.userId)
     .maybeSingle();
@@ -514,6 +527,41 @@ async function handleAppend(
   const updatedCompetitors = [...existingCompetitors, ...newCompetitors];
   const isVetted = typeof submission.score === 'number';
 
+  // Phase 5.4-O — append a lensExpansions entry on vetted markets.
+  // The append-only log is what /vetting/[asin] reads to render the
+  // recalc banner + per-batch undo. Snapshot is captured BEFORE the
+  // merge so undo can restore the pre-this-batch competitor set
+  // without disturbing earlier expansions or any existing manual
+  // adjustment.
+  const existingExpansions: any[] = Array.isArray(submissionData.lensExpansions)
+    ? submissionData.lensExpansions
+    : [];
+
+  const newExpansionEntry = isVetted
+    ? {
+        id: nowIso,
+        addedAsins: newCompetitors.map((c: any) => c.asin),
+        addedAt: nowIso,
+        source: 'bloom-lens',
+        // Pre-this-expansion score; submission.score doesn't change
+        // until a recalc fires, so the row's current value IS the
+        // correct baseline. scoreAfter stays null until recalc.
+        scoreBefore: typeof submission.score === 'number' ? submission.score : null,
+        scoreAfter: null,
+        acknowledged: false,
+        preExpansionSnapshot: {
+          productData: productData ?? {},
+          keepaResults: submissionData.keepaResults ?? [],
+          marketScore: submissionData.marketScore ?? {},
+          metrics: submission.metrics ?? {},
+          score: submission.score ?? null,
+          status: submission.status ?? null,
+          aiSummary: submission.ai_summary ?? null,
+          snapshotAt: nowIso,
+        },
+      }
+    : null;
+
   const updatedSubmissionData = {
     ...submissionData,
     productData: {
@@ -522,9 +570,12 @@ async function handleAppend(
     },
     __lens_origin: true,
     __lens_last_appended_at: nowIso,
-    // Vetted markets get the recalc nudge; pre-vet markets just
-    // accumulate quietly until the user vets for the first time.
+    // Legacy flag — dual-written for one deploy cycle while the new
+    // lensExpansions-based UI rolls out. Drop after PR B stabilizes.
     __lens_pending_recalc: isVetted ? true : Boolean(submissionData.__lens_pending_recalc),
+    ...(newExpansionEntry
+      ? { lensExpansions: [...existingExpansions, newExpansionEntry] }
+      : {}),
   };
 
   const totalRevenue = updatedCompetitors.reduce(

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -16,9 +16,7 @@
 //            a new entry to submission_data.lensExpansions[] (one per
 //            expansion event, append-only log) capturing the
 //            preExpansionSnapshot so /vetting/[asin]'s recalc banner
-//            can offer per-batch undo. The legacy __lens_pending_recalc
-//            flag is dual-written for one cycle so any stale clients
-//            keep working until the new lensExpansions-based UI ships.
+//            can offer per-batch undo.
 //
 // Auth: Authorization: Bearer <ext_token>
 // Tier: Core or Pro (Free hits 403).
@@ -509,6 +507,17 @@ async function handleAppend(
   const viewUrl = await resolveSubmissionViewUrl(submission);
 
   if (newCompetitors.length === 0) {
+    // Phase 5.4-O — pendingRecalc now reflects the lensExpansions log
+    // (any entry with scoreAfter still null), with a fallback read of
+    // the legacy __lens_pending_recalc flag for rows created before
+    // 5.4-O landed. Response shape unchanged so the extension client
+    // doesn't need a re-deploy.
+    const existingExpansionsForReply: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+    const pendingRecalc =
+      existingExpansionsForReply.some((e: any) => e?.scoreAfter == null) ||
+      Boolean(submissionData.__lens_pending_recalc);
     return extensionResponse(
       request,
       {
@@ -518,7 +527,7 @@ async function handleAppend(
         viewUrl,
         addedCount: 0,
         skippedCount,
-        pendingRecalc: Boolean(submissionData.__lens_pending_recalc),
+        pendingRecalc,
       },
       resolved
     );
@@ -570,13 +579,15 @@ async function handleAppend(
     },
     __lens_origin: true,
     __lens_last_appended_at: nowIso,
-    // Legacy flag — dual-written for one deploy cycle while the new
-    // lensExpansions-based UI rolls out. Drop after PR B stabilizes.
-    __lens_pending_recalc: isVetted ? true : Boolean(submissionData.__lens_pending_recalc),
     ...(newExpansionEntry
       ? { lensExpansions: [...existingExpansions, newExpansionEntry] }
       : {}),
   };
+  // Legacy __lens_pending_recalc was dual-written in PR A for safety
+  // while the lensExpansions-based UI was in flight. PR B reads
+  // lensExpansions only — no consumer remains for the legacy flag, so
+  // we drop the write. Existing rows that still have the flag set
+  // unchanged (lensExpansions presence supersedes it).
 
   const totalRevenue = updatedCompetitors.reduce(
     (sum, c) => sum + (typeof c.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),

--- a/src/app/api/extension/markets/route.ts
+++ b/src/app/api/extension/markets/route.ts
@@ -77,9 +77,16 @@ export async function GET(request: NextRequest) {
     // large (full competitor lists, original CSVs), so we count
     // competitors via the metrics column when present and fall back to
     // a length read from submission_data only if metrics is empty.
+    //
+    // Phase 5.4-O — also pull research_products.display_name via the
+    // FK relation so the picker shows the market's renamed label
+    // (set by the pencil-icon rename or by analyze-market on create)
+    // instead of the original Amazon listing title.
     const { data: rows, error } = await supabaseAdmin
       .from('submissions')
-      .select('id, title, product_name, score, status, metrics, submission_data, updated_at, created_at')
+      .select(
+        'id, title, product_name, score, status, metrics, submission_data, updated_at, created_at, research_products_id, research_products(display_name)'
+      )
       .eq('user_id', resolved.userId)
       .order('updated_at', { ascending: false, nullsFirst: false });
 
@@ -91,15 +98,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const markets = (rows ?? []).map((r) => {
+    const markets = (rows ?? []).map((r: any) => {
       const metricsCount =
         typeof r.metrics?.totalCompetitors === 'number' ? r.metrics.totalCompetitors : null;
       const fallbackCount = Array.isArray(r.submission_data?.productData?.competitors)
         ? r.submission_data.productData.competitors.length
         : 0;
+      // Supabase returns the FK-joined row as either an object or array
+      // depending on the relation cardinality; handle both shapes.
+      const research = Array.isArray(r.research_products)
+        ? r.research_products[0]
+        : r.research_products;
+      const displayName =
+        typeof research?.display_name === 'string' ? research.display_name.trim() : '';
       return {
         id: r.id,
-        title: r.product_name || r.title || 'Untitled market',
+        title: displayName || r.product_name || r.title || 'Untitled market',
         score: typeof r.score === 'number' ? r.score : null,
         status: r.status ?? null,
         competitorCount: metricsCount ?? fallbackCount,

--- a/src/app/api/submissions/[id]/lens-recalc/route.ts
+++ b/src/app/api/submissions/[id]/lens-recalc/route.ts
@@ -1,0 +1,417 @@
+/**
+ * Phase 5.4-O — POST /api/submissions/[id]/lens-recalc
+ *
+ * Inline recalc trigger for vetted markets that have one or more
+ * unresolved BloomLens expansions (entries in submission_data.lensExpansions
+ * with scoreAfter still null). Replaces the closed-PR-#28 redirect
+ * approach (-> /submission/[id]?triggerRecalc=1) with a server-side
+ * endpoint that runs entirely under /vetting/[asin]'s URL.
+ *
+ * Flow:
+ *   1. Bearer auth → resolve userId.
+ *   2. Load submission + RLS check.
+ *   3. Validate at least one unresolved expansion exists.
+ *   4. checkCap('vetting') → 402 if exceeded.
+ *   5. Fetch Keepa for the union of (newly-added ASINs across unresolved
+ *      expansions) ∪ (top-5 by revenue across the full competitor set).
+ *      Backfill category / productWeight / variations / brand on the
+ *      newly-added competitors so the matrix stops showing — for fields
+ *      we can recover. (PDP-only fields like fulfillment, sellerCount,
+ *      activeSellers, soldBy stay null — UI tooltips ship in PR B.)
+ *   6. Recompute marketShares + distributions + marketScore.
+ *   7. Regen ai_summary via generateVettingSummary.
+ *   8. Persist: row columns (score, status, metrics, ai_summary) +
+ *      submission_data (productData.competitors, marketScore,
+ *      keepaResults, distributions, lensExpansions[] resolved + ack'd,
+ *      legacy __lens_pending_recalc cleared).
+ *   9. Insert usage_events row with operation='vetting_recalc' so cap.ts
+ *      counts the recalc against the user's vetting cap.
+ *  10. Return updated submission.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { supabaseAdmin } from '@/utils/supabaseAdmin';
+import { checkCap } from '@/lib/subscription';
+import { calculateMarketScore } from '@/utils/scoring';
+import { keepaService } from '@/services/keepaService';
+import { generateVettingSummary } from '@/services/vettingSummary';
+import { deriveSummaryMetrics } from '@/lib/vetting/deriveSummaryMetrics';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ASIN_REGEX = /^[A-Z0-9]{10}$/;
+const KEEPA_BASE_URL = 'https://api.keepa.com';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const submissionId = params.id;
+    if (!submissionId) {
+      return NextResponse.json(
+        { success: false, error: 'Submission ID is required' },
+        { status: 400 }
+      );
+    }
+
+    // --- Auth ---
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: authData } = await supabase.auth.getUser();
+    const userId = authData.user?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid session' },
+        { status: 401 }
+      );
+    }
+
+    // --- Load submission ---
+    const { data: submission, error: fetchError } = await supabase
+      .from('submissions')
+      .select('*')
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'Submission not found' },
+        { status: 404 }
+      );
+    }
+
+    const submissionData = (submission.submission_data ?? {}) as any;
+    const expansions: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+    const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
+
+    if (unresolvedExpansions.length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'No pending Lens expansion to recalc' },
+        { status: 400 }
+      );
+    }
+
+    // --- Cap check (Phase 5.4-O — closes the "spam append → recalc"
+    // workaround: each recalc consumes a vetting slot via the
+    // usage_events insert at the end of this handler). ---
+    const cap = await checkCap(supabase, userId, 'vetting');
+    if (!cap.allowed) {
+      console.log('lens-recalc: vetting cap reached for user', {
+        userId,
+        used: cap.used,
+        limit: cap.limit,
+        tier: cap.state.effectiveTier,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: `You've used all ${cap.limit} vettings on the Core plan this period. Upgrade to Pro for unlimited vettings.`,
+          cap: {
+            action: 'vetting',
+            used: cap.used,
+            limit: cap.limit,
+            remaining: cap.remaining,
+            tier: cap.state.tier,
+            effectiveTier: cap.state.effectiveTier,
+          },
+        },
+        { status: 402 }
+      );
+    }
+
+    // --- Build the Keepa fetch list ---
+    const competitors: any[] = Array.isArray(submissionData?.productData?.competitors)
+      ? submissionData.productData.competitors
+      : [];
+
+    const newlyAddedAsinsSet = new Set<string>();
+    for (const e of unresolvedExpansions) {
+      for (const a of Array.isArray(e?.addedAsins) ? e.addedAsins : []) {
+        if (typeof a === 'string' && ASIN_REGEX.test(a)) newlyAddedAsinsSet.add(a);
+      }
+    }
+    const newlyAddedAsins = Array.from(newlyAddedAsinsSet);
+
+    const top5Asins = [...competitors]
+      .sort((a, b) => (Number(b?.monthlyRevenue) || 0) - (Number(a?.monthlyRevenue) || 0))
+      .slice(0, 5)
+      .map((c) => (typeof c?.asin === 'string' ? c.asin.toUpperCase() : ''))
+      .filter((a) => ASIN_REGEX.test(a));
+
+    const fetchAsinsSet = new Set<string>([...newlyAddedAsins, ...top5Asins]);
+    const fetchAsins = Array.from(fetchAsinsSet);
+
+    // --- Fetch raw Keepa products for backfill + scoring in one shot. ---
+    const rawProducts = await fetchKeepaRaw(fetchAsins);
+    const rawByAsin = new Map<string, any>();
+    for (const p of rawProducts) {
+      if (p?.asin) rawByAsin.set(String(p.asin).toUpperCase(), p);
+    }
+
+    // --- Backfill newly-added competitors (category/productWeight/
+    // variations/brand) from raw Keepa. PDP-only fields stay null. ---
+    const backfilledCompetitors = competitors.map((c) => {
+      const asin = typeof c?.asin === 'string' ? c.asin.toUpperCase() : '';
+      if (!asin || !newlyAddedAsinsSet.has(asin)) return c;
+      const raw = rawByAsin.get(asin);
+      if (!raw) return c;
+      return {
+        ...c,
+        category: c?.category ?? rootCategoryFromKeepa(raw),
+        productWeight: c?.productWeight ?? keepaWeightToLbs(raw?.packageWeight) ?? c?.weight ?? null,
+        weight: c?.weight ?? keepaWeightToLbs(raw?.packageWeight) ?? null,
+        variations: c?.variations ?? countKeepaVariations(raw),
+        variationCount: c?.variationCount ?? countKeepaVariations(raw),
+        brand: c?.brand ?? (typeof raw?.brand === 'string' ? raw.brand : null),
+      };
+    });
+
+    // --- Recompute market-level metrics. ---
+    const newMarketCap = backfilledCompetitors.reduce(
+      (sum, c) => sum + safeNum(c?.monthlyRevenue),
+      0
+    );
+    const newRevenuePerCompetitor =
+      backfilledCompetitors.length > 0 ? newMarketCap / backfilledCompetitors.length : 0;
+    const competitorsWithShares = backfilledCompetitors.map((c) => ({
+      ...c,
+      marketShare: newMarketCap > 0 ? (safeNum(c?.monthlyRevenue) / newMarketCap) * 100 : 0,
+    }));
+    const newDistributions = calculateDistributions(competitorsWithShares);
+
+    // --- Build keepaResults from top-5's raw products via the legacy
+    // transform (calculateMarketScore reads .analysis.bsr/.analysis.price
+    // shape from this format). ---
+    const top5Raw = top5Asins
+      .map((a) => rawByAsin.get(a))
+      .filter((p): p is any => Boolean(p));
+    let newKeepaResults: any[] = [];
+    try {
+      newKeepaResults = top5Raw.length > 0 ? keepaService.transformKeepaData(top5Raw) : [];
+    } catch (err) {
+      console.warn('[lens-recalc] keepaService.transformKeepaData threw:', err);
+      newKeepaResults = [];
+    }
+
+    const newMarketScore = calculateMarketScore(competitorsWithShares, newKeepaResults);
+
+    const newMetrics = {
+      totalCompetitors: competitorsWithShares.length,
+      totalMarketCap: newMarketCap,
+      revenuePerCompetitor: newRevenuePerCompetitor,
+      competitorCount: competitorsWithShares.length,
+      calculatedAt: new Date().toISOString(),
+    };
+
+    // --- Build the persisted submission_data first so the AI summary
+    // derivation reads the post-recalc state. ---
+    const nowIso = new Date().toISOString();
+    const updatedExpansions = expansions.map((e) =>
+      e?.scoreAfter == null
+        ? {
+            ...e,
+            scoreAfter: newMarketScore.score,
+            scoreBefore:
+              typeof e?.scoreBefore === 'number'
+                ? e.scoreBefore
+                : (e?.preExpansionSnapshot?.score ?? null),
+            acknowledged: true,
+            recalcedAt: nowIso,
+          }
+        : e
+    );
+
+    const nextSubmissionData = {
+      ...submissionData,
+      productData: {
+        ...(submissionData.productData ?? {}),
+        competitors: competitorsWithShares,
+        distributions: newDistributions,
+      },
+      keepaResults: newKeepaResults,
+      marketScore: newMarketScore,
+      metrics: newMetrics,
+      lensExpansions: updatedExpansions,
+      // Legacy flag — analyze-market still dual-writes it for one cycle.
+      // Clearing it here keeps any old client surfaces from re-prompting.
+      __lens_pending_recalc: false,
+      updatedAt: nowIso,
+    };
+
+    // --- Regen AI summary against the post-recalc state. ---
+    let newAiSummary: any = submission.ai_summary ?? null;
+    try {
+      newAiSummary = await generateVettingSummary({
+        metrics: deriveSummaryMetrics({
+          submission_data: nextSubmissionData,
+          score: newMarketScore.score,
+          status: newMarketScore.status,
+        }),
+        userId,
+        submissionId,
+      });
+    } catch (err) {
+      // AI-summary regen is best-effort — keep the prior summary so the
+      // UI doesn't go blank if Anthropic is briefly unavailable.
+      console.warn('[lens-recalc] generateVettingSummary failed:', err);
+    }
+
+    // --- Persist everything in one update. ---
+    const { data: updated, error: updateError } = await supabase
+      .from('submissions')
+      .update({
+        score: newMarketScore.score,
+        status: newMarketScore.status,
+        metrics: newMetrics,
+        ai_summary: newAiSummary,
+        submission_data: nextSubmissionData,
+      })
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .select('*')
+      .single();
+
+    if (updateError || !updated) {
+      console.error('[lens-recalc] update failed:', updateError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to persist recalc' },
+        { status: 500 }
+      );
+    }
+
+    // --- Record the usage_event so cap.ts counts this recalc against
+    // the user's vetting cap on subsequent checkCap calls. Best-effort
+    // — the recalc itself already succeeded; failure here just means
+    // the user gets a free recalc this once. ---
+    void supabaseAdmin.from('usage_events').insert({
+      user_id: userId,
+      provider: 'extension',
+      operation: 'vetting_recalc',
+      status: 'ok',
+      metadata: {
+        submissionId,
+        addedAsins: newlyAddedAsins,
+        scoreBefore: unresolvedExpansions[0]?.scoreBefore ?? null,
+        scoreAfter: newMarketScore.score,
+        ts: nowIso,
+      },
+    });
+
+    return NextResponse.json({ success: true, submission: updated });
+  } catch (err) {
+    console.error('[lens-recalc] crashed:', err);
+    return NextResponse.json(
+      { success: false, error: 'Unexpected error' },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchKeepaRaw(asins: string[]): Promise<any[]> {
+  const apiKey = process.env.KEEPA_API_KEY;
+  if (!apiKey || asins.length === 0) return [];
+  try {
+    const url = `${KEEPA_BASE_URL}/product?key=${apiKey}&domain=1&asin=${asins.join(',')}&stats=180&history=1`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.warn('[lens-recalc] Keepa fetch non-ok status:', response.status);
+      return [];
+    }
+    const data = await response.json();
+    return Array.isArray(data?.products) ? data.products : [];
+  } catch (err) {
+    console.warn('[lens-recalc] Keepa fetch threw:', err);
+    return [];
+  }
+}
+
+function rootCategoryFromKeepa(product: any): string | null {
+  const tree: Array<{ catId: number; name: string }> = product?.categoryTree || [];
+  if (!Array.isArray(tree) || tree.length === 0) return null;
+  const first = tree[0];
+  return typeof first?.name === 'string' && first.name.length > 0 ? first.name : null;
+}
+
+function keepaWeightToLbs(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  // Keepa stores weight in hundredths of a gram.
+  const grams = value / 10;
+  const pounds = grams / 453.59237;
+  return Math.round(pounds * 1000) / 1000;
+}
+
+function countKeepaVariations(product: any): number | null {
+  if (Array.isArray(product?.variations)) return product.variations.length;
+  if (typeof product?.variationCSV === 'string' && product.variationCSV.length > 0) {
+    return product.variationCSV.split(',').filter(Boolean).length;
+  }
+  return null;
+}
+
+function safeNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function calculateAgeFromDate(dateFirstAvailable: string | undefined): number {
+  if (!dateFirstAvailable) return 0;
+  const first = new Date(dateFirstAvailable);
+  if (Number.isNaN(first.getTime())) return 0;
+  const diff = Math.abs(Date.now() - first.getTime());
+  return Math.ceil(diff / (1000 * 60 * 60 * 24 * 30));
+}
+
+function calculateDistributions(competitors: any[]) {
+  const total = competitors.length || 1;
+  const ageRanges = { new: 0, growing: 0, established: 0, mature: 0, na: 0 };
+  const fulfillmentRanges = { fba: 0, fbm: 0, amazon: 0, na: 0 };
+
+  if (competitors?.length) {
+    competitors.forEach((c) => {
+      let age = c?.age;
+      if (!age && c?.dateFirstAvailable) age = calculateAgeFromDate(c.dateFirstAvailable);
+      if (age <= 6) ageRanges.new++;
+      else if (age <= 12) ageRanges.growing++;
+      else if (age <= 24) ageRanges.established++;
+      else if (age > 24) ageRanges.mature++;
+      else ageRanges.na++;
+    });
+    competitors.forEach((c) => {
+      const method = String(c?.fulfillment ?? '').toLowerCase();
+      if (method.includes('fba')) fulfillmentRanges.fba++;
+      else if (method.includes('fbm')) fulfillmentRanges.fbm++;
+      else if (method.includes('amazon')) fulfillmentRanges.amazon++;
+      else fulfillmentRanges.na++;
+    });
+  }
+
+  const pct = (ranges: Record<string, number>) =>
+    Object.entries(ranges).reduce(
+      (acc, [k, v]) => ({ ...acc, [k]: (Number(v) / total) * 100 }),
+      {} as Record<string, number>
+    );
+
+  return { age: pct(ageRanges), fulfillment: pct(fulfillmentRanges) };
+}

--- a/src/app/api/submissions/[id]/lens-recalc/route.ts
+++ b/src/app/api/submissions/[id]/lens-recalc/route.ts
@@ -102,7 +102,14 @@ export async function POST(
       : [];
     const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
 
-    if (unresolvedExpansions.length === 0) {
+    // Phase 5.4-O — legacy fallback: pre-5.4-O analyze-market wrote
+    // __lens_pending_recalc=true without creating a lensExpansions[]
+    // entry. Recalcing those rows is still valid — pull the newly-added
+    // ASINs from competitors flagged __lens_new (the existing marker
+    // analyze-market has set since Phase 5.4-D).
+    const isLegacyOnly =
+      unresolvedExpansions.length === 0 && submissionData.__lens_pending_recalc === true;
+    if (unresolvedExpansions.length === 0 && !isLegacyOnly) {
       return NextResponse.json(
         { success: false, error: 'No pending Lens expansion to recalc' },
         { status: 400 }
@@ -146,6 +153,21 @@ export async function POST(
     for (const e of unresolvedExpansions) {
       for (const a of Array.isArray(e?.addedAsins) ? e.addedAsins : []) {
         if (typeof a === 'string' && ASIN_REGEX.test(a)) newlyAddedAsinsSet.add(a);
+      }
+    }
+    // Legacy-only path: derive newly-added ASINs from competitors that
+    // analyze-market flagged with __lens_new=true. Same Keepa-backfill
+    // outcome as the new path, just sourced from the competitor markers
+    // instead of the lensExpansions log.
+    if (isLegacyOnly) {
+      for (const c of competitors) {
+        if (
+          c?.__lens_new === true &&
+          typeof c?.asin === 'string' &&
+          ASIN_REGEX.test(c.asin.toUpperCase())
+        ) {
+          newlyAddedAsinsSet.add(c.asin.toUpperCase());
+        }
       }
     }
     const newlyAddedAsins = Array.from(newlyAddedAsinsSet);
@@ -239,6 +261,31 @@ export async function POST(
         : e
     );
 
+    // Legacy-only branch: there were no lensExpansions entries to mark
+    // resolved (the user's data was created on pre-5.4-O analyze-market).
+    // Synthesize one entry so the post-recalc pill + history panel show
+    // up for legacy data too. preExpansionSnapshot is null because we
+    // never captured one at append time — Undo isn't available for
+    // synthesized entries (the UI hides the Undo button when the
+    // snapshot is missing).
+    const finalExpansions =
+      isLegacyOnly && newlyAddedAsins.length > 0
+        ? [
+            {
+              id: `legacy-${nowIso}`,
+              addedAsins: newlyAddedAsins,
+              addedAt: nowIso,
+              source: 'bloom-lens',
+              scoreBefore: typeof submission.score === 'number' ? submission.score : null,
+              scoreAfter: newMarketScore.score,
+              acknowledged: true,
+              recalcedAt: nowIso,
+              preExpansionSnapshot: null,
+              isLegacy: true,
+            },
+          ]
+        : updatedExpansions;
+
     const nextSubmissionData = {
       ...submissionData,
       productData: {
@@ -249,9 +296,8 @@ export async function POST(
       keepaResults: newKeepaResults,
       marketScore: newMarketScore,
       metrics: newMetrics,
-      lensExpansions: updatedExpansions,
-      // Legacy flag — analyze-market still dual-writes it for one cycle.
-      // Clearing it here keeps any old client surfaces from re-prompting.
+      lensExpansions: finalExpansions,
+      // Clear the legacy flag — supersedes by lensExpansions presence.
       __lens_pending_recalc: false,
       updatedAt: nowIso,
     };

--- a/src/app/api/submissions/[id]/mark-expansions-read/route.ts
+++ b/src/app/api/submissions/[id]/mark-expansions-read/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Phase 5.4-O — POST /api/submissions/[id]/mark-expansions-read
+ *
+ * Lightweight UI-state mutation: marks every entry in
+ * submission_data.lensExpansions as acknowledged=true. Fired by
+ * VettingDetailContent on mount when hasUnacknowledgedExpansion is true,
+ * which clears the "+N new" badge on the /vetting dashboard list.
+ *
+ * Does NOT touch scoreAfter — the detail page banner stays up until the
+ * user actually clicks Recalculate. Acknowledged tracks "did the user
+ * see this?" while scoreAfter tracks "is this resolved math-wise?".
+ *
+ * No cap-check: this is purely cosmetic state. Idempotent.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const submissionId = params.id;
+    if (!submissionId) {
+      return NextResponse.json(
+        { success: false, error: 'Submission ID is required' },
+        { status: 400 }
+      );
+    }
+
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: authData } = await supabase.auth.getUser();
+    const userId = authData.user?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid session' },
+        { status: 401 }
+      );
+    }
+
+    const { data: submission, error: fetchError } = await supabase
+      .from('submissions')
+      .select('id, submission_data')
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'Submission not found' },
+        { status: 404 }
+      );
+    }
+
+    const submissionData = (submission.submission_data ?? {}) as any;
+    const expansions: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+
+    if (expansions.length === 0 || expansions.every((e) => e?.acknowledged)) {
+      // Already in the desired state — return success without a write.
+      return NextResponse.json({ success: true, changed: false });
+    }
+
+    const acknowledgedExpansions = expansions.map((e) =>
+      e?.acknowledged ? e : { ...e, acknowledged: true }
+    );
+
+    const { error: updateError } = await supabase
+      .from('submissions')
+      .update({
+        submission_data: {
+          ...submissionData,
+          lensExpansions: acknowledgedExpansions,
+        },
+      })
+      .eq('id', submissionId)
+      .eq('user_id', userId);
+
+    if (updateError) {
+      console.error('[mark-expansions-read] update failed:', updateError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to update' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, changed: true });
+  } catch (err) {
+    console.error('[mark-expansions-read] crashed:', err);
+    return NextResponse.json(
+      { success: false, error: 'Unexpected error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/submissions/[id]/route.ts
+++ b/src/app/api/submissions/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabaseServer';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { supabaseAdmin } from '@/utils/supabaseAdmin';
+import { checkCap } from '@/lib/subscription';
 
 // PATCH /api/submissions/[id]
 // Body A — apply an adjustment (competitor removal + recalc):
@@ -150,6 +152,37 @@ export async function PATCH(
       );
     }
 
+    // Phase 5.4-O — adjust runs the same Keepa + scoring + AI-summary
+    // pipeline as a fresh vetting (counted via the usage_events insert
+    // below). Cap-check before doing the work; 402 surfaces the cap-modal
+    // payload so the UI can render the upgrade prompt without a follow-up
+    // call. Symmetrical with /api/submissions/[id]/lens-recalc — both
+    // paths consume a vetting slot and share the same gating.
+    const adjustCap = await checkCap(supabase, userId, 'vetting');
+    if (!adjustCap.allowed) {
+      console.log('PATCH adjust: vetting cap reached', {
+        userId,
+        used: adjustCap.used,
+        limit: adjustCap.limit,
+        tier: adjustCap.state.effectiveTier,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: `You've used all ${adjustCap.limit} vettings on the Core plan this period. Upgrade to Pro for unlimited vettings.`,
+          cap: {
+            action: 'vetting',
+            used: adjustCap.used,
+            limit: adjustCap.limit,
+            remaining: adjustCap.remaining,
+            tier: adjustCap.state.tier,
+            effectiveTier: adjustCap.state.effectiveTier,
+          },
+        },
+        { status: 402 }
+      );
+    }
+
     // Snapshot the current canonical state ONLY on the first adjustment.
     // Phase 5.4-J — also stash the current ai_summary so a later reset can
     // restore the original briefing without a Claude call.
@@ -204,6 +237,22 @@ export async function PATCH(
         { status: 500 }
       );
     }
+
+    // Phase 5.4-O — record the recalc against the user's vetting cap.
+    // Best-effort; the adjust itself already succeeded.
+    void supabaseAdmin.from('usage_events').insert({
+      user_id: userId,
+      provider: 'other',
+      operation: 'vetting_recalc',
+      status: 'ok',
+      metadata: {
+        submissionId,
+        path: 'patch-adjust',
+        removedAsins,
+        adjustedScore: marketScore?.score ?? null,
+        ts: now,
+      },
+    });
 
     return NextResponse.json({ success: true, submission: updated });
   } catch (error) {

--- a/src/app/api/submissions/[id]/undo-expansion/route.ts
+++ b/src/app/api/submissions/[id]/undo-expansion/route.ts
@@ -1,0 +1,163 @@
+/**
+ * Phase 5.4-O — POST /api/submissions/[id]/undo-expansion
+ *
+ * Removes a single Lens-driven expansion batch and restores the
+ * submission to its pre-this-batch state. Earlier and later
+ * expansions are preserved untouched — each entry's
+ * preExpansionSnapshot was captured at the moment that specific
+ * batch landed, so restoring it returns to the state immediately
+ * before that batch (and only that batch).
+ *
+ * Body: { expansionId: string }   // matches lensExpansions[].id
+ *
+ * Auth: bearer token, RLS-scoped (owner-only).
+ *
+ * Behavior:
+ *   1. Resolve user from bearer token.
+ *   2. Load submission. Find the expansion entry by id.
+ *   3. Restore productData.competitors / marketScore / metrics /
+ *      keepaResults / ai_summary from preExpansionSnapshot.
+ *   4. Remove that entry from lensExpansions[].
+ *   5. Persist + return updated submission.
+ *
+ * Note: this does NOT touch submission_data.adjustment or
+ * originalSnapshot — Adjustments and Expansions are independent
+ * concepts (per Phase 5.4-O memory rule #15). If the user has both
+ * an adjustment AND expansions, undoing one expansion preserves
+ * the adjustment.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const submissionId = params.id;
+    if (!submissionId) {
+      return NextResponse.json(
+        { success: false, error: 'Submission ID is required' },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const expansionId = typeof body?.expansionId === 'string' ? body.expansionId : '';
+    if (!expansionId) {
+      return NextResponse.json(
+        { success: false, error: 'expansionId is required' },
+        { status: 400 }
+      );
+    }
+
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const { data: authData } = await supabase.auth.getUser();
+    const userId = authData.user?.id;
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid session' },
+        { status: 401 }
+      );
+    }
+
+    const { data: submission, error: fetchError } = await supabase
+      .from('submissions')
+      .select('*')
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'Submission not found' },
+        { status: 404 }
+      );
+    }
+
+    const submissionData = (submission.submission_data ?? {}) as any;
+    const expansions: any[] = Array.isArray(submissionData.lensExpansions)
+      ? submissionData.lensExpansions
+      : [];
+    const target = expansions.find((e) => e?.id === expansionId);
+    if (!target) {
+      return NextResponse.json(
+        { success: false, error: 'Expansion not found' },
+        { status: 404 }
+      );
+    }
+
+    const snapshot = target?.preExpansionSnapshot ?? null;
+    if (!snapshot) {
+      return NextResponse.json(
+        { success: false, error: 'Expansion has no snapshot to restore' },
+        { status: 400 }
+      );
+    }
+
+    const remainingExpansions = expansions.filter((e) => e?.id !== expansionId);
+
+    const restoredSubmissionData = {
+      ...submissionData,
+      productData: snapshot.productData ?? submissionData.productData ?? {},
+      keepaResults: snapshot.keepaResults ?? submissionData.keepaResults ?? [],
+      marketScore: snapshot.marketScore ?? submissionData.marketScore ?? {},
+      metrics: snapshot.metrics ?? submissionData.metrics ?? {},
+      lensExpansions: remainingExpansions,
+      // No remaining unresolved expansions → also clear the legacy flag.
+      __lens_pending_recalc: remainingExpansions.some((e) => e?.scoreAfter == null),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const updateColumns: Record<string, any> = {
+      score: typeof snapshot.score === 'number' ? snapshot.score : submission.score,
+      status: typeof snapshot.status === 'string' ? snapshot.status : submission.status,
+      metrics: snapshot.metrics ?? submission.metrics,
+      submission_data: restoredSubmissionData,
+    };
+    if (Object.prototype.hasOwnProperty.call(snapshot, 'aiSummary')) {
+      updateColumns.ai_summary = snapshot.aiSummary ?? null;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('submissions')
+      .update(updateColumns)
+      .eq('id', submissionId)
+      .eq('user_id', userId)
+      .select('*')
+      .single();
+
+    if (updateError || !updated) {
+      console.error('[undo-expansion] update failed:', updateError);
+      return NextResponse.json(
+        { success: false, error: 'Failed to undo expansion' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, submission: updated });
+  } catch (err) {
+    console.error('[undo-expansion] crashed:', err);
+    return NextResponse.json(
+      { success: false, error: 'Unexpected error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/vetting/generate-summary/route.ts
+++ b/src/app/api/vetting/generate-summary/route.ts
@@ -6,7 +6,10 @@
  * Flow:
  *   1. Authenticate, verify the caller owns the submission.
  *   2. If ai_summary already exists and !force → return cached.
- *   3. Derive a compact metrics object from submission_data.
+ *   3. Derive a compact metrics object from submission_data via
+ *      deriveSummaryMetrics (shared with /api/submissions/[id]/lens-recalc
+ *      so the AI briefing is consistent across initial vetting and
+ *      Phase 5.4-O Lens-expansion recalcs).
  *   4. Call generateVettingSummary (Sonnet 4.6 via runAnthropic).
  *   5. Persist to submissions.ai_summary. Return the summary.
  *
@@ -19,12 +22,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabaseServer';
-import { getVettingInsights } from '@/lib/vetting/insights';
-import { calculateScore, getCompetitorStrength } from '@/utils/scoring';
-import {
-  generateVettingSummary,
-  type VettingSummaryMetrics,
-} from '@/services/vettingSummary';
+import { generateVettingSummary } from '@/services/vettingSummary';
+import { deriveSummaryMetrics } from '@/lib/vetting/deriveSummaryMetrics';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -91,7 +90,7 @@ export async function POST(request: NextRequest) {
     }
 
     // --- Derive metrics from submission_data ---
-    const metrics = deriveMetrics(submission);
+    const metrics = deriveSummaryMetrics(submission);
 
     // --- Call Anthropic ---
     const summary = await generateVettingSummary({
@@ -127,171 +126,3 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// ============================================================
-// Metric derivation — pulls a compact analytic payload out of
-// the stored submission_data blob for the model to ground on.
-// ============================================================
-
-function deriveMetrics(submission: any): VettingSummaryMetrics {
-  const data = submission?.submission_data ?? {};
-  const competitors: any[] = data?.productData?.competitors ?? [];
-  const keepaResults: any[] = data?.keepaResults ?? [];
-  const distributions = data?.productData?.distributions ?? {};
-
-  // --- Totals ---
-  const marketCap = competitors.reduce(
-    (sum, c) => sum + safeNum(c?.monthlyRevenue),
-    0
-  );
-  const competitorCount = competitors.length;
-  const revenuePerCompetitor = competitorCount ? marketCap / competitorCount : 0;
-
-  const totalReviews = competitors.reduce((s, c) => s + safeNum(c?.reviews), 0);
-
-  // --- Top-5 by monthly sales ---
-  const top5 = [...competitors]
-    .sort((a, b) => safeNum(b?.monthlySales) - safeNum(a?.monthlySales))
-    .slice(0, 5);
-
-  const avgTop5Reviews = top5.length
-    ? top5.reduce((s, c) => s + safeNum(c?.reviews), 0) / top5.length
-    : undefined;
-  const validRatings = top5.filter((c) => safeNum(c?.rating) > 0);
-  const avgTop5Rating = validRatings.length
-    ? validRatings.reduce((s, c) => s + safeNum(c?.rating), 0) / validRatings.length
-    : undefined;
-  const withAge = top5.filter((c) => c?.dateFirstAvailable);
-  const avgTop5AgeMonths = withAge.length
-    ? withAge.reduce((s, c) => s + ageMonths(c.dateFirstAvailable), 0) / withAge.length
-    : undefined;
-
-  const top5MarketSharePct = top5.reduce(
-    (s, c) => s + safeNum(c?.marketShare),
-    0
-  );
-  const top5ReviewSharePct = totalReviews > 0
-    ? (top5.reduce((s, c) => s + safeNum(c?.reviews), 0) / totalReviews) * 100
-    : undefined;
-
-  // --- Keepa stability ---
-  const bsrStabilities = keepaResults
-    .map((r) => r?.analysis?.bsr?.stability)
-    .filter((v): v is number => typeof v === 'number');
-  const priceStabilities = keepaResults
-    .map((r) => r?.analysis?.price?.stability)
-    .filter((v): v is number => typeof v === 'number');
-  const avgBsrStability = bsrStabilities.length
-    ? bsrStabilities.reduce((s, v) => s + v, 0) / bsrStabilities.length
-    : undefined;
-  const avgPriceStability = priceStabilities.length
-    ? priceStabilities.reduce((s, v) => s + v, 0) / priceStabilities.length
-    : undefined;
-
-  // --- Competitor strength mix ---
-  const strengthLabels = competitors
-    .map((c) => {
-      const score = parseFloat(String(calculateScore(c)));
-      if (!Number.isFinite(score)) return null;
-      return getCompetitorStrength(score).label;
-    })
-    .filter(Boolean) as Array<'STRONG' | 'DECENT' | 'WEAK'>;
-  const competitorStrengthMix = {
-    strong: strengthLabels.filter((l) => l === 'STRONG').length,
-    decent: strengthLabels.filter((l) => l === 'DECENT').length,
-    weak: strengthLabels.filter((l) => l === 'WEAK').length,
-  };
-
-  // --- Fulfillment + age cohort %s (already as 0-100 in the stored distributions) ---
-  const fulfillment = distributions?.fulfillment ?? {};
-  const age = distributions?.age ?? {};
-
-  // --- Price range via getVettingInsights() ---
-  let priceRange: VettingSummaryMetrics['priceRange'];
-  let concentration: VettingSummaryMetrics['concentration'];
-  let redFlags: string[] | undefined;
-  let greenFlags: string[] | undefined;
-  try {
-    const { insights } = getVettingInsights({ competitors });
-    const p = insights.distributions?.price;
-    if (p) {
-      priceRange = { min: p.min, max: p.max, median: p.median };
-    }
-    concentration = {
-      top1Share: insights.concentration?.top1Share,
-      top3Share: insights.concentration?.top3Share,
-      top5Share: insights.concentration?.top5Share,
-    };
-    redFlags = insights.flags?.red?.map((f) => f.title).filter(Boolean);
-    greenFlags = insights.flags?.green?.map((f) => f.title).filter(Boolean);
-  } catch (e) {
-    // Insights derivation is best-effort — model can still summarize on
-    // the primary metrics without the flag titles.
-    console.warn('[vetting/generate-summary] getVettingInsights threw:', e);
-  }
-
-  // --- Score + status ---
-  const marketScoreObj = data?.marketScore ?? {};
-  const score = numberOr(marketScoreObj?.score, submission?.score, 0);
-  const status = stringOr(marketScoreObj?.status, submission?.status, 'Assessment Unavailable');
-
-  return {
-    score,
-    status,
-    competitorCount,
-    marketCapUsd: marketCap,
-    revenuePerCompetitor,
-    top5MarketSharePct,
-    top5ReviewSharePct,
-    concentration,
-    avgTop5Reviews,
-    avgTop5Rating,
-    avgTop5AgeMonths,
-    avgBsrStability,
-    avgPriceStability,
-    competitorStrengthMix,
-    fulfillmentSplit: {
-      fba: safeNum(fulfillment.fba),
-      fbm: safeNum(fulfillment.fbm),
-      amazon: safeNum(fulfillment.amazon),
-    },
-    ageCohorts: {
-      new: safeNum(age.new),
-      growing: safeNum(age.growing),
-      established: safeNum(age.established),
-      mature: safeNum(age.mature),
-    },
-    priceRange,
-    redFlags,
-    greenFlags,
-  };
-}
-
-// ============================================================
-
-function safeNum(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function numberOr(...candidates: unknown[]): number {
-  for (const c of candidates) {
-    const n = Number(c);
-    if (Number.isFinite(n)) return n;
-  }
-  return 0;
-}
-
-function stringOr(...candidates: unknown[]): string {
-  for (const c of candidates) {
-    if (typeof c === 'string' && c.trim()) return c;
-  }
-  return '';
-}
-
-function ageMonths(dateFirstAvailable: string | undefined): number {
-  if (!dateFirstAvailable) return 0;
-  const d = new Date(dateFirstAvailable);
-  if (Number.isNaN(d.getTime())) return 0;
-  const diffMs = Date.now() - d.getTime();
-  return Math.ceil(diffMs / (1000 * 60 * 60 * 24 * 30));
-}

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -1440,6 +1440,35 @@ export const ProductVettingResults: React.FC<{
     }));
   };
 
+  // Phase 5.4-O — PDP-only columns Lens can't capture from Amazon SERP.
+  // Render a hover-tooltip on the — cell so users understand WHY the
+  // value is empty for Lens-sourced rows. Helium 10 CSV uploads do
+  // populate these (the user-supplied CSV path), so mentioning H10 here
+  // is honest and actionable. Helium 10 is the documented exception to
+  // the "no vendor names in user copy" rule; see Phase 5.4-O acceptance
+  // criteria.
+  const LENS_TOOLTIP_KEYS = new Set(['fulfillment', 'sellerCount', 'activeSellers', 'soldBy']);
+  const LENS_TOOLTIP_COPY =
+    'Captured from Amazon search results — this field requires a listing-page lookup, which fills in when you vet from a Helium 10 CSV.';
+  const wrapWithLensTooltip = (
+    cellContent: React.ReactNode,
+    competitor: Competitor,
+    columnKey: string
+  ): React.ReactNode => {
+    if (!LENS_TOOLTIP_KEYS.has(columnKey)) return cellContent;
+    if (!(competitor as any)?.__lens_origin) return cellContent;
+    const raw = (competitor as any)?.[columnKey];
+    if (raw !== null && raw !== undefined && raw !== '') return cellContent;
+    return (
+      <span
+        title={LENS_TOOLTIP_COPY}
+        className="cursor-help underline decoration-dotted decoration-slate-500/50 underline-offset-2"
+      >
+        {cellContent}
+      </span>
+    );
+  };
+
   const formatColumnValue = (competitor: Competitor, key: string) => {
     const value = (competitor as any)?.[key];
     if (value === null || value === undefined || value === '') return '—';
@@ -2984,16 +3013,20 @@ export const ProductVettingResults: React.FC<{
                             column.key === 'title' ? 'truncate max-w-xs' : ''
                           } ${column.key === 'dateFirstAvailable' ? 'whitespace-nowrap' : ''}`}
                         >
-                          {['reviews', 'rating', 'fulfillment', 'bsr'].includes(column.key)
-                            ? renderSignalCell(competitor, column.key, isRemovalHighlighted)
-                            : formatColumnValue(competitor, column.key)}
+                          {wrapWithLensTooltip(
+                            ['reviews', 'rating', 'fulfillment', 'bsr'].includes(column.key)
+                              ? renderSignalCell(competitor, column.key, isRemovalHighlighted)
+                              : formatColumnValue(competitor, column.key),
+                            competitor,
+                            column.key
+                          )}
                         </td>
                       ) : null
                     ))}
                   </tr>
                 );
               })}
-              
+
               {/* Show removed competitors with struck-through styling */}
               {showRemoved && removedCompetitorsList.map((competitor) => {
                 const competitorScore = parseFloat(calculateScore(competitor));
@@ -3063,7 +3096,11 @@ export const ProductVettingResults: React.FC<{
                           key={column.key}
                           className={`p-3 text-sm leading-5 text-white align-middle ${column.key === 'title' ? 'truncate max-w-xs' : ''}`}
                         >
-                          {formatColumnValue(competitor, column.key)}
+                          {wrapWithLensTooltip(
+                            formatColumnValue(competitor, column.key),
+                            competitor,
+                            column.key
+                          )}
                         </td>
                       ) : null
                     ))}

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { AlertCircle, Check, Loader2, Share2 } from 'lucide-react';
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  RotateCw,
+  Share2,
+  Sparkles,
+  Undo2,
+} from 'lucide-react';
 import { supabase } from '@/utils/supabaseClient';
 import { RootState } from '@/store';
 import { ProductHeader } from '@/components/Product/ProductHeader';
@@ -14,12 +24,47 @@ import { getProductAsin } from '@/utils/productIdentifiers';
 import { buildVettingEngineUrl } from '@/utils/vettingNavigation';
 import { applyAdjustment, resetAdjustment } from '@/utils/submissionAdjustments';
 import { getProductDisplayName } from '@/utils/product';
+import {
+  CapReachedModal,
+  type CapInfo,
+} from '@/components/subscription/CapReachedModal';
 
 function badgeToneFromStatus(status: string | null | undefined) {
   if (status === 'PASS') return 'emerald' as const;
   if (status === 'RISKY') return 'amber' as const;
   if (status === 'FAIL') return 'red' as const;
   return 'slate' as const;
+}
+
+// Phase 5.4-O — tiny relative-time formatter for the expansion pill +
+// history panel. "2 minutes ago", "3 hours ago", "Apr 20" for older
+// dates. Avoids pulling in date-fns just for two timestamps.
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return '';
+  const diff = Date.now() - ts;
+  const min = 60 * 1000;
+  const hr = 60 * min;
+  const day = 24 * hr;
+  if (diff < min) return 'just now';
+  if (diff < hr) {
+    const m = Math.floor(diff / min);
+    return `${m} minute${m === 1 ? '' : 's'} ago`;
+  }
+  if (diff < day) {
+    const h = Math.floor(diff / hr);
+    return `${h} hour${h === 1 ? '' : 's'} ago`;
+  }
+  if (diff < 7 * day) {
+    const d = Math.floor(diff / day);
+    return `${d} day${d === 1 ? '' : 's'} ago`;
+  }
+  try {
+    return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
 }
 
 export function VettingDetailContent({ asin }: { asin: string }) {
@@ -50,6 +95,15 @@ export function VettingDetailContent({ asin }: { asin: string }) {
   // handleCompetitorsUpdated; cleared by refresh and by reset (since reset
   // restores the original ai_summary alongside the original competitors).
   const [summaryStale, setSummaryStale] = useState(false);
+  // Phase 5.4-O — Lens-expansion UI state.
+  const [recalcing, setRecalcing] = useState(false);
+  const [undoingExpansionId, setUndoingExpansionId] = useState<string | null>(null);
+  const [expansionPanelOpen, setExpansionPanelOpen] = useState(false);
+  const [capReached, setCapReached] = useState<CapInfo | null>(null);
+  const expansionPanelRef = useRef<HTMLDivElement | null>(null);
+  // Mark-as-read fires once per market visit (clears the dashboard "+N new"
+  // badge). Guard so re-renders don't re-fire it.
+  const markedReadRef = useRef<string | null>(null);
   const isInvalidAsin = !asin || asin === 'undefined' || asin === 'null';
 
   // Share-feature hooks — declared at the top of the component so they
@@ -273,6 +327,65 @@ export function VettingDetailContent({ asin }: { asin: string }) {
       lastRowContext,
     });
   }, [isInvalidAsin, asin, pathname, searchString, lastRowContext, submissionId]);
+
+  // Phase 5.4-O — clear the dashboard "+N new" badge by acknowledging all
+  // expansions on detail-page mount. Acknowledged is independent of
+  // scoreAfter — the banner stays up until the user actually clicks
+  // Recalculate, but the dashboard pill clears as soon as they look.
+  useEffect(() => {
+    if (!submission?.id) return;
+    if (markedReadRef.current === submission.id) return;
+    if (!submission.hasUnacknowledgedExpansion) return;
+
+    markedReadRef.current = submission.id;
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        const res = await fetch(`/api/submissions/${submission.id}/mark-expansions-read`, {
+          method: 'POST',
+          headers: {
+            ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+          },
+          credentials: 'include',
+        });
+        if (!res.ok || cancelled) return;
+        // Mirror the server-side ack into local state so subsequent
+        // analyze fetches don't surprise us.
+        setSubmission((prev: any) =>
+          prev
+            ? {
+                ...prev,
+                lensExpansions: (prev.lensExpansions ?? []).map((e: any) =>
+                  e?.acknowledged ? e : { ...e, acknowledged: true }
+                ),
+                hasUnacknowledgedExpansion: false,
+              }
+            : prev
+        );
+      } catch (e) {
+        // Best-effort — badge will clear next page load if this fails.
+        console.warn('[VettingDetail] mark-expansions-read failed:', e);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [submission?.id, submission?.hasUnacknowledgedExpansion]);
+
+  // Close the expansion-history panel on outside click.
+  useEffect(() => {
+    if (!expansionPanelOpen) return;
+    const onDocClick = (ev: MouseEvent) => {
+      if (!expansionPanelRef.current) return;
+      if (!expansionPanelRef.current.contains(ev.target as Node)) {
+        setExpansionPanelOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [expansionPanelOpen]);
 
   if (loading) {
     return (
@@ -498,6 +611,120 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     }
   };
 
+  // Phase 5.4-O — inline recalc on /vetting/[asin] when there's an
+  // unresolved BloomLens expansion. Hits the new lens-recalc endpoint
+  // which runs Keepa enrichment for backfill + scoring + AI summary
+  // regeneration server-side, then mirrors the response into local
+  // state. 402 surfaces the cap-modal so a Core user at vetting limit
+  // sees an upgrade nudge inline (no Stripe redirect — rule).
+  const handleLensRecalc = async () => {
+    if (!submission?.id || recalcing) return;
+    setRecalcing(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(`/api/submissions/${submission.id}/lens-recalc`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+        },
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (res.status === 402 && data?.cap) {
+        setCapReached(data.cap as CapInfo);
+        return;
+      }
+      if (!res.ok || !data?.success || !data?.submission) {
+        throw new Error(data?.error || `Recalc failed (${res.status})`);
+      }
+      const updated = data.submission;
+      setSubmission((prev: any) =>
+        prev
+          ? {
+              ...prev,
+              score: updated.score ?? prev.score,
+              status: updated.status ?? prev.status,
+              productData: updated.submission_data?.productData ?? prev.productData,
+              keepaResults: updated.submission_data?.keepaResults ?? prev.keepaResults,
+              marketScore: updated.submission_data?.marketScore ?? prev.marketScore,
+              metrics: updated.metrics ?? prev.metrics,
+              lensExpansions: updated.submission_data?.lensExpansions ?? prev.lensExpansions ?? [],
+              hasUnacknowledgedExpansion: false,
+            }
+          : prev
+      );
+      if (updated.ai_summary !== undefined) {
+        setAiSummary(updated.ai_summary);
+      }
+      setSummaryStale(false);
+    } catch (err) {
+      console.error('[VettingDetail] lens-recalc failed:', err);
+      setShareToast({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Could not recalculate.',
+      });
+    } finally {
+      setRecalcing(false);
+    }
+  };
+
+  // Phase 5.4-O — undo a single expansion batch. Restores from the
+  // entry's preExpansionSnapshot and removes that entry from the log.
+  // Earlier/later expansions and any `adjustment` are untouched.
+  const handleUndoExpansion = async (expansionId: string) => {
+    if (!submission?.id || undoingExpansionId) return;
+    setUndoingExpansionId(expansionId);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(`/api/submissions/${submission.id}/undo-expansion`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(session?.access_token && { Authorization: `Bearer ${session.access_token}` }),
+        },
+        credentials: 'include',
+        body: JSON.stringify({ expansionId }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data?.success || !data?.submission) {
+        throw new Error(data?.error || `Undo failed (${res.status})`);
+      }
+      const updated = data.submission;
+      setSubmission((prev: any) =>
+        prev
+          ? {
+              ...prev,
+              score: updated.score ?? prev.score,
+              status: updated.status ?? prev.status,
+              productData: updated.submission_data?.productData ?? prev.productData,
+              keepaResults: updated.submission_data?.keepaResults ?? prev.keepaResults,
+              marketScore: updated.submission_data?.marketScore ?? prev.marketScore,
+              metrics: updated.metrics ?? prev.metrics,
+              lensExpansions: updated.submission_data?.lensExpansions ?? [],
+              hasUnacknowledgedExpansion: (updated.submission_data?.lensExpansions ?? []).some(
+                (e: any) => !e?.acknowledged
+              ),
+            }
+          : prev
+      );
+      if (updated.ai_summary !== undefined) {
+        setAiSummary(updated.ai_summary);
+      }
+      // Snapshot's ai_summary matched the pre-expansion state, so it's
+      // not stale relative to the now-current competitor set.
+      setSummaryStale(false);
+    } catch (err) {
+      console.error('[VettingDetail] undo-expansion failed:', err);
+      setShareToast({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Could not undo expansion.',
+      });
+    } finally {
+      setUndoingExpansionId(null);
+    }
+  };
+
   const shareAction = submission?.id ? (
     <div className="flex items-center gap-2">
       <button
@@ -616,9 +843,152 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     );
   }
 
+  // Phase 5.4-O — derive Lens-expansion render state. expansions is
+  // append-only (one entry per Lens "Add to existing" event); unresolved
+  // entries are those that haven't been recalced yet (scoreAfter null).
+  const expansions: any[] = Array.isArray(submission?.lensExpansions)
+    ? submission.lensExpansions
+    : [];
+  const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
+  const totalAddedFromLens = expansions.reduce(
+    (sum, e) => sum + (Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0),
+    0
+  );
+  const mostRecentExpansionAt = expansions.length > 0
+    ? expansions
+        .map((e) => e?.addedAt)
+        .filter((t): t is string => typeof t === 'string')
+        .sort()
+        .slice(-1)[0]
+    : null;
+
   return (
     <div className={`transition-opacity duration-300 ${isMounted ? 'opacity-100' : 'opacity-0'}`}>
       {header}
+
+      {/* Phase 5.4-O — recalc banner (unresolved expansion). Click runs
+          POST /api/submissions/[id]/lens-recalc inline; no page bounce. */}
+      {unresolvedExpansions.length > 0 && submission?.id ? (
+        <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50/80 dark:border-amber-500/40 dark:bg-amber-900/20 p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-amber-500 dark:text-amber-300 mt-0.5 flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-amber-900 dark:text-amber-100">
+                New competitors detected
+              </p>
+              <p className="text-sm text-amber-800/90 dark:text-amber-200/80 mt-1">
+                Competitors were added from BloomLens since this market was last vetted.
+                Recalculate to refresh the score, market metrics, and AI summary.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleLensRecalc}
+              disabled={recalcing}
+              className="px-4 py-2 bg-amber-500 hover:bg-amber-600 dark:bg-amber-500 dark:hover:bg-amber-400 text-white text-sm font-medium rounded-lg transition-colors shadow-sm flex-shrink-0 inline-flex items-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {recalcing ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Recalculating…
+                </>
+              ) : (
+                <>
+                  <RotateCw className="w-4 h-4" />
+                  Recalculate
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Phase 5.4-O — post-recalc pill + expansion-history panel.
+          Shown when expansions exist AND none are unresolved. Click the
+          pill to expand the history; per-batch undo lives in the panel. */}
+      {unresolvedExpansions.length === 0 && expansions.length > 0 && submission?.id ? (
+        <div className="mt-4 relative" ref={expansionPanelRef}>
+          <button
+            type="button"
+            onClick={() => setExpansionPanelOpen((v) => !v)}
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-400/40 bg-emerald-50/80 dark:bg-emerald-500/10 text-sm font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100/80 dark:hover:bg-emerald-500/20 transition-colors"
+          >
+            <Sparkles className="w-3.5 h-3.5" />
+            +{totalAddedFromLens} from BloomLens
+            {mostRecentExpansionAt ? (
+              <span className="text-emerald-700/80 dark:text-emerald-300/80">
+                · {formatRelativeTime(mostRecentExpansionAt)}
+              </span>
+            ) : null}
+            {expansionPanelOpen ? (
+              <ChevronUp className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5" />
+            )}
+          </button>
+
+          {expansionPanelOpen ? (
+            <div className="absolute z-30 mt-2 w-[28rem] max-w-[90vw] rounded-xl border border-gray-200 dark:border-slate-700/70 bg-white dark:bg-slate-900 shadow-xl p-2">
+              <p className="px-3 pt-2 pb-1 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
+                Expansion history
+              </p>
+              <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+                {[...expansions]
+                  .sort((a, b) => String(b?.addedAt ?? '').localeCompare(String(a?.addedAt ?? '')))
+                  .map((e) => {
+                    const id = String(e?.id ?? e?.addedAt ?? '');
+                    const count = Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0;
+                    const before = typeof e?.scoreBefore === 'number' ? e.scoreBefore : null;
+                    const after = typeof e?.scoreAfter === 'number' ? e.scoreAfter : null;
+                    const isUndoing = undoingExpansionId === id;
+                    return (
+                      <li key={id} className="px-3 py-2 flex items-center gap-3">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-gray-800 dark:text-slate-200">
+                            +{count} competitor{count === 1 ? '' : 's'} added
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                            {formatRelativeTime(e?.addedAt)}
+                            {before != null && after != null ? (
+                              <>
+                                {' · '}
+                                <span className="tabular-nums">
+                                  {before.toFixed(1)}% → {after.toFixed(1)}%
+                                </span>
+                              </>
+                            ) : null}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (
+                              window.confirm(
+                                `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
+                              )
+                            ) {
+                              handleUndoExpansion(id);
+                            }
+                          }}
+                          disabled={Boolean(undoingExpansionId)}
+                          className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {isUndoing ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <Undo2 className="w-3 h-3" />
+                          )}
+                          Undo
+                        </button>
+                      </li>
+                    );
+                  })}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <ProductVettingResults
         productId={researchProduct?.id || submission?.id}
         competitors={submission.productData?.competitors || []}
@@ -655,6 +1025,11 @@ export function VettingDetailContent({ asin }: { asin: string }) {
           </div>
         </div>
       )}
+      <CapReachedModal
+        isOpen={capReached !== null}
+        onClose={() => setCapReached(null)}
+        cap={capReached}
+      />
     </div>
   );
 }

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -889,7 +889,8 @@ export function VettingDetailContent({ asin }: { asin: string }) {
               </p>
               <p className="text-sm text-amber-800/90 dark:text-amber-200/80 mt-1">
                 Competitors were added from BloomLens since this market was last vetted.
-                Recalculate to refresh the score, market metrics, and AI summary.
+                Recalculate to refresh the score, stability signals, and AI briefing
+                using the latest sales-rank data for the new competitors.
               </p>
             </div>
             <button

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -850,6 +850,15 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     ? submission.lensExpansions
     : [];
   const unresolvedExpansions = expansions.filter((e) => e?.scoreAfter == null);
+  // Transitional fallback: pre-5.4-O analyze-market wrote
+  // __lens_pending_recalc=true without creating a lensExpansions[]
+  // entry. /api/analyze surfaces that as lensPendingRecalcLegacy.
+  // The banner shows for either signal so users with legacy-flag-only
+  // data can still recalc; the recalc endpoint handles both paths.
+  // Drop after PR A ships to production for a full deploy cycle.
+  const hasLegacyPendingRecalc =
+    expansions.length === 0 && Boolean(submission?.lensPendingRecalcLegacy);
+  const showRecalcBanner = unresolvedExpansions.length > 0 || hasLegacyPendingRecalc;
   const totalAddedFromLens = expansions.reduce(
     (sum, e) => sum + (Array.isArray(e?.addedAsins) ? e.addedAsins.length : 0),
     0
@@ -866,9 +875,11 @@ export function VettingDetailContent({ asin }: { asin: string }) {
     <div className={`transition-opacity duration-300 ${isMounted ? 'opacity-100' : 'opacity-0'}`}>
       {header}
 
-      {/* Phase 5.4-O — recalc banner (unresolved expansion). Click runs
-          POST /api/submissions/[id]/lens-recalc inline; no page bounce. */}
-      {unresolvedExpansions.length > 0 && submission?.id ? (
+      {/* Phase 5.4-O — recalc banner. Shown when there's an unresolved
+          lensExpansions entry OR (legacy fallback) the pre-5.4-O
+          __lens_pending_recalc flag is set. Click runs the recalc
+          endpoint inline. */}
+      {showRecalcBanner && submission?.id ? (
         <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50/80 dark:border-amber-500/40 dark:bg-amber-900/20 p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="w-5 h-5 text-amber-500 dark:text-amber-300 mt-0.5 flex-shrink-0" />
@@ -941,6 +952,12 @@ export function VettingDetailContent({ asin }: { asin: string }) {
                     const before = typeof e?.scoreBefore === 'number' ? e.scoreBefore : null;
                     const after = typeof e?.scoreAfter === 'number' ? e.scoreAfter : null;
                     const isUndoing = undoingExpansionId === id;
+                    // Synthesized legacy entries don't have a
+                    // preExpansionSnapshot (analyze-market wasn't
+                    // capturing one before 5.4-O), so Undo isn't
+                    // available — the necessary state to restore to
+                    // simply doesn't exist for old data.
+                    const canUndo = Boolean(e?.preExpansionSnapshot);
                     return (
                       <li key={id} className="px-3 py-2 flex items-center gap-3">
                         <div className="flex-1 min-w-0">
@@ -959,27 +976,29 @@ export function VettingDetailContent({ asin }: { asin: string }) {
                             ) : null}
                           </p>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (
-                              window.confirm(
-                                `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
-                              )
-                            ) {
-                              handleUndoExpansion(id);
-                            }
-                          }}
-                          disabled={Boolean(undoingExpansionId)}
-                          className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {isUndoing ? (
-                            <Loader2 className="w-3 h-3 animate-spin" />
-                          ) : (
-                            <Undo2 className="w-3 h-3" />
-                          )}
-                          Undo
-                        </button>
+                        {canUndo ? (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (
+                                window.confirm(
+                                  `Remove these ${count} competitor${count === 1 ? '' : 's'}? The market will recalculate from the snapshot taken before this batch landed.`
+                                )
+                              ) {
+                                handleUndoExpansion(id);
+                              }
+                            }}
+                            disabled={Boolean(undoingExpansionId)}
+                            className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-gray-200 dark:border-slate-700 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {isUndoing ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <Undo2 className="w-3 h-3" />
+                            )}
+                            Undo
+                          </button>
+                        ) : null}
                       </li>
                     );
                   })}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -81,6 +81,30 @@ function resolveTotalCompetitors(submission: any): number | null {
   return typeof len === 'number' && len > 0 ? len : null;
 }
 
+// Phase 5.4-O — small "+N new" pill shown next to the score when a
+// submission has unacknowledged BloomLens expansions (extension appended
+// competitors after the last vetting and the user hasn't opened the
+// detail page yet). Clears once the user navigates to the detail
+// (mark-as-read fires) OR clicks Recalculate. Green = growth/positive,
+// to distinguish it from the amber "Adjusted" pill.
+function NewExpansionBadge({
+  count,
+}: {
+  count: number;
+}) {
+  if (count <= 0) return null;
+  return (
+    <span
+      className="relative inline-flex items-center gap-1 shrink-0"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-emerald-400/20 text-emerald-700 dark:text-emerald-300 border border-emerald-400/40 whitespace-nowrap">
+        +{count} new
+      </span>
+    </span>
+  );
+}
+
 // Phase 2.7 — small "Adjusted" pill + info icon shown next to the score in the
 // submissions list when a submission has persisted competitor removals. Hover
 // OR tap on the icon reveals the original score and removed count. Tap support
@@ -1336,19 +1360,39 @@ export function Dashboard({ onTabChange }: { onTabChange?: (tab: string) => void
                                         {typeof submission.score === 'number' ? submission.score.toFixed(1) : '0'}%
                                       </span>
                                     </div>
-                                    {submission.adjustment && (
-                                      <div className="flex">
-                                        <AdjustedBadge
-                                          submissionId={submission.id}
-                                          adjustment={submission.adjustment}
-                                          originalSnapshot={submission.originalSnapshot}
-                                          isOpen={openAdjustedTooltip === submission.id}
-                                          onToggle={() =>
-                                            setOpenAdjustedTooltip(
-                                              openAdjustedTooltip === submission.id ? null : submission.id
-                                            )
-                                          }
-                                        />
+                                    {(submission.adjustment || submission.hasUnacknowledgedExpansion) && (
+                                      <div className="flex flex-wrap items-center gap-1">
+                                        {submission.adjustment && (
+                                          <AdjustedBadge
+                                            submissionId={submission.id}
+                                            adjustment={submission.adjustment}
+                                            originalSnapshot={submission.originalSnapshot}
+                                            isOpen={openAdjustedTooltip === submission.id}
+                                            onToggle={() =>
+                                              setOpenAdjustedTooltip(
+                                                openAdjustedTooltip === submission.id ? null : submission.id
+                                              )
+                                            }
+                                          />
+                                        )}
+                                        {submission.hasUnacknowledgedExpansion && (
+                                          <NewExpansionBadge
+                                            count={
+                                              Array.isArray(submission.lensExpansions)
+                                                ? submission.lensExpansions
+                                                    .filter((e: any) => !e?.acknowledged)
+                                                    .reduce(
+                                                      (sum: number, e: any) =>
+                                                        sum +
+                                                        (Array.isArray(e?.addedAsins)
+                                                          ? e.addedAsins.length
+                                                          : 0),
+                                                      0
+                                                    )
+                                                : 0
+                                            }
+                                          />
+                                        )}
                                       </div>
                                     )}
                                   </div>

--- a/src/lib/subscription/cap.ts
+++ b/src/lib/subscription/cap.ts
@@ -12,8 +12,12 @@ import { getTierState } from './state';
  * Pro / active trial → unlimited; returns { allowed: true, limit: null }.
  *
  * Core → counts usage since `current_period_start`:
- *   - 'vetting' counts rows in `public.submissions` (one row per vetting,
- *     refreshes don't create new rows so they don't count).
+ *   - 'vetting' counts rows in `public.submissions` PLUS rows in
+ *     `public.usage_events` where operation = 'vetting_recalc'. Each
+ *     recalc consumes the same Keepa quota + AI-summary spend as a
+ *     fresh vetting, so it consumes a slot. (Phase 5.4-O — closes the
+ *     "spam BloomLens append → recalc to extract Keepa value past the
+ *     cap" loophole.)
  *   - 'ssp' counts rows in `public.usage_events` where operation matches
  *     'ssp_generate%' (covers the main SSP gen + mechanical/deep variants).
  *
@@ -75,12 +79,20 @@ async function countUsage(
   const sinceIso = since.toISOString();
 
   if (action === 'vetting') {
-    const { count } = await supabase
-      .from('submissions')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', userId)
-      .gte('created_at', sinceIso);
-    return count ?? 0;
+    const [submissionsRes, recalcRes] = await Promise.all([
+      supabase
+        .from('submissions')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .gte('created_at', sinceIso),
+      supabase
+        .from('usage_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('operation', 'vetting_recalc')
+        .gte('created_at', sinceIso),
+    ]);
+    return (submissionsRes.count ?? 0) + (recalcRes.count ?? 0);
   }
 
   if (action === 'ssp') {

--- a/src/lib/vetting/deriveSummaryMetrics.ts
+++ b/src/lib/vetting/deriveSummaryMetrics.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared metric derivation for the vetting AI summary. Consumed by:
+ *   - POST /api/vetting/generate-summary (owner-triggered fresh-vetting flow)
+ *   - POST /api/submissions/[id]/lens-recalc (Phase 5.4-O recalc after Lens expansion)
+ *
+ * Both flows feed the same VettingSummaryMetrics shape into
+ * generateVettingSummary (Sonnet 4.6) so the briefing remains coherent
+ * across initial vetting and post-expansion recalcs.
+ */
+import { getVettingInsights } from '@/lib/vetting/insights';
+import { calculateScore, getCompetitorStrength } from '@/utils/scoring';
+import { type VettingSummaryMetrics } from '@/services/vettingSummary';
+
+export function deriveSummaryMetrics(submission: any): VettingSummaryMetrics {
+  const data = submission?.submission_data ?? {};
+  const competitors: any[] = data?.productData?.competitors ?? [];
+  const keepaResults: any[] = data?.keepaResults ?? [];
+  const distributions = data?.productData?.distributions ?? {};
+
+  const marketCap = competitors.reduce((sum, c) => sum + safeNum(c?.monthlyRevenue), 0);
+  const competitorCount = competitors.length;
+  const revenuePerCompetitor = competitorCount ? marketCap / competitorCount : 0;
+
+  const totalReviews = competitors.reduce((s, c) => s + safeNum(c?.reviews), 0);
+
+  const top5 = [...competitors]
+    .sort((a, b) => safeNum(b?.monthlySales) - safeNum(a?.monthlySales))
+    .slice(0, 5);
+
+  const avgTop5Reviews = top5.length
+    ? top5.reduce((s, c) => s + safeNum(c?.reviews), 0) / top5.length
+    : undefined;
+  const validRatings = top5.filter((c) => safeNum(c?.rating) > 0);
+  const avgTop5Rating = validRatings.length
+    ? validRatings.reduce((s, c) => s + safeNum(c?.rating), 0) / validRatings.length
+    : undefined;
+  const withAge = top5.filter((c) => c?.dateFirstAvailable);
+  const avgTop5AgeMonths = withAge.length
+    ? withAge.reduce((s, c) => s + ageMonths(c.dateFirstAvailable), 0) / withAge.length
+    : undefined;
+
+  const top5MarketSharePct = top5.reduce((s, c) => s + safeNum(c?.marketShare), 0);
+  const top5ReviewSharePct =
+    totalReviews > 0
+      ? (top5.reduce((s, c) => s + safeNum(c?.reviews), 0) / totalReviews) * 100
+      : undefined;
+
+  const bsrStabilities = keepaResults
+    .map((r) => r?.analysis?.bsr?.stability)
+    .filter((v): v is number => typeof v === 'number');
+  const priceStabilities = keepaResults
+    .map((r) => r?.analysis?.price?.stability)
+    .filter((v): v is number => typeof v === 'number');
+  const avgBsrStability = bsrStabilities.length
+    ? bsrStabilities.reduce((s, v) => s + v, 0) / bsrStabilities.length
+    : undefined;
+  const avgPriceStability = priceStabilities.length
+    ? priceStabilities.reduce((s, v) => s + v, 0) / priceStabilities.length
+    : undefined;
+
+  const strengthLabels = competitors
+    .map((c) => {
+      const score = parseFloat(String(calculateScore(c)));
+      if (!Number.isFinite(score)) return null;
+      return getCompetitorStrength(score).label;
+    })
+    .filter(Boolean) as Array<'STRONG' | 'DECENT' | 'WEAK'>;
+  const competitorStrengthMix = {
+    strong: strengthLabels.filter((l) => l === 'STRONG').length,
+    decent: strengthLabels.filter((l) => l === 'DECENT').length,
+    weak: strengthLabels.filter((l) => l === 'WEAK').length,
+  };
+
+  const fulfillment = distributions?.fulfillment ?? {};
+  const age = distributions?.age ?? {};
+
+  let priceRange: VettingSummaryMetrics['priceRange'];
+  let concentration: VettingSummaryMetrics['concentration'];
+  let redFlags: string[] | undefined;
+  let greenFlags: string[] | undefined;
+  try {
+    const { insights } = getVettingInsights({ competitors });
+    const p = insights.distributions?.price;
+    if (p) {
+      priceRange = { min: p.min, max: p.max, median: p.median };
+    }
+    concentration = {
+      top1Share: insights.concentration?.top1Share,
+      top3Share: insights.concentration?.top3Share,
+      top5Share: insights.concentration?.top5Share,
+    };
+    redFlags = insights.flags?.red?.map((f) => f.title).filter(Boolean);
+    greenFlags = insights.flags?.green?.map((f) => f.title).filter(Boolean);
+  } catch (e) {
+    console.warn('[deriveSummaryMetrics] getVettingInsights threw:', e);
+  }
+
+  const marketScoreObj = data?.marketScore ?? {};
+  const score = numberOr(marketScoreObj?.score, submission?.score, 0);
+  const status = stringOr(marketScoreObj?.status, submission?.status, 'Assessment Unavailable');
+
+  return {
+    score,
+    status,
+    competitorCount,
+    marketCapUsd: marketCap,
+    revenuePerCompetitor,
+    top5MarketSharePct,
+    top5ReviewSharePct,
+    concentration,
+    avgTop5Reviews,
+    avgTop5Rating,
+    avgTop5AgeMonths,
+    avgBsrStability,
+    avgPriceStability,
+    competitorStrengthMix,
+    fulfillmentSplit: {
+      fba: safeNum(fulfillment.fba),
+      fbm: safeNum(fulfillment.fbm),
+      amazon: safeNum(fulfillment.amazon),
+    },
+    ageCohorts: {
+      new: safeNum(age.new),
+      growing: safeNum(age.growing),
+      established: safeNum(age.established),
+      mature: safeNum(age.mature),
+    },
+    priceRange,
+    redFlags,
+    greenFlags,
+  };
+}
+
+function safeNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function numberOr(...candidates: unknown[]): number {
+  for (const c of candidates) {
+    const n = Number(c);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+}
+
+function stringOr(...candidates: unknown[]): string {
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim()) return c;
+  }
+  return '';
+}
+
+function ageMonths(dateFirstAvailable: string | undefined): number {
+  if (!dateFirstAvailable) return 0;
+  const d = new Date(dateFirstAvailable);
+  if (Number.isNaN(d.getTime())) return 0;
+  const diffMs = Date.now() - d.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24 * 30));
+}


### PR DESCRIPTION
## Summary

Ships the full Phase 5.4-O Market Expansions redesign to production. Replaces the closed PR #28 attempt and addresses all eight architectural issues from Dave's 2026-05-07 testing.

### What lands

- **PR #29 (PR A — backend + data model)** — `submission_data.lensExpansions[]` append-only log with per-batch `preExpansionSnapshot`. New `POST /api/submissions/[id]/lens-recalc` endpoint runs Keepa enrichment + scoring + AI summary regen server-side. New `POST /api/submissions/[id]/undo-expansion` for per-batch undo. Cap enforcement on both lens-recalc AND PATCH `action='adjust'` (closes the spam-append → recalc loophole). `/api/analyze` GET surfaces `lensExpansions` + `hasUnacknowledgedExpansion`.
- **PR #30 (PR B — UI + cleanup)** — Recalculate banner on `/vetting/[asin]` runs inline (no `/submission/[id]?triggerRecalc=1` redirect). "+N from BloomLens · X ago" emerald pill replaces the banner post-recalc. Click pill → expansion-history panel with per-entry Undo. "+N new" badge on `/vetting` list rows where `hasUnacknowledgedExpansion`. PDP-only matrix tooltips on Lens-sourced rows ("Captured from Amazon search results — fills in when you vet from a Helium 10 CSV"). Markets-popup picker now shows the renamed market label via `research_products.display_name` join. Legacy `__lens_pending_recalc` fallback so the banner works on data created before this lands.
- **NEW endpoint** `POST /api/submissions/[id]/mark-expansions-read` — clears the dashboard "+N new" badge when the user opens the detail page.
- **Shared helper** `src/lib/vetting/deriveSummaryMetrics.ts` — extracted from `/api/vetting/generate-summary` so both fresh-vetting and lens-recalc compute identical AI-briefing inputs.

### Acceptance criteria validated on Vercel preview

- [x] Banner appears on markets with pending Lens-added competitors (legacy fallback path)
- [x] Click Recalculate → spinner inline, no page bounce, score updates from 22.6% → 25.9%
- [x] AI briefing regenerates with new top-5 stats
- [x] Banner replaced by "+1 from BloomLens · just now" emerald pill
- [x] Expansion history panel shows the entry with score delta
- [x] Dashboard "+N new" badge clears on detail-page open

### Standing rules check

- No "Keepa" in user-facing copy. Helium 10 mentioned only in the documented PDP-tooltip exception (rule #6).
- No Stripe redirects (cap-modal renders inline via existing `CapReachedModal`).
- No round-number metrics. BSR-curve drives display unchanged.
- Targets `main` from `dev` (explicit promotion).

### Post-deploy followups

- Once production is on this code for a full deploy cycle, drop the legacy `__lens_pending_recalc` fallback in `/api/analyze` GET, `VettingDetailContent.tsx` banner condition, and the `isLegacyOnly` branch in `lens-recalc/route.ts`.
- BloomLens repo: score pill color coding in the markets picker (PASS/RISKY/FAIL → emerald/amber/red). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)