### PR TITLE
Phase 6 V9 polish 2: five small wins

### DIFF
--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -645,12 +645,20 @@ export function PlaceOrderTab({
       {selectedSupplier && supplierWithMetrics && (
         <>
           {/* Agreed Order Summary Card */}
-          <div className="bg-gradient-to-br from-slate-800/80 to-slate-900/80 border-2 border-slate-700/50 rounded-lg p-6 shadow-lg">
-            <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-bold text-white flex items-center gap-2">
-                <FileText className="w-6 h-6" />
-                Agreed Order Summary
-              </h3>
+          <div className="bg-gradient-to-br from-slate-800/80 to-slate-900/80 border border-slate-700/50 rounded-xl p-6 shadow-lg">
+            <div className="flex items-center justify-between mb-5">
+              <div className="flex items-center gap-3">
+                <h3 className="text-xl font-bold text-white flex items-center gap-2">
+                  <FileText className="w-5 h-5 text-slate-400" />
+                  Agreed Order Summary
+                </h3>
+                <div className="text-sm text-slate-400">
+                  <span className="text-white font-medium">{selectedSupplier.displayName || '—'}</span>
+                  {selectedSupplier.companyName && (
+                    <span className="text-slate-500"> · {selectedSupplier.companyName}</span>
+                  )}
+                </div>
+              </div>
               {selectedSupplier.supplierGrade && (
                 <span className={`px-3 py-1 rounded-full text-sm font-semibold ${
                   selectedSupplier.supplierGrade === 'A' ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' :
@@ -662,80 +670,70 @@ export function PlaceOrderTab({
                 </span>
               )}
             </div>
-            
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Supplier</span>
-                <p className="text-white font-semibold mt-1">{selectedSupplier.displayName || '—'}</p>
-                {selectedSupplier.companyName && (
-                  <p className="text-sm text-slate-400 mt-0.5">{selectedSupplier.companyName}</p>
-                )}
+
+            {/* Top row: the four "money" stats — emphasized */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+              <div className="bg-slate-900/60 border border-slate-700/50 rounded-lg px-4 py-3">
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider font-semibold">Final MOQ</div>
+                <div className="text-2xl font-bold text-white tabular-nums mt-0.5">{tierValues?.moq?.toLocaleString() || '—'}</div>
               </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Final MOQ</span>
-                <p className="text-white font-semibold mt-1">{tierValues?.moq || '—'}</p>
-              </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Cost per Unit</span>
-                <p className="text-white font-semibold mt-1">
+              <div className="bg-slate-900/60 border border-slate-700/50 rounded-lg px-4 py-3">
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider font-semibold">Cost per Unit</div>
+                <div className="text-2xl font-bold text-white tabular-nums mt-0.5">
                   {tierValues?.costPerUnit ? formatCurrency(tierValues.costPerUnit) : '—'}
-                </p>
+                </div>
               </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Pro Forma Invoice Total</span>
-                <p className="text-white font-semibold mt-1">
-                  {orderQuantity && tierValues?.costPerUnit 
-                    ? formatCurrency(orderQuantity * tierValues.costPerUnit) 
+              <div className="bg-slate-900/60 border border-slate-700/50 rounded-lg px-4 py-3">
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider font-semibold">Pro Forma Total</div>
+                <div className="text-2xl font-bold text-white tabular-nums mt-0.5">
+                  {orderQuantity && tierValues?.costPerUnit
+                    ? formatCurrency(orderQuantity * tierValues.costPerUnit)
                     : '—'}
-                </p>
+                </div>
               </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Incoterms</span>
-                <p className="text-white font-semibold mt-1">
-                  {selectedSupplier.incotermsAgreed || selectedSupplier.incoterms || '—'}
-                </p>
-              </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Lead Time</span>
-                <p className="text-white font-semibold mt-1">{selectedSupplier.leadTime || '—'}</p>
-              </div>
-              
-              <div>
-                <span className="text-xs text-slate-400 uppercase tracking-wider">Payment Terms</span>
-                <p className="text-white font-semibold mt-1">{selectedSupplier.paymentTerms || '—'}</p>
-              </div>
-              
-              {supplierWithMetrics.profitPerUnit !== null && (
-                <>
-                  <div>
-                    <span className="text-xs text-slate-400 uppercase tracking-wider">Profit/Unit</span>
-                    <p className="text-emerald-400 font-semibold mt-1">
-                      {formatCurrency(supplierWithMetrics.profitPerUnit)}
-                    </p>
+              {supplierWithMetrics.profitPerUnit !== null ? (
+                <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg px-4 py-3">
+                  <div className="text-[10px] text-emerald-400/80 uppercase tracking-wider font-semibold">Profit / Unit</div>
+                  <div className="text-2xl font-bold text-emerald-300 tabular-nums mt-0.5">
+                    {formatCurrency(supplierWithMetrics.profitPerUnit)}
                   </div>
-                  <div>
-                    <span className="text-xs text-slate-400 uppercase tracking-wider">Margin %</span>
-                    <p className="text-white font-semibold mt-1">
-                      {supplierWithMetrics.marginPct !== null 
-                        ? `${supplierWithMetrics.marginPct.toFixed(1)}%`
-                        : '—'}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-xs text-slate-400 uppercase tracking-wider">ROI %</span>
-                    <p className="text-white font-semibold mt-1">
-                      {supplierWithMetrics.roiPct !== null 
-                        ? `${supplierWithMetrics.roiPct.toFixed(1)}%`
-                        : '—'}
-                    </p>
-                  </div>
-                </>
+                </div>
+              ) : (
+                <div className="bg-slate-900/60 border border-slate-700/50 rounded-lg px-4 py-3">
+                  <div className="text-[10px] text-slate-500 uppercase tracking-wider font-semibold">Profit / Unit</div>
+                  <div className="text-2xl font-bold text-slate-500 tabular-nums mt-0.5">—</div>
+                </div>
               )}
+            </div>
+
+            {/* Bottom row: secondary terms — demoted */}
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-x-4 gap-y-3 pt-4 border-t border-slate-700/40">
+              <div>
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider">Incoterms</div>
+                <div className="text-sm text-slate-200 font-medium mt-0.5">
+                  {selectedSupplier.incotermsAgreed || selectedSupplier.incoterms || '—'}
+                </div>
+              </div>
+              <div>
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider">Lead Time</div>
+                <div className="text-sm text-slate-200 font-medium mt-0.5">{selectedSupplier.leadTime || '—'}</div>
+              </div>
+              <div>
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider">Payment</div>
+                <div className="text-sm text-slate-200 font-medium mt-0.5">{selectedSupplier.paymentTerms || '—'}</div>
+              </div>
+              <div>
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider">Margin</div>
+                <div className="text-sm text-slate-200 font-medium tabular-nums mt-0.5">
+                  {supplierWithMetrics.marginPct !== null ? `${supplierWithMetrics.marginPct.toFixed(1)}%` : '—'}
+                </div>
+              </div>
+              <div>
+                <div className="text-[10px] text-slate-500 uppercase tracking-wider">ROI</div>
+                <div className="text-sm text-slate-200 font-medium tabular-nums mt-0.5">
+                  {supplierWithMetrics.roiPct !== null ? `${supplierWithMetrics.roiPct.toFixed(1)}%` : '—'}
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -685,9 +685,21 @@ export function SourcingHub({
 
           {/* Product Category */}
           <div className="px-3 py-2.5 bg-slate-800/40 border border-blue-500/20 rounded-lg">
-            <div className="text-xs font-semibold text-slate-400 mb-1.5 uppercase tracking-wide flex items-center gap-1.5">
-              <BarChart3 className="w-3 h-3" />
-              Product Category
+            <div className="text-xs font-semibold text-slate-400 mb-1.5 uppercase tracking-wide flex items-center justify-between gap-1.5">
+              <span className="flex items-center gap-1.5">
+                <BarChart3 className="w-3 h-3" />
+                Product Category
+              </span>
+              {hub.categoryOverride && originalCategory && hub.categoryOverride !== originalCategory && (
+                <button
+                  type="button"
+                  onClick={() => handleCategoryChange('')}
+                  className="text-[10px] font-medium text-blue-400 hover:text-blue-300 normal-case tracking-normal transition-colors"
+                  title={`Reset to Research category (${originalCategory})`}
+                >
+                  Reset to Research
+                </button>
+              )}
             </div>
             <select
               value={category}
@@ -701,6 +713,13 @@ export function SourcingHub({
                 </option>
               ))}
             </select>
+            {originalCategory && (
+              <div className="mt-1 text-[10px] text-slate-500">
+                {!hub.categoryOverride || hub.categoryOverride === originalCategory
+                  ? `From Research`
+                  : `Overridden (Research: ${originalCategory})`}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -1321,16 +1321,19 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-700/50 mb-4">
             <Calculator className="w-8 h-8 text-slate-500" />
           </div>
-          <h3 className="text-xl font-semibold text-white mb-2">Your Sourcing Hub Is Empty — Let's Fill It With Real Numbers 🧾</h3>
-          <p className="text-slate-400 mb-6">
-            Click Add Supplier to start tracking quotes and tracking real profit potenial.
+          <h3 className="text-xl font-semibold text-white mb-2">No supplier quotes yet</h3>
+          <p className="text-slate-400 mb-2 max-w-md mx-auto">
+            Add a supplier to log their pricing, MOQ, lead time, and freight terms. Compare side-by-side to find the strongest profit potential before placing your order.
+          </p>
+          <p className="text-slate-500 text-sm mb-6">
+            You'll typically want to compare 2&ndash;4 suppliers per product.
           </p>
           <button
             onClick={handleAddSupplier}
             className="px-6 py-3 bg-gradient-to-r from-blue-500 to-emerald-500 hover:from-blue-600 hover:to-emerald-600 rounded-lg text-white font-medium transition-all transform hover:scale-105 inline-flex items-center gap-2"
           >
             <Plus className="w-5 h-5" />
-            Add Supplier
+            Add Your First Supplier
           </button>
         </div>
       ) : (

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -2592,16 +2592,22 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className="grid grid-cols-2 gap-2">
-                            <div className="bg-slate-800/50 rounded-lg p-2 border border-slate-700/30">
-                              <label className="block text-xs font-medium text-slate-400 mb-1">CBM/Carton</label>
-                              <div className="text-sm font-semibold text-white">
+                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40">
+                              <label className="block text-xs font-medium text-slate-500 mb-1 flex items-center gap-1">
+                                CBM/Carton
+                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold">auto</span>
+                              </label>
+                              <div className="text-sm font-medium text-slate-300 tabular-nums">
                                 {formatValue(quote.cbmPerCarton ?? null)}
                                 {quote.cbmPerCarton !== null && !isNaN(quote.cbmPerCarton ?? NaN) ? ' m³' : ''}
                               </div>
                             </div>
-                            <div className="bg-slate-800/50 rounded-lg p-2 border border-slate-700/30">
-                              <label className="block text-xs font-medium text-slate-400 mb-1">Total CBM</label>
-                              <div className="text-sm font-semibold text-white">
+                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40">
+                              <label className="block text-xs font-medium text-slate-500 mb-1 flex items-center gap-1">
+                                Total CBM
+                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold">auto</span>
+                              </label>
+                              <div className="text-sm font-medium text-slate-300 tabular-nums">
                                 {formatValue(quote.totalCbm ?? null)}
                                 {quote.totalCbm !== null && !isNaN(quote.totalCbm ?? NaN) ? ' m³' : ''}
                               </div>

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -2687,10 +2687,17 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         </div>
                       </div>
 
+                      {/* Group caption — separates Quality & Differentiation from the cost-driven sections above. */}
+                      <div className="pt-2 mt-2 border-t border-slate-700/30">
+                        <div className="text-[10px] uppercase tracking-[0.2em] text-slate-500 font-semibold mb-2 px-1">
+                          Quality &amp; Differentiation
+                        </div>
+                      </div>
+
                       {/* Super Selling Points (SSPs) - Section 8 */}
-                      <div className="bg-slate-500/20 rounded-lg p-3 border border-slate-700/30">
+                      <div className="bg-emerald-500/[0.04] rounded-lg p-3 border border-emerald-500/15">
                         <div className="flex items-center justify-between mb-3">
-                          <h4 className="text-sm font-semibold text-slate-300">Super Selling Points (SSPs)</h4>
+                          <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 pb-2 border-b border-slate-700/40 flex-1">Super Selling Points (SSPs)</h4>
                           {/* <button
                             type="button"
                             onClick={() => {
@@ -2852,7 +2859,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                       </div>
 
                       {/* Sampling - Section 9 */}
-                      <div className="bg-slate-900/20 rounded-lg p-3 border border-slate-700/30">
+                      <div className="bg-emerald-500/[0.04] rounded-lg p-3 border border-emerald-500/15">
                         <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-3 pb-2 border-b border-slate-700/40">Sampling</h4>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                           <div className={getFieldContainerClass()}>


### PR DESCRIPTION
## Summary

Five small polish wins layered on top of the V9 polish that just landed (PR #32). All visual / UX, no data model changes.

## Commits

1. **\`05da020\`** — Product Category in Sourcing Hub mirrors the From-Offering / Reset-to-Offering pattern that Target Sales Price now uses. Reads from \`productData.category\` by default; surfaces "Overridden (Research: X)" + Reset link when user picks a different category.
2. **\`9239caa\`** — Supplier Quotes empty-state copy. Was "Your Sourcing Hub Is Empty 🧾" with a typo ("potenial"); now "No supplier quotes yet" with a clearer explainer of what suppliers track and a directive "Add Your First Supplier" CTA.
3. **\`32377f2\`** — CBM/Carton + Total CBM derived fields visually demoted (darker bg, dashed border, "AUTO" tag, slate-300 medium weight) so they no longer look like editable inputs.
4. **\`61755f9\`** — Agreed Order Summary on Place Order tab restructured into two rows: top row is the four "money" stats (MOQ / Cost per Unit / Pro Forma Total / Profit per Unit) emphasized as 2xl-bold cards with Profit/Unit in emerald; bottom row is logistics terms (Incoterms / Lead Time / Payment / Margin / ROI) in a smaller demoted strip below a slate-700/40 divider.
5. **\`c462d2d\`** — SSP + Sampling sections in Supplier Quotes Advanced view get a "Quality & Differentiation" caption row + soft emerald-tinted backgrounds, visually separating them from the cost-driven sections above. Partial of #10 without the full sub-tab restructure (still V10).

## Test plan

- [ ] Sourcing Hub → Product Category — pick a different category, see "Overridden (Research: X)" tag + Reset link
- [ ] Supplier Quotes tab with zero suppliers → see new empty-state copy + "Add Your First Supplier" button
- [ ] Supplier Quotes Advanced → fill carton dimensions + MOQ, scroll down → CBM/Carton + Total CBM render in dashed-border darker boxes with AUTO tag (clearly not editable)
- [ ] Place Order tab → Agreed Order Summary header is tighter; top row shows four big money stats; bottom row shows demoted logistics terms
- [ ] Supplier Quotes Advanced → SSP and Sampling sections sit under "Quality & Differentiation" caption with emerald-tinted bg, clearly separated from cost fields above

🤖 Generated with [Claude Code](https://claude.com/claude-code)