### PR TITLE
Phase 6 V9 sourcing polish: bug fixes + visual cleanup

### DIFF
--- a/src/components/Sourcing/SourcingDetailContent.tsx
+++ b/src/components/Sourcing/SourcingDetailContent.tsx
@@ -454,7 +454,13 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
   }
 
   return (
-    <div>
+    // Prevents a scroll-flicker loop when the page is short (e.g. no
+    // supplier quotes yet). Without this, scrolling to the bottom flips
+    // ProductHeader expanded ↔ compact, the document shrinks, the browser
+    // clamps scroll position, the sentinel re-intersects, and the toggle
+    // reverses — infinite oscillation. The buffer needs to exceed the
+    // header's expanded-vs-compact height delta (~130px).
+    <div className="min-h-[calc(100vh+12rem)]">
       {error && (
         <div className="mb-6 bg-red-600 text-white px-6 py-4 rounded-xl shadow-lg flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/src/components/Sourcing/SourcingDetailContent.tsx
+++ b/src/components/Sourcing/SourcingDetailContent.tsx
@@ -545,7 +545,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
         <div className="flex border-b border-slate-700/50 bg-slate-800/50 overflow-x-auto">
           {[
             { id: 'quotes', label: 'Supplier Quotes', icon: Users },
-            { id: 'profit', label: 'Profit Overview', icon: Calculator },
+            { id: 'profit', label: 'Profit Matrix', icon: Calculator },
             { id: 'placeOrder', label: 'Place Order', icon: ShoppingCart },
           ].map(({ id, label, icon: Icon }) => (
             <button

--- a/src/components/Sourcing/SourcingPageContent.tsx
+++ b/src/components/Sourcing/SourcingPageContent.tsx
@@ -554,23 +554,19 @@ export function SourcingPageContent() {
                         </div>
                       </td>
                       <td className="p-4">
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${statusBadge}`}>
+                        <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border ${statusBadge}`}>
                           {row.supplierStatus}
                         </span>
                       </td>
                       <td className="p-4">
-                        <div className={`inline-flex items-center px-2.5 py-1 rounded-md border ${marginTier.bgColor} ${marginTier.borderColor}`}>
-                          <span className={`text-sm font-semibold ${marginTier.textColor}`}>
-                            {marginTier.label}
-                          </span>
-                        </div>
+                        <span className={`text-sm font-semibold tabular-nums ${marginTier.textColor}`}>
+                          {marginTier.label}
+                        </span>
                       </td>
                       <td className="p-4">
-                        <div className={`inline-flex items-center px-2.5 py-1 rounded-md border ${roiTier.bgColor} ${roiTier.borderColor}`}>
-                          <span className={`text-sm font-semibold ${roiTier.textColor}`}>
-                            {roiTier.label}
-                          </span>
-                        </div>
+                        <span className={`text-sm font-semibold tabular-nums ${roiTier.textColor}`}>
+                          {roiTier.label}
+                        </span>
                       </td>
                     </tr>
                   );

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -9,7 +9,6 @@ import {
   TrendingUp,
   BarChart3,
   Trophy,
-  AlertTriangle,
   Eye,
   EyeOff,
   GripVertical,
@@ -1544,20 +1543,19 @@ export function ProfitCalculatorTab({
     
     let cellClasses = 'px-4 py-3 text-sm text-center relative';
     if (isMissing) {
-      // Two-level missing styling
-      if (hasRelative) {
-        // Attention missing: at least one supplier has data, this one is missing
-        cellClasses += ' bg-red-950/30 border border-dashed border-red-700/50 text-red-300';
-      } else {
-        // Neutral missing: all suppliers are missing this field
-        cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
-      }
+      // All missing cells get a calm slate treatment regardless of whether
+      // a peer supplier has the value. The peer-comparison row layout
+      // already conveys missing-ness; the previous "red attention" tint
+      // read as "error" and clashed with legitimate red used for negative
+      // metrics elsewhere.
+      cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
     } else if (rowDef.isProfitMetric) {
-      // Enhanced styling for profit metrics
+      // Profit-metric cells: only emphasize Best (emerald). Drop the
+      // matching red "isWorst" treatment — it produced a Christmas-tree
+      // effect across the Totals & Profit section that visually competed
+      // with the legitimate signal (which supplier wins).
       if (isBest) {
-        cellClasses += ' bg-emerald-900/30 border-2 border-emerald-500/70 text-emerald-300 font-semibold';
-      } else if (isWorst) {
-        cellClasses += ' bg-red-900/30 border-2 border-red-500/70 text-red-300 font-semibold';
+        cellClasses += ' bg-emerald-900/30 border border-emerald-500/40 text-emerald-300 font-semibold';
       } else {
         cellClasses += ' bg-slate-800/20 text-slate-200';
       }
@@ -1806,7 +1804,12 @@ export function ProfitCalculatorTab({
             {isMissing ? (
               <>
                 <span>—</span>
-                {hasRelative && <AlertCircle className="w-3 h-3 text-red-400" />}
+                {hasRelative && (
+                  <AlertCircle
+                    className="w-3 h-3 text-slate-500"
+                    aria-label="Other suppliers have a value here"
+                  />
+                )}
               </>
             ) : (
               <>
@@ -1823,9 +1826,6 @@ export function ProfitCalculatorTab({
                 <Trophy className="w-4 h-4 text-emerald-400" aria-label="Best value" />
                 <span className="text-xs text-emerald-400 font-medium">Best</span>
               </div>
-            )}
-            {isWorst && rowDef.isProfitMetric && (
-              <AlertTriangle className="w-4 h-4 text-red-400" aria-label="Worst value" />
             )}
           </div>
         )}

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -1543,12 +1543,18 @@ export function ProfitCalculatorTab({
     
     let cellClasses = 'px-4 py-3 text-sm text-center relative';
     if (isMissing) {
-      // All missing cells get a calm slate treatment regardless of whether
-      // a peer supplier has the value. The peer-comparison row layout
-      // already conveys missing-ness; the previous "red attention" tint
-      // read as "error" and clashed with legitimate red used for negative
-      // metrics elsewhere.
-      cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
+      // Two-tier missing styling:
+      // - Peer-has-data (hasRelative): amber tint + dashed amber border —
+      //   warning, not error. Tells the user "fill this in to compare."
+      // - Nobody has data (hasAbsolute): neutral slate — non-judgemental.
+      // The previous red treatment read as "error"; amber reads as
+      // "incomplete" and matches the empty-input convention elsewhere
+      // in the form.
+      if (hasRelative) {
+        cellClasses += ' bg-amber-500/5 border border-dashed border-amber-500/40 text-slate-300';
+      } else {
+        cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
+      }
     } else if (rowDef.isProfitMetric) {
       // Profit-metric cells: only emphasize Best (emerald). Drop the
       // matching red "isWorst" treatment — it produced a Christmas-tree
@@ -1806,7 +1812,7 @@ export function ProfitCalculatorTab({
                 <span>—</span>
                 {hasRelative && (
                   <AlertCircle
-                    className="w-3 h-3 text-slate-500"
+                    className="w-3 h-3 text-amber-400"
                     aria-label="Other suppliers have a value here"
                   />
                 )}

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -750,13 +750,7 @@ export function ProfitCalculatorTab({
           ? toNumberOrNull(quote.costPerUnitMediumTerm)
           : tierUsed === 'long'
           ? toNumberOrNull(quote.costPerUnitLongTerm)
-          : (() => {
-              const effectiveIncoterms = quote.incotermsAgreed || quote.incoterms || 'DDP';
-              if (effectiveIncoterms === 'DDP' && quote.ddpPrice && quote.ddpPrice > 0) {
-                return toNumberOrNull(quote.ddpPrice);
-              }
-              return toNumberOrNull(quote.costPerUnitShortTerm ?? quote.exwUnitCost);
-            })();
+          : toNumberOrNull(quote.costPerUnitShortTerm ?? quote.exwUnitCost);
         // DEV: Debug logging
         if (process.env.NODE_ENV === 'development' && quote.id === 'quote_1767475901219_0') {
           console.log('[getMatrixCellValue] costPerUnit row:', {
@@ -824,7 +818,10 @@ export function ProfitCalculatorTab({
         if (combined > 0) {
           return { value: combined };
         }
-        const basic = toNumberOrNull(quote.freightDutyCost) ?? 0;
+        const effectiveIncotermsForBasic = quote.incotermsAgreed || quote.incoterms || 'DDP';
+        const basic = effectiveIncotermsForBasic === 'DDP'
+          ? toNumberOrNull(quote.ddpPrice) ?? 0
+          : toNumberOrNull(quote.freightDutyCost) ?? 0;
         return {
           value: basic > 0 ? basic : null,
           missingReason: basic === 0 ? 'Freight/Duty Cost' : undefined

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -1220,7 +1220,15 @@ export function ProfitCalculatorTab({
       }
       return '';
     }
-    
+
+    // Mirror the matrix-cell read fallback so the editor opens showing
+    // the same value the user was looking at. Without this, users who
+    // never touched the Advanced incotermsAgreed override see an empty
+    // editor, click EXW, and end up clearing the override silently.
+    if (rowKey === 'incotermsAgreed') {
+      return value ?? quote.incoterms ?? '';
+    }
+
     return value;
   };
   
@@ -1300,6 +1308,17 @@ export function ProfitCalculatorTab({
     // Special handling for freightDutyCombined
     if (rowKey === 'freightDutyCombined') {
       handleUpdateQuote(quoteId, { freightDutyCost: processedValue });
+      return;
+    }
+
+    // Editing incoterms from the Profit Overview should flip the value
+    // everywhere — write to both the Basic field and the Advanced override
+    // so the Supplier Quotes dropdown reflects the change too.
+    if (rowKey === 'incotermsAgreed') {
+      handleUpdateQuote(quoteId, {
+        incoterms: processedValue,
+        incotermsAgreed: processedValue,
+      });
       return;
     }
     

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -21,7 +21,7 @@ interface CircularGaugeProps {
 }
 
 function CircularGauge({ percent, status, colorClass, message, nextActions, onClick }: CircularGaugeProps) {
-  const size = 170; // Diameter in pixels — sized to match the height of the L/R column stacks.
+  const size = 200; // Diameter in pixels — sized to match the height of the L/R column 3-stacks.
   const strokeWidth = 10;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -108,7 +108,7 @@ interface PlaceOrderGaugeProps {
 }
 
 function PlaceOrderGauge({ percent, status, colorClass, message, totalRequired, confirmedRequired }: PlaceOrderGaugeProps) {
-  const size = 170; // Diameter in pixels — matches CircularGauge so the hub looks identical across tabs.
+  const size = 200; // Diameter in pixels — matches CircularGauge so the hub looks identical across tabs.
   const strokeWidth = 10;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -587,9 +587,9 @@ export function SourcingHub({
       <div className="absolute top-0 right-0 w-64 h-64 bg-purple-500/5 rounded-full blur-3xl"></div>
       <div className="absolute bottom-0 left-0 w-48 h-48 bg-indigo-500/5 rounded-full blur-3xl"></div>
       
-      {/* Header */}
-      <div className="flex items-start justify-between mb-4 relative z-10">
-        <div className="flex items-center gap-3">
+      {/* Header — title on the left, gauge label centered above the gauge column */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4 relative z-10 items-center">
+        <div className="flex items-center gap-3 lg:col-span-1">
           <div className="w-10 h-10 bg-gradient-to-br from-purple-500 to-indigo-500 rounded-xl flex items-center justify-center shadow-lg shadow-purple-500/50">
             <ShoppingCart className="w-5 h-5 text-white" strokeWidth={2.5} fill="white" />
           </div>
@@ -600,6 +600,13 @@ export function SourcingHub({
             <p className="text-slate-300 text-sm mt-1 font-medium">Set assumptions and track order readiness</p>
           </div>
         </div>
+        {/* Gauge label aligns with gauge column below; sits on the same row as the subtitle. */}
+        <div className="hidden lg:flex justify-center">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+            {activeTab === 'placeOrder' ? 'Order Readiness' : 'Calculation Accuracy'}
+          </span>
+        </div>
+        <div className="hidden lg:block" />
       </div>
       
       {/* Compact 3-Column Layout */}
@@ -678,11 +685,14 @@ export function SourcingHub({
           </div>
         </div>
 
-        {/* Center Column: Circular Gauge - Conditional based on active tab */}
-        <div className="flex flex-col items-center justify-center">
-          {activeTab === 'placeOrder' ? (
-            <>
-              <label className="block text-xs font-semibold text-slate-300 mb-2 tracking-wide uppercase">Order Readiness</label>
+        {/* Center Column: Circular Gauge — label is now in the hub header above. */}
+        <div className="flex items-center justify-center">
+          {/* On mobile (lg-), the header collapses; show the label inline above the gauge. */}
+          <div className="flex flex-col items-center w-full">
+            <span className="lg:hidden text-xs font-semibold uppercase tracking-wide text-slate-300 mb-2">
+              {activeTab === 'placeOrder' ? 'Order Readiness' : 'Calculation Accuracy'}
+            </span>
+            {activeTab === 'placeOrder' ? (
               <PlaceOrderGauge
                 percent={placeOrderProgress.percent}
                 status={placeOrderProgress.status}
@@ -691,10 +701,7 @@ export function SourcingHub({
                 totalRequired={placeOrderProgress.totalRequired}
                 confirmedRequired={placeOrderProgress.confirmedRequired}
               />
-            </>
-          ) : (
-            <>
-              <label className="block text-xs font-semibold text-slate-300 mb-2 tracking-wide uppercase">Calculation Accuracy</label>
+            ) : (
               <CircularGauge
                 percent={orderReadiness.percent}
                 status={orderReadiness.status}
@@ -703,8 +710,8 @@ export function SourcingHub({
                 nextActions={orderReadiness.nextActions}
                 onClick={handleReadinessClick}
               />
-            </>
-          )}
+            )}
+          </div>
         </div>
 
         {/* Right Column: Top Supplier Snapshot */}

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -626,9 +626,21 @@ export function SourcingHub({
 
           {/* Target Sales Price */}
           <div className="px-3 py-2.5 bg-slate-800/40 border border-emerald-500/20 rounded-lg">
-            <div className="text-xs font-semibold text-slate-400 mb-1.5 uppercase tracking-wide flex items-center gap-1.5">
-              <DollarSign className="w-3 h-3" />
-              Target Sales Price
+            <div className="text-xs font-semibold text-slate-400 mb-1.5 uppercase tracking-wide flex items-center justify-between gap-1.5">
+              <span className="flex items-center gap-1.5">
+                <DollarSign className="w-3 h-3" />
+                Target Sales Price
+              </span>
+              {hub.targetSalesPrice !== null && originalPrice !== null && hub.targetSalesPrice !== originalPrice && (
+                <button
+                  type="button"
+                  onClick={() => handleTargetSalesPriceChange(null)}
+                  className="text-[10px] font-medium text-emerald-400 hover:text-emerald-300 normal-case tracking-normal transition-colors"
+                  title={`Reset to Offering price (${formatCurrency(originalPrice)})`}
+                >
+                  Reset to Offering
+                </button>
+              )}
             </div>
             <div className="relative">
               <span className="absolute left-0 top-1/2 -translate-y-1/2 text-emerald-400 font-semibold text-sm z-10">$</span>
@@ -662,6 +674,13 @@ export function SourcingHub({
               />
               <span className="absolute right-0 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-xs z-10">USD</span>
             </div>
+            {originalPrice !== null && (
+              <div className="mt-1 text-[10px] text-slate-500">
+                {hub.targetSalesPrice === null || hub.targetSalesPrice === originalPrice
+                  ? `From Offering`
+                  : `Overridden (Offering: ${formatCurrency(originalPrice)})`}
+              </div>
+            )}
           </div>
 
           {/* Product Category */}

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -21,8 +21,8 @@ interface CircularGaugeProps {
 }
 
 function CircularGauge({ percent, status, colorClass, message, nextActions, onClick }: CircularGaugeProps) {
-  const size = 200; // Diameter in pixels (responsive: scales down on smaller screens)
-  const strokeWidth = 12;
+  const size = 170; // Diameter in pixels — sized to match the height of the L/R column stacks.
+  const strokeWidth = 10;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (percent / 100) * circumference;
@@ -83,13 +83,12 @@ function CircularGauge({ percent, status, colorClass, message, nextActions, onCl
           />
         </svg>
         {/* Center content */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          {/* Rocket icon */}
-          <Rocket className={`w-8 h-8 ${colorClass.text} mb-2`} strokeWidth={2} />
-          <div className={`text-4xl font-bold ${colorClass.text} mb-1`}>
+        <div className="absolute inset-0 flex flex-col items-center justify-center px-3">
+          <Rocket className={`w-6 h-6 ${colorClass.text} mb-0.5`} strokeWidth={2} />
+          <div className={`text-3xl font-bold leading-none ${colorClass.text}`}>
             {percent}%
           </div>
-          <div className={`text-xs font-semibold uppercase tracking-wider ${colorClass.text}`}>
+          <div className={`mt-1 text-[10px] font-semibold uppercase tracking-wide text-center ${colorClass.text}`}>
             {status}
           </div>
         </div>
@@ -109,8 +108,8 @@ interface PlaceOrderGaugeProps {
 }
 
 function PlaceOrderGauge({ percent, status, colorClass, message, totalRequired, confirmedRequired }: PlaceOrderGaugeProps) {
-  const size = 200; // Diameter in pixels (responsive: scales down on smaller screens)
-  const strokeWidth = 12;
+  const size = 170; // Diameter in pixels — matches CircularGauge so the hub looks identical across tabs.
+  const strokeWidth = 10;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (percent / 100) * circumference;
@@ -159,16 +158,15 @@ function PlaceOrderGauge({ percent, status, colorClass, message, totalRequired, 
           />
         </svg>
         {/* Center content */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          {/* CheckSquare icon */}
-          <CheckSquare className={`w-8 h-8 ${colorClass.text} mb-2`} strokeWidth={2} />
-          <div className={`text-4xl font-bold ${colorClass.text} mb-1`}>
+        <div className="absolute inset-0 flex flex-col items-center justify-center px-3">
+          <CheckSquare className={`w-6 h-6 ${colorClass.text} mb-0.5`} strokeWidth={2} />
+          <div className={`text-3xl font-bold leading-none ${colorClass.text}`}>
             {percent}%
           </div>
-          <div className={`text-xs font-semibold uppercase tracking-wider ${colorClass.text}`}>
+          <div className={`mt-1 text-[10px] font-semibold uppercase tracking-wide text-center ${colorClass.text}`}>
             {status}
           </div>
-          <div className="text-xs text-slate-400 mt-2">
+          <div className="mt-0.5 text-[10px] text-slate-400">
             {confirmedRequired}/{totalRequired} Required
           </div>
         </div>
@@ -684,7 +682,7 @@ export function SourcingHub({
         <div className="flex flex-col items-center justify-center">
           {activeTab === 'placeOrder' ? (
             <>
-              <label className="block text-sm font-bold text-slate-300 mb-4 tracking-tight">Order Readiness</label>
+              <label className="block text-xs font-semibold text-slate-300 mb-2 tracking-wide uppercase">Order Readiness</label>
               <PlaceOrderGauge
                 percent={placeOrderProgress.percent}
                 status={placeOrderProgress.status}
@@ -696,7 +694,7 @@ export function SourcingHub({
             </>
           ) : (
             <>
-              <label className="block text-sm font-bold text-slate-300 mb-4 tracking-tight">Calculation Accuracy</label>
+              <label className="block text-xs font-semibold text-slate-300 mb-2 tracking-wide uppercase">Calculation Accuracy</label>
               <CircularGauge
                 percent={orderReadiness.percent}
                 status={orderReadiness.status}

--- a/src/components/Sourcing/tabs/SourcingSandbox.tsx
+++ b/src/components/Sourcing/tabs/SourcingSandbox.tsx
@@ -243,21 +243,21 @@ export function SourcingSandbox() {
   const shippingFieldLabel = isDDP ? 'DDP Shipping Price (USD)' : 'Estimated Freight/Duty (USD)';
 
   return (
-    <div className="space-y-6 p-6">
+    <div className="space-y-4 p-6">
       {/* Header */}
-      <div className="mb-6">
+      <div className="mb-4">
         <h2 className="text-2xl font-bold text-white mb-2">Sourcing Sandbox</h2>
         <p className="text-sm text-slate-400">
           Sourcing Sandbox is for quick what-if calculations. Changes aren't saved - so play around in here and have some fun.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {/* Left Column: Inputs */}
-        <div className="space-y-6">
+        <div className="space-y-4">
           {/* Target Sales Price + Product Category */}
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+            <h3 className="text-base font-semibold text-white mb-3 flex items-center gap-2">
               <TrendingUp className="w-5 h-5 text-emerald-400" />
               Target Sales Price + Product Category
             </h3>
@@ -302,8 +302,8 @@ export function SourcingSandbox() {
           </div>
 
           {/* Pricing / Terms */}
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+            <h3 className="text-base font-semibold text-white mb-3 flex items-center gap-2">
               <DollarSign className="w-5 h-5 text-emerald-400" />
               Pricing / Terms
             </h3>
@@ -377,8 +377,8 @@ export function SourcingSandbox() {
           </div>
 
           {/* Single Unit Package */}
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+            <h3 className="text-base font-semibold text-white mb-3 flex items-center gap-2">
               <Package className="w-5 h-5 text-blue-400" />
               Single Unit Package
             </h3>
@@ -439,8 +439,8 @@ export function SourcingSandbox() {
           </div>
 
           {/* FBA Fees */}
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+            <h3 className="text-base font-semibold text-white mb-3 flex items-center gap-2">
               <Calculator className="w-5 h-5 text-purple-400" />
               FBA Fees
             </h3>
@@ -487,30 +487,30 @@ export function SourcingSandbox() {
         </div>
 
         {/* Right Column: KPI Output Cards */}
-        <div className="space-y-6">
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-6">
-            <h3 className="text-lg font-semibold text-white mb-4">Key Performance Indicators</h3>
-            <div className="grid grid-cols-1 gap-4">
+        <div className="space-y-4">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+            <h3 className="text-base font-semibold text-white mb-3">Key Performance Indicators</h3>
+            <div className="grid grid-cols-1 gap-2">
               {/* ROI */}
-              <div className={`rounded-lg p-4 border ${roiTier.bgColor} ${roiTier.borderColor}`}>
-                <div className="text-sm font-medium text-slate-400 mb-1">ROI</div>
-                <div className={`text-2xl font-bold ${roiTier.textColor}`}>
+              <div className={`rounded-lg px-4 py-2.5 border ${roiTier.bgColor} ${roiTier.borderColor}`}>
+                <div className="text-xs font-medium text-slate-400 mb-0.5">ROI</div>
+                <div className={`text-xl font-bold ${roiTier.textColor}`}>
                   {roiTier.label}
                 </div>
               </div>
 
               {/* Margin */}
-              <div className={`rounded-lg p-4 border ${marginTier.bgColor} ${marginTier.borderColor}`}>
-                <div className="text-sm font-medium text-slate-400 mb-1">Margin</div>
-                <div className={`text-2xl font-bold ${marginTier.textColor}`}>
+              <div className={`rounded-lg px-4 py-2.5 border ${marginTier.bgColor} ${marginTier.borderColor}`}>
+                <div className="text-xs font-medium text-slate-400 mb-0.5">Margin</div>
+                <div className={`text-xl font-bold ${marginTier.textColor}`}>
                   {marginTier.label}
                 </div>
               </div>
 
               {/* Profit/Unit */}
-              <div className="bg-slate-900/50 rounded-lg p-4 border border-emerald-500/30">
-                <div className="text-sm font-medium text-slate-400 mb-1">Profit/Unit</div>
-                <div className="text-2xl font-bold text-emerald-400">
+              <div className="bg-slate-900/50 rounded-lg px-4 py-2.5 border border-emerald-500/30">
+                <div className="text-xs font-medium text-slate-400 mb-0.5">Profit/Unit</div>
+                <div className="text-xl font-bold text-emerald-400">
                   {kpis.profitPerUnit !== null && !isNaN(kpis.profitPerUnit)
                     ? formatCurrency(kpis.profitPerUnit)
                     : '—'}
@@ -518,17 +518,17 @@ export function SourcingSandbox() {
               </div>
 
               {/* Total Order Investment */}
-              <div className={`rounded-lg p-4 border ${investmentTier.bgColor} ${investmentTier.borderColor}`}>
-                <div className="text-sm font-medium text-slate-400 mb-1">Total Order Investment</div>
-                <div className={`text-2xl font-bold ${investmentTier.textColor}`}>
+              <div className={`rounded-lg px-4 py-2.5 border ${investmentTier.bgColor} ${investmentTier.borderColor}`}>
+                <div className="text-xs font-medium text-slate-400 mb-0.5">Total Order Investment</div>
+                <div className={`text-xl font-bold ${investmentTier.textColor}`}>
                   {investmentTier.label}
                 </div>
               </div>
 
               {/* Total Gross Profit */}
-              <div className="bg-slate-900/50 rounded-lg p-4 border border-emerald-500/30">
-                <div className="text-sm font-medium text-slate-400 mb-1">Total Gross Profit</div>
-                <div className="text-2xl font-bold text-emerald-400">
+              <div className="bg-slate-900/50 rounded-lg px-4 py-2.5 border border-emerald-500/30">
+                <div className="text-xs font-medium text-slate-400 mb-0.5">Total Gross Profit</div>
+                <div className="text-xl font-bold text-emerald-400">
                   {kpis.totalGrossProfit !== null && !isNaN(kpis.totalGrossProfit)
                     ? formatCurrency(kpis.totalGrossProfit)
                     : '—'}

--- a/src/components/Sourcing/tabs/SourcingSandbox.tsx
+++ b/src/components/Sourcing/tabs/SourcingSandbox.tsx
@@ -486,13 +486,13 @@ export function SourcingSandbox() {
           </div>
         </div>
 
-        {/* Right Column: KPI Output Cards */}
-        <div className="space-y-4">
-          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4">
+        {/* Right Column: KPI Output Cards — stretches to match left column height */}
+        <div className="h-full">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-4 h-full flex flex-col">
             <h3 className="text-base font-semibold text-white mb-3">Key Performance Indicators</h3>
-            <div className="grid grid-cols-1 gap-2">
+            <div className="flex flex-col gap-2 flex-1">
               {/* ROI */}
-              <div className={`rounded-lg px-4 py-2.5 border ${roiTier.bgColor} ${roiTier.borderColor}`}>
+              <div className={`rounded-lg px-4 py-3 border flex flex-col justify-center flex-1 min-h-[60px] ${roiTier.bgColor} ${roiTier.borderColor}`}>
                 <div className="text-xs font-medium text-slate-400 mb-0.5">ROI</div>
                 <div className={`text-xl font-bold ${roiTier.textColor}`}>
                   {roiTier.label}
@@ -500,7 +500,7 @@ export function SourcingSandbox() {
               </div>
 
               {/* Margin */}
-              <div className={`rounded-lg px-4 py-2.5 border ${marginTier.bgColor} ${marginTier.borderColor}`}>
+              <div className={`rounded-lg px-4 py-3 border flex flex-col justify-center flex-1 min-h-[60px] ${marginTier.bgColor} ${marginTier.borderColor}`}>
                 <div className="text-xs font-medium text-slate-400 mb-0.5">Margin</div>
                 <div className={`text-xl font-bold ${marginTier.textColor}`}>
                   {marginTier.label}
@@ -508,7 +508,7 @@ export function SourcingSandbox() {
               </div>
 
               {/* Profit/Unit */}
-              <div className="bg-slate-900/50 rounded-lg px-4 py-2.5 border border-emerald-500/30">
+              <div className="bg-slate-900/50 rounded-lg px-4 py-3 border border-emerald-500/30 flex flex-col justify-center flex-1 min-h-[60px]">
                 <div className="text-xs font-medium text-slate-400 mb-0.5">Profit/Unit</div>
                 <div className="text-xl font-bold text-emerald-400">
                   {kpis.profitPerUnit !== null && !isNaN(kpis.profitPerUnit)
@@ -518,7 +518,7 @@ export function SourcingSandbox() {
               </div>
 
               {/* Total Order Investment */}
-              <div className={`rounded-lg px-4 py-2.5 border ${investmentTier.bgColor} ${investmentTier.borderColor}`}>
+              <div className={`rounded-lg px-4 py-3 border flex flex-col justify-center flex-1 min-h-[60px] ${investmentTier.bgColor} ${investmentTier.borderColor}`}>
                 <div className="text-xs font-medium text-slate-400 mb-0.5">Total Order Investment</div>
                 <div className={`text-xl font-bold ${investmentTier.textColor}`}>
                   {investmentTier.label}
@@ -526,7 +526,7 @@ export function SourcingSandbox() {
               </div>
 
               {/* Total Gross Profit */}
-              <div className="bg-slate-900/50 rounded-lg px-4 py-2.5 border border-emerald-500/30">
+              <div className="bg-slate-900/50 rounded-lg px-4 py-3 border border-emerald-500/30 flex flex-col justify-center flex-1 min-h-[60px]">
                 <div className="text-xs font-medium text-slate-400 mb-0.5">Total Gross Profit</div>
                 <div className="text-xl font-bold text-emerald-400">
                   {kpis.totalGrossProfit !== null && !isNaN(kpis.totalGrossProfit)

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -1243,9 +1243,15 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
     setEditingUrls(prev => ({ ...prev, [quoteId]: !prev[quoteId] }));
   };
 
-  // Toggle Supplier Info expanded state
+  // Toggle Supplier Info expanded state.
+  // Reads the *effective* current state (default = expanded) before inverting,
+  // otherwise the first click on a default-expanded section is a no-op
+  // (because !undefined === true, writing the same state back).
   const toggleSupplierInfo = (quoteId: string) => {
-    setSupplierInfoExpanded(prev => ({ ...prev, [quoteId]: !prev[quoteId] }));
+    setSupplierInfoExpanded(prev => ({
+      ...prev,
+      [quoteId]: !(prev[quoteId] ?? true),
+    }));
   };
 
   const isSupplierInfoExpanded = (quoteId: string): boolean => {
@@ -1602,14 +1608,18 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <button
                           type="button"
                           onClick={() => toggleSupplierInfo(quote.id)}
-                          className="w-full flex items-center justify-between p-4 hover:bg-slate-800/30 transition-colors"
+                          className="w-full flex items-center justify-between p-4 hover:bg-slate-800/40 transition-colors group"
+                          aria-expanded={isSupplierInfoExpanded(quote.id)}
                         >
                           <h4 className="text-sm font-semibold text-slate-300">Supplier Info</h4>
-                          {isSupplierInfoExpanded(quote.id) ? (
-                            <ChevronUp className="w-4 h-4 text-slate-400" />
-                          ) : (
-                            <ChevronDown className="w-4 h-4 text-slate-400" />
-                          )}
+                          <span className="flex items-center gap-1.5 text-xs font-medium text-slate-400 group-hover:text-slate-200 transition-colors">
+                            {isSupplierInfoExpanded(quote.id) ? 'Hide' : 'Show'}
+                            {isSupplierInfoExpanded(quote.id) ? (
+                              <ChevronUp className="w-4 h-4" />
+                            ) : (
+                              <ChevronDown className="w-4 h-4" />
+                            )}
+                          </span>
                         </button>
                         {isSupplierInfoExpanded(quote.id) ? (
                           <div className="px-4 pb-4 space-y-4">

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -246,7 +246,7 @@ export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: Sourcin
   // let costPrice: number;
   // let moq: number;
   // const estimatedShipping = effectiveIncoterms === 'DDP' ? quote.ddpPrice ?? 0 : quote.freightDutyCost ?? 0;
-  const costPrice = quote.costPerUnitShortTerm ?? quote.costPerUnitMediumTerm ?? quote.costPerUnitLongTerm ?? 0;
+  const costPrice = quote.costPerUnitShortTerm ?? quote.exwUnitCost ?? quote.costPerUnitMediumTerm ?? quote.costPerUnitLongTerm ?? 0;
   const moq = quote.moqShortTerm ?? quote.moqMediumTerm ?? quote.moqLongTerm ?? quote.moq ?? 0;
 
   // if (tier === 'medium' && quote.costPerUnitMediumTerm !== null && quote.costPerUnitMediumTerm !== undefined) {
@@ -293,18 +293,16 @@ export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: Sourcin
   
   // Calculate profit per unit: Target Sales Price - Cost Price - Shipping Cost - FBA Fee - Referral Fee
   const profitPerUnit = targetSalesPrice - costPrice - shippingCost - fbaFeePerUnit - referralFee - aditionalCosts;
-  // For advanced calculations, still use landed unit cost (for display purposes)
-  const freightPerUnit = quote.freightCostPerUnit ?? quote.ddpShippingPerUnit ?? 0;
   const packagingPerUnit = quote.packagingCostPerUnit ?? quote.packagingPerUnit ?? 0;
   const inspectionPerUnit = quote.inspectionCostPerUnit ?? quote.inspectionPerUnit ?? 0;
   const sspPerUnit = quote.sspCostPerUnit ?? 0;
   const labellingPerUnit = quote.labellingCostPerUnit ?? 0;
-  const dutyPerUnit = quote.dutyCostPerUnit ?? 0;
-  const tariffPerUnit = quote.tariffCostPerUnit ?? 0;
   const miscPerUnit = quote.miscPerUnit ?? 0;
-  
-  const landedUnitCost = costPrice + freightPerUnit + packagingPerUnit + inspectionPerUnit + 
-                         sspPerUnit + labellingPerUnit + dutyPerUnit + tariffPerUnit + miscPerUnit;
+
+  // shippingCost (above) already resolves Advanced freight/duty/tariff with Basic ddpPrice/freightDutyCost fallback,
+  // so reusing it here keeps landedUnitCost consistent with profitPerUnit's math.
+  const landedUnitCost = costPrice + shippingCost + packagingPerUnit + inspectionPerUnit +
+                         sspPerUnit + labellingPerUnit + miscPerUnit;
   
   const roiPct = landedUnitCost > 0 ? (profitPerUnit / landedUnitCost) * 100 : null;
   const marginPct = targetSalesPrice > 0 ? (profitPerUnit / targetSalesPrice) * 100 : null;

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -1449,8 +1449,10 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
             return (
             <div
               key={quote.id}
-              className={`border-b border-slate-700/50 hover:bg-slate-800/40 transition-colors ${
-                index % 2 === 0 ? 'bg-slate-500/20' : 'bg-slate-900/20'
+              className={`border-b-2 border-slate-700/60 hover:bg-slate-800/50 transition-colors border-l-4 ${
+                index % 2 === 0
+                  ? 'bg-slate-800/40 border-l-blue-500/40'
+                  : 'bg-slate-900/40 border-l-purple-500/40'
               }`}
             >
               {/* Table Row */}
@@ -1884,7 +1886,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Pricing / Terms */}
                       <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Pricing / Terms</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Pricing / Terms</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">
@@ -1999,7 +2001,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Single Unit Package */}
                       <div className="bg-slate-900/30 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Single Unit Package</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Single Unit Package</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">
@@ -2074,7 +2076,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* FBA Fees */}
                       <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">FBA Fees</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">FBA Fees</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1 flex items-center gap-2">
@@ -2151,7 +2153,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Single Unit Package (Advanced) - Section 1 */}
                       <div className="bg-slate-900/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Single Unit Package</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Single Unit Package</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">
@@ -2226,7 +2228,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* FBA Fees (Advanced) - Section 2 */}
                       <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">FBA Fees</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">FBA Fees</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1 flex items-center gap-2">
@@ -2404,7 +2406,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Additional Costs - Section 4 */}
                       <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Additional Costs</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Additional Costs</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">
@@ -2481,7 +2483,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Production / Terms - Section 5 */}
                       <div className="bg-slate-900/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Production Terms</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Production Terms</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">Lead Time (Days)</label>
@@ -2520,7 +2522,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Carton / Logistics - Section 6 */}
                       <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Carton / Logistics</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Carton / Logistics</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">
@@ -2607,7 +2609,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Freight/Compliance Costs - Section 7 */}
                       <div className="bg-slate-900/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Freight & Compliance</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Freight & Compliance</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">Incoterms Agreed</label>
@@ -2842,7 +2844,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
                       {/* Sampling - Section 9 */}
                       <div className="bg-slate-900/20 rounded-lg p-3 border border-slate-700/30">
-                        <h4 className="text-sm font-semibold text-slate-300 mb-2">Sampling</h4>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Sampling</h4>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1">Sample Ordered</label>

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -1142,12 +1142,19 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
     return false;
   };
 
-  // Mandatory field styling - subtle but noticeable
+  // Mandatory field styling - amber tint when empty so the user can see
+  // at a glance which required fields still need data.
   const getRequiredFieldClass = (isFilled: boolean): string => {
     if (isFilled) {
       return 'border-slate-700/50 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20';
     }
     return 'border-amber-500/30 bg-amber-500/5 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20';
+  };
+
+  // Optional/nice-to-have field styling - neutral whether filled or empty,
+  // so they don't compete visually with mandatory fields.
+  const getOptionalFieldClass = (): string => {
+    return 'border-slate-700/50 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20';
   };
 
   // Currency input handler - format on blur, show raw on focus
@@ -1696,7 +1703,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                                           }
                                         }}
                                         placeholder="www.alibaba.com/... or https://..."
-                                        className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getRequiredFieldClass(isFieldFilled(url))}`}
+                                        className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getOptionalFieldClass()}`}
                                         autoFocus
                                       />
                                     </div>
@@ -1880,7 +1887,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <h4 className="text-sm font-semibold text-slate-300 mb-2">Pricing / Terms</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'costPerUnitShortTerm', quote.costPerUnitShortTerm ?? quote.exwUnitCost)}
@@ -1901,7 +1910,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">MOQ</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              MOQ<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               value={quote.moqShortTerm ?? quote.moq ?? ''}
@@ -1921,7 +1932,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Incoterms</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Incoterms<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <select
                               value={quote.incoterms || 'DDP'}
                               onChange={(e) => {
@@ -1957,7 +1970,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                                       handleUpdateQuote(quote.id, { ddpPrice: val });
                                     })}
                                     placeholder="$0.00"
-                                    className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getRequiredFieldClass(isFieldFilled(quote.ddpPrice))}`}
+                                    className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getOptionalFieldClass()}`}
                                   />
                                 </div>
                               );
@@ -1975,7 +1988,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                                       handleUpdateQuote(quote.id, { freightDutyCost: val });
                                     })}
                                     placeholder="$0.00"
-                                    className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getRequiredFieldClass(isFieldFilled(quote.freightDutyCost))}`}
+                                    className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getOptionalFieldClass()}`}
                                   />
                                 </div>
                               );
@@ -1989,7 +2002,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <h4 className="text-sm font-semibold text-slate-300 mb-2">Single Unit Package</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Length (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Length (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2004,7 +2019,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Width (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Width (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2019,7 +2036,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Height (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Height (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2034,7 +2053,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Weight (kg)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Weight (kg)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2057,7 +2078,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1 flex items-center gap-2">
-                              FBA Fee
+                              <span>
+                                FBA Fee<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                              </span>
                               <a
                                 href="https://sellercentral.amazon.com/fba/profitabilitycalculator/index.html"
                                 target="_blank"
@@ -2131,7 +2154,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <h4 className="text-sm font-semibold text-slate-300 mb-2">Single Unit Package</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Length (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Length (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2146,7 +2171,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Width (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Width (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2161,7 +2188,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Height (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Height (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2176,7 +2205,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Weight (kg)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Weight (kg)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2199,7 +2230,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                           <div className={getFieldContainerClass()}>
                             <label className="block text-xs font-medium text-slate-400 mb-1 flex items-center gap-2">
-                              FBA Fee
+                              <span>
+                                FBA Fee<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                              </span>
                               <a
                                 href="https://sellercentral.amazon.com/fba/profitabilitycalculator/index.html"
                                 target="_blank"
@@ -2275,7 +2308,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                           {/* Base MOQ + Cost (always exists) */}
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                             <div className={getFieldContainerClass()}>
-                              <label className="block text-xs font-medium text-slate-400 mb-1">MOQ</label>
+                              <label className="block text-xs font-medium text-slate-400 mb-1">
+                                MOQ<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                              </label>
                               <input
                                 type="number"
                                 value={quote.moqShortTerm ?? quote.moq ?? ''}
@@ -2291,7 +2326,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                               />
                             </div>
                             <div className={getFieldContainerClass()}>
-                              <label className="block text-xs font-medium text-slate-400 mb-1">Cost/Unit (USD)</label>
+                              <label className="block text-xs font-medium text-slate-400 mb-1">
+                                Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                              </label>
                               <input
                                 type="text"
                                 value={getCurrencyDisplayValue(quote.id, 'costPerUnitShortTerm', quote.costPerUnitShortTerm ?? quote.exwUnitCost)}
@@ -2325,7 +2362,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                                         handleUpdateQuote(quote.id, { moqOptions: newOptions });
                                       }}
                                       placeholder="0"
-                                      className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getRequiredFieldClass(isFieldFilled(option.moq))}`}
+                                      className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getOptionalFieldClass()}`}
                                     />
                                   </div>
                                   <div className={getFieldContainerClass()}>
@@ -2341,7 +2378,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                                         handleUpdateQuote(quote.id, { moqOptions: newOptions });
                                       })}
                                       placeholder="$0.00"
-                                      className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getRequiredFieldClass(isFieldFilled(option.costPerUnit))}`}
+                                      className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white placeholder-slate-500 focus:outline-none ${getOptionalFieldClass()}`}
                                     />
                                   </div>
                                   <div className="flex items-end">
@@ -2370,7 +2407,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <h4 className="text-sm font-semibold text-slate-300 mb-2">Additional Costs</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">SSP Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              SSP Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'sspCostPerUnit', quote.sspCostPerUnit)}
@@ -2384,7 +2423,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Labelling Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Labelling Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'labellingCostPerUnit', quote.labellingCostPerUnit)}
@@ -2398,7 +2439,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Packaging Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Packaging Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'packagingCostPerUnit', quote.packagingCostPerUnit ?? quote.packagingPerUnit)}
@@ -2415,7 +2458,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Misc Costs/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Inspection Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'inspectionCostPerUnit', quote.inspectionCostPerUnit ?? quote.inspectionPerUnit)}
@@ -2478,7 +2523,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         <h4 className="text-sm font-semibold text-slate-300 mb-2">Carton / Logistics</h4>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-3">
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Units/Carton</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Units/Carton<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               value={quote.unitsPerCarton ?? ''}
@@ -2488,7 +2535,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Carton Weight (kg)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Carton Weight (kg)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2499,7 +2548,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Carton Length (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Carton Length (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2510,7 +2561,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Carton Width (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Carton Width (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2521,7 +2574,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Carton Height (cm)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Carton Height (cm)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="number"
                               step="0.01"
@@ -2559,7 +2614,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             <select
                               value={quote.incotermsAgreed || ''}
                               onChange={(e) => handleUpdateQuote(quote.id, { incotermsAgreed: e.target.value || undefined })}
-                              className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white focus:outline-none ${getRequiredFieldClass(isFieldFilled(quote.incotermsAgreed))}`}
+                              className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white focus:outline-none ${getOptionalFieldClass()}`}
                             >
                               <option value="">Select...</option>
                               <option value="EXW">EXW</option>
@@ -2568,7 +2623,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             </select>
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Freight Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Freight Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'freightCostPerUnit', quote.freightCostPerUnit ?? quote.ddpShippingPerUnit)}
@@ -2585,7 +2642,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Duty Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Duty Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'dutyCostPerUnit', quote.dutyCostPerUnit)}
@@ -2599,7 +2658,9 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className={getFieldContainerClass()}>
-                            <label className="block text-xs font-medium text-slate-400 mb-1">Tariff Cost/Unit (USD)</label>
+                            <label className="block text-xs font-medium text-slate-400 mb-1">
+                              Tariff Cost/Unit (USD)<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
+                            </label>
                             <input
                               type="text"
                               value={getCurrencyDisplayValue(quote.id, 'tariffCostPerUnit', quote.tariffCostPerUnit)}

--- a/src/utils/learnVideos.ts
+++ b/src/utils/learnVideos.ts
@@ -151,10 +151,10 @@ export const LEARN_VIDEOS: Record<LearnSection, LearnVideo[]> = {
     },
     {
       id: 'profit-overview',
-      label: 'Profit Overview Tab',
+      label: 'Profit Matrix Tab',
       icon: DollarSign,
       embedId: 'fd10140a1cfa44cea7469c5a06034a5a',
-      title: 'Profit Overview',
+      title: 'Profit Matrix',
       description: 'Compare your supplier options side by side using BloomEngine\u2019s profit overview matrix. This section helps you evaluate margins, pricing scenarios, and total costs so you can clearly identify which supplier offers the strongest opportunity.',
       thumbnail: '/thumbnail/15.png',
     },


### PR DESCRIPTION
## Summary

V9-scoped sourcing polish — eleven commits' worth of bug fixes, data-flow corrections, and visual cleanup across the sourcing dashboard, sourcing detail page, Sourcing Hub, Supplier Quotes tab, and the renamed Profit Matrix tab. Bigger redesigns (Supplier Quotes tab restructure, Profit Matrix data-presentation overhaul, Place Order redesign, FBA-fee auto-populate, Sourced Products column picker) explicitly deferred to V10.

## What's in this PR

**Bug fixes**
- DDP-Basic field mapping bugs in Profit Matrix (cost row showed shipping value, freight row was empty, ROI inflated, totalInvestment understated)
- ProductHeader sticky-toggle flicker on short sourcing detail pages (no quotes yet)
- Inspection Cost/Unit label said "Misc Costs/Unit" — relabeled to match its binding
- Supplier Info collapse — first click on default-expanded state was a no-op

**Data wiring**
- Profit Matrix incoterms cell is now bidirectional — editing it on Profit Matrix updates the Supplier Quotes Pricing/Terms dropdown, not just the Advanced override
- Sourcing Hub's Target Sales Price reads from Offering canonical with explicit "Reset to Offering" override link when user has typed a different value

**Visual polish**
- Profit "Overview" tab → "Profit Matrix" everywhere user-visible
- Christmas-tree red/green in Profit Matrix Totals & Profit dropped — only emerald Best now; calmer slate elsewhere
- Peer-missing cells: amber-warning treatment instead of red-error (warning, not alarm)
- Sourcing Hub gauge label "CALCULATION ACCURACY" moved up to header row; gauge enlarged to fill L/R column heights; status text fits inside the 100% ring
- Sourced Products list: pill consistency with Vetting dashboard; Margin/ROI dropped to plain colored text
- Sourcing Sandbox: tightened padding/gaps; right KPI column now stretches to match left column height
- Supplier Info dropdown — added "Show / Hide" text label next to chevron
- Multi-supplier row chrome — alternating blue/purple left accent border, stronger row separator
- Supplier Quotes section hierarchy — uppercase headers with bottom border for clearer scanning

**The big one — Sprint C item 1 (was paused for sessions):** Mandatory-vs-nice field indicators on Supplier Quotes
- Red asterisk after every mandatory field label (8 Basic + 12 Advanced)
- New \`getOptionalFieldClass()\` keeps nice-to-have inputs neutral always; amber-tint reserved for empty mandatory fields
- Inspection cost label fixed (was the "Misc" mislabel)

## Test plan

- [ ] DDP-Basic supplier: fill Cost/Unit + DDP Shipping Price; verify Profit Matrix shows correct Cost row + Freight/Duty row + ROI matches profit math
- [ ] Profit Matrix → click Incoterms Agreed → switch values → confirm Supplier Quotes dropdown also updates
- [ ] Sourcing detail page with no supplier quotes → scroll to bottom → no flicker
- [ ] Sourcing Hub → "Calculation Accuracy" label appears in header row; ring height matches L/R column 3-stack
- [ ] Sourcing Hub Target Sales Price → "From Offering" tag visible by default; "Reset to Offering" link appears after typing a different value
- [ ] Supplier Quotes mandatory fields show red asterisk; empty mandatory fields tint amber; empty nice-to-haves stay neutral
- [ ] Multiple suppliers stacked: blue/purple left accents alternate; section headers visually distinct
- [ ] Sourced Products dashboard list: status pills match Vetting style; Margin/ROI plain text
- [ ] Sourcing Sandbox: right column extends to match left column

🤖 Generated with [Claude Code](https://claude.com/claude-code)