### PR TITLE
Phase 6 V9 pre-main: 9 fixes for ship-readiness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import json,sys; p=json.load(sys.stdin).get('tool_input',{}).get('file_path',''); sys.exit(0 if p.endswith(('.ts','.tsx')) else 1)\" && cd \"$CLAUDE_PROJECT_DIR\" && ./node_modules/.bin/tsc --noEmit --incremental --tsBuildInfoFile .claude/.tsbuildinfo 2>&1 | head -30 || true",
+            "timeout": 60,
+            "statusMessage": "Typechecking..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/handoffs/phase-5.4-M-rotations-shipped.md
+++ b/docs/handoffs/phase-5.4-M-rotations-shipped.md
@@ -1,0 +1,211 @@
+# Phase 5.4-M close-out + Vercel-incident rotations (2026-05-07 EOD)
+
+End of session 2026-05-07. Wraps Phase 5.4-M with the morning critical-path validation, three bug-fix passes on the just-shipped Sprint D tier system, the full Vercel-incident key rotation queue, the OpenAI dead-code purge, and a complete polish of the Supabase Auth transactional emails.
+
+**Production state:** `main` at `cf40b48` (deployed). Sprint D is fully shipped + validated end-to-end; Test Tesy lives in Stripe live mode at `cus_UTRZqpAfkR8aBN` / `sub_1TUUfzG4KxGhBse6Bx8Jvu6T` in pending-cancel state (will fully cancel May 14, no charge will fire).
+
+---
+
+## 1. What shipped today
+
+### bloomengine — production progressed `1d868e6` → `cf40b48` on `main` (3 commits)
+
+| Commit | What |
+|---|---|
+| `7be42a0` | **Phase 5.4-M tier-card fix.** `/subscription` page was reading `usage.effectiveTier` (which is `'pro'` during *any* trial by design in `state.ts:47`) for the tier-card *display*. Result: a Core trial user saw "BloomEngine Pro" + rocket icon + "Upgrade to Pro" button — internally contradictory. Switched header to read `usage.tier` (selected). Added "· Pro features unlocked" sub-text inside the TRIAL pill so the Pro-feature trial perk is communicated without lying about the tier. Also fixed the broken icon: `bg-clip-text text-transparent` only clips gradients onto **text glyphs**, not SVG paths — that's why the icon rendered as an empty green square. Replaced with a solid `iconColor` per tier. |
+| `c2b450e` | **Phase 5.4-M /profile sidebar fix.** Same `effectiveTier`-as-display bug, different file: the Current Plan sidebar card was reading `data.effectiveTier`, so Core trial users saw "BloomEngine Pro". One-line fix to `data.tier`. The `isInTrial` pill is gated independently and stays correct. |
+| `8531e83` | **Phase 5.4-M cancel/resume flow.** Closes the deferred Reactivate item from yesterday's Sprint D handoff (Q3 in section 6). Read cancel state live from Stripe in `/api/subscription/usage` (no DB mirror — Stripe is source of truth, no migration needed). New `/api/stripe/reactivate` endpoint flips `cancel_at_period_end: false`. Redesigned `/subscription` cancel zone: active state is a single polished card (no duplicate "Cancel subscription" title + link); pending-cancel state replaces it with an amber "Subscription ending May 14, 2026" card + Resume CTA + cancellation date. Fixes both the post-cancel-still-shows-Cancel bug and the duplication complaint. **Also fixed `/profile` name update**: handleSave now dispatches `setUser` to Redux so the AppHeader dropdown reflects the new name immediately, no refresh needed. Existing `reduxUser` is merged so subscription fields populated elsewhere survive. |
+| `cf40b48` | **OPENAI cleanup.** `analyzeOpenAI.ts` had zero importers — the entire offer pipeline (4 routes, every `ssp_generate*` operation) runs through `analyzeAnthropic.ts`. Deleted 1209 lines of dead service code + uninstalled the `openai` package. Prepared `OPENAI_SECRET_KEY` for Vercel + `.env.local` deletion. |
+
+### Sprint D critical-path: validated end-to-end on production
+
+Walked the morning checklist (Steps A–E from `phase-5.4-M-kickoff-prompt.md`):
+- **A. /plans smoke test** ✅ — 2-tier design, monthly/yearly toggle, modal Embedded Checkout, no Stripe-hosted redirects.
+- **B. End-to-end signup with real card** ✅ — Test Tesy signed up Core/monthly. Verified row in `profiles`: tier=core, billing_interval=monthly, subscription_status=TRIALING, trial_ends_at=2026-05-14, stripe_customer_id + stripe_subscription_id populated. Webhook fired correctly.
+- **C. /subscription page** 🟡→✅ — initially failed (tier-card mislabel bug above); fixed and re-verified.
+- **D. /profile Plan badge** 🟡→✅ — initially failed (sidebar mislabel bug); fixed and re-verified.
+- **E. Cancel test** ✅ — exercised in-app cancel flow + Stripe set to cancel_at_period_end=true. Resume button (built today) verified the round-trip.
+
+### Vercel-incident key rotation queue: complete
+
+Today's pre-emptive rotation (Vercel breach Apr 19, 2026 — Dave was not in affected subset, but Vercel recommended preventive rotation):
+
+| Key | Action |
+|---|---|
+| `OPENAI_SECRET_KEY` | ✅ **Deleted.** Dead code purge made it unused. |
+| `ANTHROPIC_API_KEY` | ✅ Rotated. Smoke-tested via `claude-haiku-4-5-20251001` ping. |
+| `RESEND_API_KEY` | ✅ Rotated. New key scoped to **send-only** (best practice). Verified by sending real test email to support@bloomengine.ai (id `9d7e8960-5c80-4cd0-a9db-67ac0435c42c`). |
+| `KEEPA_API_KEY` | ✅ Rotated. Verified via `/token` endpoint — 3,720 tokens left, refilling at 62/min, 0% rate-limit penalty. |
+| `STRIPE_SECRET_KEY` (test mode / Pre-Production) | ✅ Rotated. Verified via `/v1/balance` — `livemode: false` confirms correct scope. |
+| `STRIPE_WEBHOOK_SECRET` (Production / live) | ✅ Rotated via Stripe's "Roll secret" with 24h grace overlap on the BloomEngine AI PROD endpoint. |
+| Supabase ↔ Resend SMTP integration key (separate full-access key in Resend) | ✅ Rotated. Replaced full-access key with **send-only** scope (was overprivileged for SMTP). New key plugged into Supabase Dashboard → Auth → SMTP Settings. Verified by triggering password reset and receiving email. |
+| `STRIPE_WEBHOOK_SECRET` (Pre-Production / test) | ✅ **Cleaned up — deleted.** The endpoint it was paired with (`saasogv6.vercel.app/api/s...`) was orphaned from the pre-rebrand era. Stripe-side endpoint deleted, Vercel env var deleted. Local dev should use `stripe listen` (Stripe CLI generates session-specific secrets). |
+
+All Vercel-stored secrets that were active during the breach window are now rotated. **No customer-facing impact.** All Sensitive flags now properly set on rotated vars. "Needs Attention" badges in Vercel: gone.
+
+### Supabase Auth email templates: full polish pass
+
+The morning password-reset test surfaced that the entire Supabase Auth email template suite was running on the **pre-rebrand "Grow With FBA AI" branding** (smiley logo, dark blue text on dark blue button = unreadable, "© 2025" copyright, etc.). Built six BloomEngine-branded HTML templates with consistent shell:
+
+- ✅ Confirm signup
+- ✅ Reset Password (verified delivered + rendering)
+- ✅ Magic Link
+- ✅ Change Email Address
+- ✅ Reauthentication (code-based, not button)
+- ✅ Invite User
+
+Design: dark slate-900 body, slate-800 card with 16px radius, BloomEngine horizontal logo on solid dark header (no gradient — Dave's call after first preview), gradient blue→emerald CTA button as the only accent. Logo asset hosted at `https://www.bloomengine.ai/BloomEngine-HorizontalLogo-Final-DarkMode.png` (verified HTTP 200 with permissive CORS).
+
+These are NOT in the repo — they live in Supabase Dashboard → Authentication → Email Templates. Source of truth lives in chat history of this session if they need to be re-pasted.
+
+---
+
+## 2. Repo state (end of day 2026-05-07)
+
+| Repo | Branch | Tip | Status |
+|---|---|---|---|
+| bloomengine | `main` | `cf40b48` | **Production. Vercel deployed.** All 4 commits from today live. |
+| bloomengine | `dev` | `cf40b48` | Synced with main. Was *severely* behind at start of day (`19a8dbf` Phase 5.4-G3 — 12 commits behind); fast-forwarded mid-session. Going forward, dev should track main. |
+| bloom-lens-extension | `phase-5-2-bottom-drawer-pivot` | `46028a2` | **Unchanged today.** v0.5.8 zip still awaiting Web Store upload. |
+| Web Store | — | v0.5.7 published | v0.5.8 still pending Dave's manual upload. |
+
+---
+
+## 3. Files changed (today)
+
+### bloomengine — 4 commits, ~1465 lines net (-1213 / +252)
+
+**New files:**
+- `src/app/api/stripe/reactivate/route.ts` — mirror of `/api/stripe/cancel`, flips `cancel_at_period_end: false`
+
+**Deleted files:**
+- `src/services/analyzeOpenAI.ts` — 1209 lines of dead OpenAI-backed service replaced by `analyzeAnthropic.ts` months ago
+
+**Modified:**
+- `src/app/api/subscription/usage/route.ts` — fetches Stripe subscription's `cancel_at_period_end` + `cancel_at` for the `/subscription` page (fail-soft if Stripe is unreachable)
+- `src/app/subscription/page.tsx` — tier-card uses `tier` not `effectiveTier`; new pending-cancel UI with Resume button; "Pro features unlocked" sub-text on TRIAL pill; icon CSS fix
+- `src/app/profile/page.tsx` — sidebar tier card uses `tier`; `handleSave` dispatches Redux `setUser` to update AppHeader name immediately
+- `package.json` + `package-lock.json` + `yarn.lock` — `openai` package removed
+
+### Supabase
+No migrations applied today.
+
+### `.env.local` (local-only, not committed)
+- Removed: `OPENAI_SECRET_KEY`
+- Updated: `ANTHROPIC_API_KEY`, `KEEPA_API_KEY`, `STRIPE_SECRET_KEY` (test mode)
+- Added: `RESEND_API_KEY` (was previously not in `.env.local`)
+- Note: `STRIPE_WEBHOOK_SECRET` line 10 still has the old test-mode value. With the orphan endpoint deleted, this value is dead. When you next run `stripe listen`, replace with the CLI-generated session secret.
+
+---
+
+## 4. What's blocked / awaiting Dave
+
+### Tiny cleanups (not blocking, ~3 min)
+1. **Mark 3 secrets as Sensitive in Vercel** (no rotation needed — flag toggle only):
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `STRIPE_SECRET_KEY` (Production / live mode)
+   - `SERPAPI_API_KEY` — also deselect Development scope since `.env.local` has it
+2. **Verify production webhook signing secret** with a real event. Trigger a `customer.subscription.updated` from Stripe Dashboard → Webhooks → BloomEngine AI PROD endpoint → "Send test webhook." Or just have Test Tesy click Resume → Cancel on `/subscription`. Watch for 200 OK in the Stripe event delivery log. (Not strictly required — the rotation succeeded; this is belt-and-suspenders.)
+
+### Pending decisions (no action this session, deferred)
+3. **`SERPAPI_API_KEY` rotation** — *not* required for incident hygiene (added 2026-04-21, **after** the April 19 breach window — was never exposed). Optional periodic rotation; defer to next quarter.
+
+### Web Store / extension (carrying over from prior handoffs)
+4. **Upload `bloom-lens-extension-0.5.8-chrome.zip`** to Chrome Web Store. Reviewer note already drafted in `phase-5.4-M-sprint-d-shipped.md` section 5.
+5. **Re-enable extension detection** in `src/hooks/useExtensionInstalled.ts` — delete the `return false;` early-return at the top once v0.5.8 propagates to existing users' browsers. Right now every CTA shows for everyone (intentional during testing).
+
+---
+
+## 5. V9 remaining roadmap (sprint order locked: A → E → D → B → C)
+
+### Sprint A — Phase 5 wrap-up
+| Item | Status |
+|---|---|
+| 5.4-I sub-category granularity | ✅ shipped 2026-05-06 |
+| 6 new band-aware category calibrations | ✅ shipped 2026-05-06 |
+| Web Store v0.5.7 upload | ✅ shipped earlier this week |
+| Web Store v0.5.8 upload | ⏳ Open — Dave's manual step |
+| **r8: refit existing 12 categories with bands** (no new CSVs needed) | ⏳ Open — uses Supabase corpus + existing harness |
+| Recalculate pill on `/vetting/[asin]` | ⏳ Open — deferred from 5.4-E without spec |
+| BloomLens UI polish backlog | ⏳ See `project_bloom_lens_ui_polish_backlog.md`. Open: BloomLens-one-word rename, branded loading state, top-left logo asset, popup outer glow, **paywall fires for PRO users** (probably resolved by Phase 6 fix from yesterday but verify), **My Funnel 2s click delay** |
+
+### Sprint E — Public launch readiness (biggest open scope)
+Pulled from `phase-5.4-H2-and-v9-finish.md`. Needs Dave's strategic direction:
+- **Demo video** — Dave was going to record. Slot into landing page section 8 (between Versus and Case Studies) once available.
+- **Real case-study testimonials** — currently using drafted quotes for Barbara/Art/Will/James + randomuser.me male portraits. Replace `CASE_STUDIES` constant in `src/app/page.tsx` with real photos + quotes when collected.
+- **Onboarding tour** — first-time-user walkthrough on bloomengine.ai vs popup welcome screen vs both.
+- **Pricing page polish** — currently functional, may need marketing copy + visual treatment.
+- **Marketing surfaces** — landing page sections, demo video slot, social proof.
+- **Monitoring** — Sentry? Datadog? Just Vercel logs? Decide before public launch.
+- **Support channel** — email (`support@bloomengine.ai`)? In-app chat? Skool community? Decide before public launch.
+- **Soft launch plan** — invite list, beta cohort size, feedback collection, launch announcement timing.
+
+### Sprint D — Phase 7 Billing
+**Sprint D core scope is SHIPPED** (tier system + Stripe Embedded + cap enforcement live in production as of 2026-05-06). Remaining tier-system polish (low-priority follow-ups):
+- Update payment method UX — currently no in-app way to change card on file (workaround: cancel + resubscribe).
+- Switch billing interval mid-subscription — no UI to flip Core monthly → Core yearly (workaround: cancel + resubscribe; needs proration math when built).
+- ~~Resume a pending cancellation~~ — **DONE 2026-05-07** (cancel/resume flow shipped today).
+- Trial-extension flow — what happens if a user's trial fails to convert (card declined)? Currently webhook marks subscription_status=CANCELED. Needs grace period + email reminder flow.
+
+### Sprint B — Pre-Vetting / Market Climate polish backlog
+9 items captured in `project_market_climate_v2_polish.md` (memory). 2026-04-25 vintage; verify still current before starting.
+
+### Sprint C — Phase 6 Sourcing polish
+- Mandatory-vs-nice field indicators
+- Supplier comparison view
+- SP-API auto-fetch FBA fees
+- PO contract PDF + info-collection popup
+- Alibaba automation deferred to V11
+
+---
+
+## 6. Open questions for next session
+
+The next Claude needs Dave's answers on these before starting any new work. Group A is calibration / extension wrap-up; Group B is the Sprint E launch arc; Group C is Sprint D polish that piggybacks on what shipped today.
+
+### Group A — Sprint A finish
+1. **r8 priority.** Worth band-refitting the existing 12 categories before Sprint E? ~30 min of work, makes the calibration table uniformly band-aware. Or "good enough for launch"?
+2. **Recalc pill on `/vetting/[asin]`** — what's the desired UX? Show stale-data indicator? Trigger re-fetch on click? This was deferred from 5.4-E without a spec.
+3. **PRO-paywall regression** — was supposedly fixed in Phase 6 of Sprint D (commit `b4922a3`). Verify the Bloom Lens popup no longer shows the upsell for PRO users. If still broken, fix as part of Sprint A wrap-up.
+
+### Group B — Sprint E (the big one)
+4. **Soft launch — beta cohort or open?** Invite-only beta first or open the Web Store doors?
+5. **Monitoring stack.** Sentry adds vendor cost + complexity but catches errors users won't report. Vercel logs are free but reactive. Pick one.
+6. **Support channel.** Email-only (`support@bloomengine.ai`) is simplest. Skool community is closest to where students already are. In-app chat (Intercom, Crisp) is highest-touch but most expensive.
+7. **Pricing page polish vs full marketing site.** Are we shipping the existing `/pricing` page now and a full marketing site later? Or both before launch?
+8. **Onboarding tour.** First-time-user walkthrough on the BloomEngine app, popup welcome screen on the extension, or both?
+9. **Demo video** — when's it being recorded? Want me to draft a script outline?
+
+### Group C — Sprint D polish (post-launch follow-ups)
+10. **Update-payment-method UX** — Stripe SetupIntent + Payment Element flow when the customer's card changes. Build this pre-launch or post?
+11. **Switch billing interval mid-subscription** — flip Core monthly → Core yearly without canceling. Proration math needed.
+12. **Trial-fail-to-convert handling** — what happens when a card declines on day 7? Grace period + email + cap-down to free? Currently it just hard-canceles.
+
+### Standalone questions
+13. **`SERPAPI_API_KEY` rotation** — skip until next quarter (recommended) or rotate now for completeness?
+14. **`SUPABASE_SERVICE_ROLE_KEY` / `STRIPE_SECRET_KEY` (Production) / `SERPAPI_API_KEY` Sensitive flags** — toggle now, or wait until something else needs to happen in Vercel?
+
+---
+
+## 7. Standing rules (don't break)
+
+1. PRs target `dev`, never `main` without explicit instruction.
+2. After committing, pause and wait for confirmation before merging or pushing.
+3. Don't punt the merge to Dave — push + PR + merge are mine to drive.
+4. Never combine commit + merge + push in one chained command.
+5. **NO ROUND NUMBERS in displayed metrics.** BSR-curve drives display, full stop.
+6. No "Keepa" in user-facing copy.
+7. "BloomLens" is one word in user-facing surfaces.
+8. **No Stripe-hosted page redirects.** All checkout/billing flows must render inside BloomEngine via Stripe Embedded.
+9. Tolerance-based numeric checks for AI / rounded values (`Math.abs(sum - 100) < 2`).
+10. Production deploys from `main`. Dev = preview.
+11. **Never sacrifice one BSR band's accuracy for another's** (calibration vision rule).
+12. Any new button in `entrypoints/content/` must use `window.open` (or message background SW), not `chrome.tabs.*`.
+13. Sensitive env vars in Vercel must drop the Development environment scope (Vercel constraint).
+14. **`effectiveTier` ≠ `tier` for display.** `effectiveTier` is the cap-governing tier (Pro during any trial). `tier` is what the customer purchased. Display the latter; gate caps on the former.
+
+---
+
+## 8. Tomorrow's first message to Claude
+
+Use the kickoff prompt at: `docs/handoffs/phase-5.4-N-kickoff-prompt.md`

--- a/docs/handoffs/phase-5.4-N-kickoff-prompt.md
+++ b/docs/handoffs/phase-5.4-N-kickoff-prompt.md
@@ -1,0 +1,65 @@
+Picking up after a heavy 2026-05-07 session that closed Phase 5.4-M. Sprint D (tier system + Stripe Embedded + cap enforcement) is fully shipped + validated end-to-end on production. The full Vercel-incident key rotation queue is done. All six Supabase Auth email templates are now BloomEngine-branded. Three bug fixes that came out of the critical-path testing also shipped (tier-card mislabel, profile sidebar mislabel, cancel/resume flow + profile name reflection in AppHeader).
+
+**Read in this order:**
+
+1. `docs/handoffs/phase-5.4-M-rotations-shipped.md` — the full handoff for what just shipped. Section 4 is the small remainder of pending tasks; section 5 is the V9 remaining roadmap; section 6 has 14 open questions grouped A/B/C.
+2. `MEMORY.md` — durable rules, especially `feedback_no_stripe_redirects.md`, `project_pricing_yearly_toggle.md`, and the new `effectiveTier ≠ tier` rule (rule #14 in the handoff).
+3. `docs/handoffs/phase-5.4-I-ship-and-v9-remaining.md` — older sprint map. V9 sprint order is locked: A → E → D → B → C. Sprint D is done; A is mostly done; **E is the biggest open scope** (public launch readiness) and needs Dave's strategic direction more than mine.
+
+**Verify production is healthy first:**
+```
+git log -3 main           # top should be cf40b48 "chore: remove dead OpenAI service + uninstall openai package"
+curl -s -o /dev/null -w "%{http_code}\n" https://www.bloomengine.ai/api/subscription/usage    # expect 401
+curl -s -o /dev/null -w "%{http_code}\n" -X POST https://www.bloomengine.ai/api/stripe/reactivate  # expect 401 (new endpoint)
+```
+
+---
+
+**DON'T immediately code.** This is the most important instruction. Walk Dave through the open list FIRST — there are 14 open questions in section 6 of the handoff doc, plus a few small pending cleanups, and what to prioritize is genuinely his call.
+
+Use the **AskUserQuestion** tool (or numbered options if AskUserQuestion isn't a fit) to elicit his priorities. Walk through these in order:
+
+### Step 1 — Quick cleanups still pending from yesterday (~3 min total)
+
+Ask if Dave wants to knock these out before any new work:
+
+- **Mark 3 secrets as Sensitive in Vercel** (no rotation, just a toggle): `SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET_KEY` (Production / live mode), `SERPAPI_API_KEY` (also deselect Development scope).
+- **Verify production webhook signing secret** with a real Stripe event (Test Tesy resume/cancel cycle).
+- **Upload `bloom-lens-extension-0.5.8-chrome.zip`** to Chrome Web Store (Dave's manual step — but worth flagging now if it's gone stale).
+- **Re-enable extension detection** in `src/hooks/useExtensionInstalled.ts` (delete the `return false;` early-return) — only after v0.5.8 is approved + propagated.
+
+These are 1–2 minutes each. Recommend knocking out Sensitive-flag toggles before anything else.
+
+### Step 2 — Pick the priority track
+
+Ask Dave which of these tracks to push next. Give him 4–5 options via AskUserQuestion:
+
+1. **Sprint E launch readiness** (biggest scope, needs Dave's strategic input). Sub-questions: monitoring (Sentry vs Vercel logs), support channel (email vs Skool vs in-app chat), soft-launch shape (beta cohort vs open), pricing page polish vs full marketing site, onboarding tour scope.
+2. **Sprint A finish-up** (calibration r8 — band-refit existing 12 categories from Supabase corpus, ~30 min). Plus the `/vetting/[asin]` Recalc pill UX (deferred from 5.4-E without spec).
+3. **Sprint D polish** (update-payment-method UX, switch billing interval mid-subscription, trial-fail-to-convert grace period). These are small post-launch UX wins; could ship pre-launch if priority.
+4. **BloomLens UI polish backlog** — see `project_bloom_lens_ui_polish_backlog.md` memory. Open: BloomLens-one-word rename, branded loading state, top-left logo asset, popup outer glow, paywall verification, My Funnel 2s click delay.
+5. **Sprint C sourcing** (was originally next, deferred during Sprint D) — mandatory-vs-nice field indicators, supplier comparison view, SP-API auto-fetch FBA fees, PO contract PDF + info-collection popup.
+6. **Sprint B Pre-Vetting / Market Climate polish** — 9 items in `project_market_climate_v2_polish.md`, 2026-04-25 vintage. Verify still current before starting.
+
+### Step 3 — Within whichever track Dave picks, ask the strategic sub-questions
+
+If he picks Sprint E (most likely the biggest one), follow up with the Group B questions from section 6 of the handoff doc — monitoring stack, support channel, soft-launch shape, pricing/marketing scope, onboarding tour. Use AskUserQuestion to surface 2–3 of these at a time.
+
+If he picks Sprint A finish-up, ask about r8 priority + Recalc pill UX spec.
+
+If he picks BloomLens polish, the memory doc has the open items + Dave's recurring rules (no Bloom Lens design without pixel-matching the BloomEngine app first — `feedback_lens_pixel_match_first.md`).
+
+---
+
+**Standing rules (don't break):**
+- PRs to `dev` never `main` without explicit instruction.
+- After commits, pause for push confirm.
+- Don't punt merges to Dave — push + PR + merge are mine to drive.
+- Never combine commit + merge + push.
+- No round numbers in displayed metrics.
+- No "Keepa" or "Helium 10" in user-facing copy.
+- "BloomLens" is one word.
+- No Stripe-hosted redirects.
+- Production = main, dev = preview.
+- `effectiveTier` is for cap gating only; display the user's `tier`.
+- Pixel-match Bloom Lens to BloomEngine app before any Lens UI change.

--- a/docs/handoffs/phase-5.4-N-shipped-and-lens-redesign.md
+++ b/docs/handoffs/phase-5.4-N-shipped-and-lens-redesign.md
@@ -1,0 +1,388 @@
+# Phase 5.4-N close-out + Lens-Expansion redesign queued (2026-05-07 EOD)
+
+End of session 2026-05-07. Three PRs shipped clean to main; a fourth (Recalc pill) was closed after preview testing surfaced architectural issues. The full rework is now spec'd as **Phase 5.4-O — the "Market Expansions" redesign** and is the kickoff item for tomorrow.
+
+**Production state:** `main` at `3164865` (deployed). Phase 5.4-N tier-mislabel fix + r8 band-aware calibration both live. Test Tesy still in pending-cancel state (auto-cancels May 14, no charge).
+
+---
+
+## 1. What shipped today
+
+### bloomengine — production progressed `cf40b48` → `3164865` on `main` (4 merge commits + 4 underlying)
+
+| Commit | What |
+|---|---|
+| `bb12703` (PR #25) | **Phase 5.4-N tier mislabel fix.** Same `effectiveTier ≠ tier` bug pattern as yesterday's two web-side fixes — but in the BloomLens extension. `deriveLensTier(status, type)` was running stale Phase 5.4 logic that mapped `subscription_type` → tier (YEARLY=pro, MONTHLY=core). Sprint D split tier from billing interval — they're independent axes. Fix replaces with `deriveLensTier(profile)` reading the new `tier` column, plus `deriveEffectiveLensTier(profile)` for trial→pro elevation in feature gating. Five extension routes updated (`me`, `save-funnel`, `funnel-asins`, `markets`, `analyze-market`). Response shape unchanged; no extension version bump or Web Store re-upload needed. |
+| `a26a708` (PR #26) | **Phase 5.4-N r8 band-refit.** The 12 v6 single-multiplier categories (Kitchen & Dining, Sports & Outdoors, etc.) re-fit against the same merged corpus v6 used (Supabase submissions filtered to single-variation rows + `scripts/probes/data/h10-extra-corpus.jsonl`, 2,506 deduped samples). 10 of 11 picked up at least one fitted band (n≥30); Industrial & Scientific stays default-only. **Defaults landed within ±13% of v6 across all 11 categories** — corpus is stable, math is sound. Notable band discoveries hidden by the single-mult fits: **Tools & Home Improvement** hunt-mid spikes to 2.41x while default is 1.63x; **Kitchen & Dining** spans 3.4x range across bands (1.39x at hunt-low → 0.41x at deep tail). Version stamp: `v6-2026-05-06-band-aware-r7` → `v7-2026-05-08-band-aware-r8`. |
+| `8538ed8` | Merge PR #25 → dev |
+| `4cbdea0` | Merge PR #26 → dev |
+| `3164865` (PR #27) | **dev → main promotion.** Both fixes shipped to production. |
+
+### Vercel cleanup (manual, your hands)
+
+- ✅ Marked 3 secrets Sensitive in Vercel: `SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET_KEY` (Production / live), `SERPAPI_API_KEY` (Development scope dropped). No redeploy needed — Sensitive flag is metadata-only.
+- ✅ Production webhook signing secret verified.
+- ✅ v0.5.8 zip uploaded to Chrome Web Store (awaiting reviewer approval).
+
+---
+
+## 2. What got CLOSED — PR #28 Recalc pill
+
+PR #28 (Phase 5.4-N: BloomLens Recalc pill on `/vetting/[asin]`) shipped a banner + auto-fire redirect to `/submission/[id]?triggerRecalc=1`. Preview testing surfaced eight distinct issues — see section 4 for the full list and the redesign that resolves them. The PR is **closed**, not merged. The branch `phase-5.4-N-vetting-recalc-pill` is preserved on remote for reference but should be considered obsolete; the redesign in section 4 will land as a fresh PR.
+
+The existing infrastructure is partially salvageable:
+
+- ✅ The banner on `/vetting/[asin]` looks right and Dave likes the visual treatment — keep the markup, just rewire the click action.
+- ✅ `/api/analyze` already exposes `lensPendingRecalc` on each submission (commit `68dce8c`). That data plumbing is fine.
+- ❌ The redirect to `/submission/[id]?triggerRecalc=1` is wrong destination — that's the public-share renderer, missing the proper navigation chrome.
+- ❌ The auto-fire of `handleCompetitorsUpdated` in submission/[id] is wrong because it leverages the *adjustment* (removal) data model for what is conceptually an *addition*.
+- ❌ The `__lens_pending_recalc=false` clear in PATCH `action='adjust'` is fine in isolation but predicated on the wrong event semantics.
+
+---
+
+## 3. Repo state (end of day 2026-05-07)
+
+| Repo | Branch | Tip | Status |
+|---|---|---|---|
+| bloomengine | `main` | `3164865` | **Production. Vercel deployed.** Phase 5.4-N tier fix + r8 calibration live. |
+| bloomengine | `dev` | `4cbdea0` | Synced with main (PR #27 promoted dev → main; merge commit `3164865` lives on main only). Should be fast-forwarded to `3164865` at session start tomorrow. |
+| bloomengine | `phase-5.4-N-vetting-recalc-pill` (local + remote) | `68dce8c` | **Obsolete — kept for reference.** PR #28 closed. Delete after Phase 5.4-O ships. |
+| bloom-lens-extension | `phase-5-2-bottom-drawer-pivot` | `46028a2` | **v0.5.8 uploaded to Web Store, awaiting approval.** |
+
+### MEMORY.md additions today
+
+- `project_recalc_cap_enforcement_deferred.md` — both `/vetting/[asin]` Lens-triggered + `/submission/[id]` manual recalcs run uncapped today. Wire vetting cap into both during recalc rework. **Spec'd to be addressed as part of 5.4-O — see section 4.6.**
+
+---
+
+## 4. Phase 5.4-O — "Market Expansions" redesign (LOCKED 2026-05-07)
+
+**This is tomorrow's primary work.** Read this section carefully before writing any code.
+
+### 4.0 Background — why we're redesigning
+
+Since Phase 5.4-D, BloomLens has had a "Add to existing market" flow on `/api/extension/analyze-market` that appends competitors to a vetted market and sets `submission_data.__lens_pending_recalc = true`. Until PR #28 (today) no UI surface read the flag. PR #28 shipped a banner + recalc trigger that **leveraged the existing remove-competitors adjustment system** to also handle additions.
+
+That conflation is the root problem. Adjustments (removing weak competitors) and Expansions (finding more competitors via different search terms) are **two fundamentally different mental models**. Forcing them through the same data model + UI produced eight distinct UX problems below.
+
+### 4.1 Dave's testing feedback (verbatim, 2026-05-07 ~7:50 PM)
+
+Dave added 3-4 new ASINs to an existing market via BloomLens, then tested the recalc flow on the Vercel preview. His 8 observations:
+
+1. **Banner appearance: keep it.** "I like the way the banner looks."
+2. **Wrong destination on Recalculate click.** "When I hit recalculate, it actually opens it up into the share view, not into the actual view that the user should be seeing. The product header is missing."
+3. **"Adjusted view — 0 competitors removed" copy is wrong.** "I don't like that the adjusted view says zero competitors removed. We should think of a new way of saying that because I don't even know if we need to say that it's adjusted at all because they are adding competitors ongoing, presumably. Especially if it's a new market that they're trying different Amazon search terms on, looking for more and more competitors."
+4. **New comps come in with missing matrix columns.** Dave verified by checking the row for the newly-added competitor (Tlaleikejia, B0FJ5HKBPX). Missing values in: **Category, Variations, Fulfilled By, Seller Count, Active Sellers, Product Weight, Sold By**.
+5. **"Reset to original" copy doesn't make sense in this context.** The modal says "Undo all competitor removals" + "0 currently removed" — nonsensical when the user added (didn't remove) comps.
+6. **Reset doesn't actually remove the added competitors.** The button does nothing useful for the addition case.
+7. **Need a "New Competitors" badge on the Vetting Dashboard list** (not just on the detail page).
+8. **Whole framing wrong: addition ≠ adjustment.** "If we are adding new competitors to a market, we should be treating it in a different way that is building up the market rather than saying it has been altered and taken down. Think of a creative way to put this together that matches the experience of finding more competitors in your niche and building up a market to get a full perspective."
+
+### 4.2 Root-cause diagnosis (per-issue → cause)
+
+| # | Symptom | Root cause |
+|---|---|---|
+| 2 | Recalc opens "share view" without ProductHeader | PR #28's redirect goes to `/submission/[id]` which is the public-share renderer (a different page than `/vetting/[asin]`). The recalc handler lived there because it was authored for a different use case. |
+| 3 | "Adjusted view — 0 competitors removed" | PR #28 leveraged the *removal* `adjustment` data model to also persist Lens *additions*. The UI banner under the score reads `submission_data.adjustment` and renders generic "adjusted" copy. |
+| 4 | Missing matrix columns | `/api/extension/analyze-market` accepts `ScrapedRow` from BloomLens which has `bsr/price/units/rating/reviews/weightLb/sizeTier/variationCount/seller` but **not** `category` and **not** PDP-only fields like `fulfilledBy/sellerCount/activeSellers/soldBy`. Recalc currently runs Keepa for top 5 by revenue only — it doesn't backfill the new comps' missing columns. |
+| 5–6 | "Reset to original" copy + reset doesn't actually undo | `originalSnapshot` is captured on the *first* PATCH `action='adjust'`. PR #28's auto-recalc was that first adjust — so the snapshot was taken **after** Lens already merged the new comps into `productData.competitors` via the analyze-market route. Reset restores to that post-merge state, not pre-Lens-merge state. The reset is doing exactly what it was built to do; it was just never built for this flow. |
+| 7 | No badge on vetting list | Never built. |
+| 8 | Whole framing wrong | One concept ("adjustment") forced to handle two semantically opposite operations (remove / add). Needs separation. |
+
+### 4.3 The redesign — "Market Expansions" data model
+
+Two distinct concepts on `submission_data`:
+
+```typescript
+submission_data: {
+  productData: { competitors: [...] },        // canonical, post-merge
+  marketScore, metrics, ...
+
+  // EXISTING — for removals (manual edit-competitors flow):
+  adjustment: {
+    removedAsins: string[],
+    adjustedScore: number,
+    adjustedAt: string,
+  },
+  originalSnapshot: { /* pre-FIRST-adjustment state */ },
+
+  // NEW — for additions (BloomLens-driven):
+  lensExpansions: [
+    {
+      addedAsins: string[],                    // the ASINs added in this single expansion event
+      addedAt: string,                         // ISO timestamp
+      source: 'bloom-lens',                    // future-proofs against other expansion sources
+      scoreBefore: number,                     // score before this expansion (after Keepa enrich + recompute)
+      scoreAfter: number,                      // score after this expansion
+      preExpansionSnapshot: {                  // for per-expansion undo
+        productData: { competitors: [...] },   // pre-merge competitor list
+        marketScore, metrics, keepaResults, ai_summary,
+      },
+      acknowledged: boolean,                   // false until user clicks Recalculate or otherwise dismisses
+    },
+    // ... one entry per expansion event over the market's lifetime
+  ],
+}
+```
+
+**Critical separation rules:**
+
+- An `adjustment` is **one** persistent state — removing more comps overwrites it. There's only ever zero or one adjustment.
+- A `lensExpansions` is an **append-only log** — each Lens-driven add creates a new entry with its own snapshot. Multiple expansions can stack.
+- Reset flows are independent: "Reset to original" only operates on `adjustment`. "Undo this expansion" operates on a single `lensExpansions[i]`.
+- Both can coexist: a user can have both an adjustment (removed weak comps) AND multiple expansions (added more comps over time). The canonical `productData.competitors` reflects all of it merged.
+
+### 4.4 Behavior changes mapped to Dave's 8 points
+
+| # | What changes |
+|---|---|
+| 1 | **Banner preserved.** Same markup as PR #28 (`AlertCircle` + amber background + "New competitors detected" + "Recalculate" CTA). Lift the inline JSX in `VettingDetailContent.tsx` from PR #28's diff. |
+| 2 | **Recalculate runs INLINE on `/vetting/[asin]`.** No redirect. Click → spinner state in the banner ("Recalculating..."), client calls a new endpoint `POST /api/submissions/[id]/lens-recalc`, page rerenders with new score / metrics / banner gone. The `/submission/[id]` recalc handler is left untouched — it's a different code path for the manual remove-competitors flow. |
+| 3 | **No "Adjusted view" banner for expansions.** Replace with a different element near the score: a small green "+3 comps from BloomLens · 2 hours ago" pill with a hover-link "View expansion history". Score change is framed as growth: "Score updated to 51.1% as competitors were added" — not "Adjusted from 51.8% to 51.1%". |
+| 4 | **Field-gap fix during recalc.** The new endpoint runs Keepa enrichment on the **newly-added comps** (not just top 5 by revenue) to backfill: `category`, `variations`, `productWeight`. The PDP-only fields Lens genuinely can't capture from a SERP scrape — `fulfilledBy`, `sellerCount`, `activeSellers`, `soldBy` — stay as `—` BUT add a tooltip to the `—` cells explaining "Available after a fresh Helium 10 vetting on this ASIN" or similar honest copy. Maintain the cap-rule from Dave's 5.4-N spec: **count the recalc against the user's vetting cap** (since it's the same compute as a fresh vetting — Keepa enrich + scoring + AI summary regen). See section 4.6 for the cap-enforcement requirement that's now coupled with this work. |
+| 5–6 | **Reset modal becomes context-aware.** If `adjustment` exists → current "Reset to original" copy shown. If `adjustment` is null but `lensExpansions` is non-empty → no Reset button at the score level. Per-expansion undo is in the expansion-history panel: each entry has an "Undo this expansion" link that removes just that batch's `addedAsins` and restores from that entry's `preExpansionSnapshot`. |
+| 7 | **Vetting Dashboard badge.** On the `/vetting` list page, rows whose submission has `lensExpansions.some(e => !e.acknowledged)` get a small green pill: "+N new" (where N is the count of unacknowledged additions across all expansions). Pill clears when the user opens the detail page (mark all as `acknowledged: true`) OR when they click Recalculate (which resolves the recalc-pending state for the latest expansion). |
+| 8 | **Reframe everything as growth.** New language model:<br>• Banner copy stays "New competitors detected" (active, not adjustment language).<br>• Score-change copy: "**Score updated** as competitors were added" — not "Adjusted score" or "Score changed."<br>• Pill copy: "**+3 from BloomLens**" — additive symbol.<br>• Reset modal title for adjustments: unchanged.<br>• Per-expansion undo title: "**Remove these 3 competitors?**" — surgical, not "Reset". |
+
+### 4.5 Endpoint changes
+
+#### NEW: `POST /api/submissions/[id]/lens-recalc`
+
+Replaces the redirect-to-/submission/[id] approach.
+
+```typescript
+// Auth: bearer token (same pattern as other /api/submissions/* routes)
+// Body: empty (server reads everything from submission_data)
+
+// Behavior:
+// 1. Load submission, RLS check, find latest unresolved expansion (one without
+//    a populated scoreAfter)
+// 2. Run cap check via checkCap(supabase, userId, 'vetting'). 402 if exceeded.
+// 3. Fetch Keepa for ALL newly-added ASINs in the latest expansion (to backfill
+//    category, variations, productWeight). Plus top 5 by revenue across the
+//    full competitor set for the score recompute (existing pattern).
+// 4. Recompute marketScore + metrics with the merged competitor set.
+// 5. Regenerate AI summary (mirrors fresh vetting flow).
+// 6. Persist:
+//    - Update submission row with new score, status, metrics
+//    - Update submission_data.productData.competitors with backfilled fields
+//    - Update submission_data.lensExpansions[latest].scoreBefore + scoreAfter
+//    - Set submission_data.lensExpansions[latest].acknowledged = true
+//    - Clear submission_data.__lens_pending_recalc (legacy flag, drop after one cycle)
+// 7. Record vetting usage event (for cap counting) — see section 4.6.
+// 8. Return updated submission.
+```
+
+#### MODIFIED: `POST /api/extension/analyze-market` (mode=append)
+
+When appending competitors to an already-vetted market:
+
+- Stop setting `__lens_pending_recalc = true` (legacy — replaced by lensExpansions presence).
+- BEFORE merging new comps into `productData.competitors`, snapshot the current state as `preExpansionSnapshot`.
+- Append a new entry to `submission_data.lensExpansions[]` with `addedAsins`, `addedAt`, `source: 'bloom-lens'`, `preExpansionSnapshot`, `acknowledged: false`. `scoreBefore`/`scoreAfter` left null until recalc.
+- Then merge the comps into `productData.competitors` (existing behavior).
+
+#### NEW: `POST /api/submissions/[id]/undo-expansion`
+
+```typescript
+// Body: { expansionId: string }  (the addedAt timestamp acts as the ID)
+// Behavior:
+// 1. Load submission. Find the expansion entry by addedAt match.
+// 2. Restore productData.competitors from that entry's preExpansionSnapshot.
+// 3. Restore marketScore, metrics, keepaResults, ai_summary from preExpansionSnapshot.
+// 4. Remove that expansion from lensExpansions[].
+// 5. Persist + return updated submission.
+//
+// Note: this is "remove THIS batch only" semantics. Earlier expansions stay
+// intact. If the user undoes the second expansion of three, expansion 1 and 3
+// are preserved. The preExpansionSnapshot was captured at the moment of THIS
+// expansion, so restoring it returns to the state right before this batch
+// landed — which is correct.
+```
+
+#### MODIFIED: `/api/analyze` (GET)
+
+Already exposes `lensPendingRecalc` (commit `68dce8c`). Replace with:
+
+```typescript
+lensExpansions: sub.submission_data?.lensExpansions || [],
+hasUnacknowledgedExpansion: (sub.submission_data?.lensExpansions || []).some(e => !e.acknowledged),
+```
+
+Drop the legacy `lensPendingRecalc` flag from the response after one deploy cycle (so any cached client state has time to refresh).
+
+### 4.6 Cap enforcement — REQUIRED for 5.4-O
+
+Per `project_recalc_cap_enforcement_deferred.md` memory: the deferred cap enforcement is **part of 5.4-O scope**, not a follow-up. The new `/api/submissions/[id]/lens-recalc` endpoint MUST:
+
+1. Call `checkCap(supabase, userId, 'vetting')` before doing the Keepa fetch.
+2. Return 402 with the standard cap-modal payload (see `/api/analyze` POST for the canonical shape) when exceeded.
+3. Record a `usage_events` row with `provider='extension'`, `operation='vetting'` (or whatever the canonical vetting operation tag is — verify against `cap.ts`) on success.
+
+This is non-negotiable because shipping the inline recalc without cap creates a workaround: a Pro-blocked Core user who's hit their vetting limit could spam BloomLens "Add to existing" → recalc to consume Keepa tokens at no cost. Capping the Lens-triggered path closes that loophole.
+
+The MANUAL recalc on `/submission/[id]` (existing remove-competitors flow) ALSO needs cap enforcement to keep the two paths uniform — but that's a separate file (`/submission/[id]/page.tsx::handleCompetitorsUpdated`) and a separate endpoint (`/api/submissions/[id]` PATCH `action='adjust'`). Add the cap check to PATCH `action='adjust'` in the same PR so it ships together.
+
+### 4.7 UI changes
+
+#### `/vetting/[asin]` (`VettingDetailContent.tsx`)
+
+1. Lift the banner JSX from PR #28's diff (commit `68dce8c`) — same markup, replace the click handler.
+2. New click handler: inline POST to `/api/submissions/[id]/lens-recalc`. Show banner spinner state during the call. On success: `setSubmission(updated)` to rerender with new score; banner self-hides because `lensExpansions[latest].acknowledged === true`.
+3. NEW component: small "+3 comps from BloomLens · 2 hours ago" pill near the score (replaces the "Adjusted view" banner for expansion-only cases). Hover-link to expansion history.
+4. NEW expansion-history panel (collapsed by default, accessed via the pill hover-link): one row per expansion entry showing `addedAt`, `addedAsins.length`, `scoreBefore → scoreAfter`, and an "Undo" button per row. Each Undo posts to `/api/submissions/[id]/undo-expansion`.
+5. Existing "Adjusted view" banner stays gated on `submission.adjustment` (removals only). No change to that branch.
+
+#### `/vetting` list page
+
+Adds the "+N new" pill on rows where `submission.hasUnacknowledgedExpansion === true`. Cleared when the user navigates to the detail page (mark-as-read on detail mount) OR explicitly via Recalculate.
+
+#### `/submission/[id]` (the public-share renderer)
+
+NO changes for 5.4-O. The auto-fire `useEffect` from PR #28 that detects `?triggerRecalc=1` should be deleted as part of the cleanup since no surface navigates there with that param anymore. Same for the `useRef` guard. Strip the unused `useSearchParams` import after deletion.
+
+#### Competitor matrix tooltips
+
+For PDP-only columns (`Fulfilled By`, `Seller Count`, `Active Sellers`, `Sold By`), when value is `—` AND the row is from a Lens expansion (track via a `__source: 'bloom-lens'` marker on the competitor object set during analyze-market merge), show a tooltip on hover: "BloomLens captures from Amazon SERP — this field is only available after a fresh Helium 10 vetting upload."
+
+### 4.8 Implementation plan / order of operations
+
+Estimated total: **4–6 hours of careful work.** Recommend splitting across two PRs to make review tractable:
+
+**PR A — Data model + backend** (~2 hours):
+1. Add `lensExpansions` to `analyze-market` route (mode=append branch). Snapshot before merge.
+2. Build `/api/submissions/[id]/lens-recalc` endpoint with cap enforcement.
+3. Build `/api/submissions/[id]/undo-expansion` endpoint.
+4. Add cap enforcement to existing PATCH `action='adjust'` (close the workaround loophole).
+5. Update `/api/analyze` GET to expose `lensExpansions` + `hasUnacknowledgedExpansion`.
+6. Drop the legacy `__lens_pending_recalc` flag from analyze-market (leave one deploy of dual-write if paranoid).
+
+**PR B — UI** (~2-3 hours):
+1. Rewire `VettingDetailContent.tsx` banner click to call lens-recalc inline.
+2. Add the "+N from BloomLens" pill near the score.
+3. Build the expansion-history panel + per-expansion undo UI.
+4. Add the "+N new" badge to the `/vetting` list page.
+5. Strip the auto-fire useEffect from `/submission/[id]/page.tsx` (cleanup from PR #28).
+6. Add tooltips to the PDP-only matrix cells when value is `—` on Lens-sourced rows.
+
+Both PRs target `dev`, then promote together via dev → main when validated on Vercel preview.
+
+### 4.9 What NOT to break
+
+- The manual remove-competitors flow on `/submission/[id]` MUST still work end-to-end after this PR. Its `handleCompetitorsUpdated` handler is a separate code path — don't refactor it unless something else in 5.4-O requires it.
+- The `originalSnapshot`-based reset for adjustments must still work. Snapshot semantics ARE different from expansions — keep them separate.
+- Existing submissions (zero-state — no `lensExpansions` field on submission_data) must render fine. Default to `[]` everywhere it's read.
+- The Vercel preview build of any PR should be tested by Dave end-to-end before merging — this flow is too easy to get subtly wrong.
+
+### 4.10 Acceptance criteria
+
+A 5.4-O ship is "done" when:
+
+- [ ] User on `/vetting/[asin]` sees the banner when fresh comps are pending. ✓ markup lifted from PR #28.
+- [ ] Click Recalculate → spinner inline, no page bounce, score + metrics update.
+- [ ] After recalc, banner is gone. New "+N from BloomLens · X minutes ago" pill present near score.
+- [ ] Hovering the pill reveals an expansion-history panel listing each expansion event.
+- [ ] Clicking "Undo" on an expansion entry restores the pre-expansion state for that batch only (other expansions preserved).
+- [ ] On `/vetting` list, the row shows "+N new" badge when `hasUnacknowledgedExpansion === true`. Badge clears on detail-page open or recalc.
+- [ ] New competitors from Lens have backfilled `category`, `variations`, `productWeight` post-recalc.
+- [ ] PDP-only fields (`fulfilledBy`, `sellerCount`, `activeSellers`, `soldBy`) on Lens-sourced rows show `—` with tooltip explaining the limitation.
+- [ ] Cap enforcement: a Core user at vetting limit gets 402 with cap-modal payload when clicking Recalculate. PATCH `action='adjust'` (manual recalc) also enforces.
+- [ ] No Stripe-hosted page redirects (rule unchanged but easy to forget — cap-modal renders in-app).
+- [ ] No "Keepa" or "Helium 10" in user-facing copy. The PDP-tooltip mentions Helium 10 as a vetting source — that's a known exception (the user provides H10 CSVs, they know the name) but verify the tooltip copy with Dave before shipping.
+
+---
+
+## 5. Sprint A status
+
+| Item | Status |
+|---|---|
+| 5.4-I sub-category granularity | ✅ shipped 2026-05-06 |
+| 6 new band-aware category calibrations | ✅ shipped 2026-05-06 |
+| Web Store v0.5.7 upload | ✅ shipped earlier this week |
+| Web Store v0.5.8 upload | ✅ uploaded 2026-05-07 (awaiting reviewer approval) |
+| **r8: refit existing 12 categories with bands** | ✅ shipped 2026-05-07 (PR #26) |
+| **Recalc pill on `/vetting/[asin]`** | 🔄 **deferred to 5.4-O — see section 4** |
+| Re-enable extension detection | ⏳ Open — pending v0.5.8 reviewer approval + propagation |
+| BloomLens UI polish backlog | ⏳ Open — see `project_bloom_lens_ui_polish_backlog.md` |
+| PRO-paywall regression verify | ✅ verified during PR #25 work — fix from `b4922a3` is working; mentorship Pro users see no upsell on extension popup |
+
+---
+
+## 6. Sprint C status
+
+Started item 1 (Mandatory-vs-nice field indicators) during today's session, paused at the design-question stage. **No commits, no branch state to recover.**
+
+The exploration found:
+- `placeOrderSchema.ts` already has `required: boolean` on every field — the data is canonical.
+- `PlaceOrderChecklist.tsx` already separates required from optional structurally (the optional section is currently commented out / hidden).
+- `SupplierQuotesTab.tsx` (2,970 LOC) has a `getRequiredFieldClass` helper but no inline label asterisks.
+
+Open design questions queued for tomorrow:
+1. Indicator style: red asterisk on required only, OR asterisk + "(optional)" on optional, OR pill badges.
+2. Scope: just SupplierQuotesTab, or sweep all sourcing tabs.
+
+---
+
+## 7. What's blocked / awaiting Dave
+
+1. **Re-enable extension detection** in `src/hooks/useExtensionInstalled.ts` — delete the `return false;` early-return at the top once v0.5.8 propagates to existing users' browsers (typically 1-7 days post-Web-Store-approval).
+2. **5.4-O kickoff decision** — proceed with the section 4 redesign as spec'd, or iterate further before code starts? (Default: proceed.)
+3. **Sprint C item 1 design call** — pick indicator style + scope before re-starting.
+
+---
+
+## 8. V9 remaining roadmap (sprint order: A → E → D → B → C)
+
+### Sprint A — Phase 5 wrap-up
+**Mostly done.** 5.4-O closes the last meaningful UX gap (Recalc pill / expansion handling). Web Store v0.5.8 detection re-enable is the only carry-over after that.
+
+### Sprint E — Public launch readiness (biggest open scope)
+Unchanged from yesterday's handoff. Strategic decisions still owed:
+- Soft-launch shape (invite-only beta cohort vs open Web Store)
+- Monitoring (Sentry vs Vercel logs)
+- Support channel (email vs Skool vs in-app chat)
+- Pricing page polish vs full marketing site
+- Onboarding tour scope
+- Demo video timing
+- Real case-study testimonials
+
+### Sprint D — Phase 7 Billing
+**Core scope shipped 2026-05-06.** Polish backlog (low-priority):
+- Update payment method UX (no in-app card change today)
+- Switch billing interval mid-subscription (proration math)
+- Trial-fail-to-convert grace period
+
+### Sprint B — Pre-Vetting / Market Climate polish
+9 items in `project_market_climate_v2_polish.md` (2026-04-25 vintage). Verify still current before starting.
+
+### Sprint C — Phase 6 Sourcing polish
+- Mandatory-vs-nice field indicators (started, paused)
+- Supplier comparison view
+- SP-API auto-fetch FBA fees
+- PO contract PDF + info-collection popup
+
+---
+
+## 9. Standing rules (don't break)
+
+1. PRs target `dev`, never `main` without explicit instruction.
+2. After committing, pause and wait for confirmation before merging or pushing.
+3. Don't punt the merge to Dave — push + PR + merge are mine to drive.
+4. Never combine commit + merge + push in one chained command.
+5. **NO ROUND NUMBERS in displayed metrics.** BSR-curve drives display, full stop.
+6. No "Keepa" in user-facing copy. (Helium 10 is a known exception when the user provided the CSV — see 4.10.)
+7. "BloomLens" is one word in user-facing surfaces.
+8. **No Stripe-hosted page redirects.** All checkout/billing flows render inside BloomEngine via Stripe Embedded.
+9. Tolerance-based numeric checks for AI / rounded values (`Math.abs(sum - 100) < 2`).
+10. Production deploys from `main`. Dev = preview.
+11. Never sacrifice one BSR band's accuracy for another's (calibration vision rule).
+12. Any new button in `entrypoints/content/` must use `window.open` (or message background SW), not `chrome.tabs.*`.
+13. Sensitive env vars in Vercel must drop the Development environment scope (Vercel constraint).
+14. **`effectiveTier` ≠ `tier` for display.** `effectiveTier` is the cap-governing tier (Pro during any trial). `tier` is what the customer purchased. Display the latter; gate caps on the former.
+15. **NEW (2026-05-07): Adjustments and Expansions are separate concepts.** Don't conflate them in shared data structures. Removals = `submission_data.adjustment`. Additions = `submission_data.lensExpansions[]`.
+
+---
+
+## 10. Tomorrow's first message to Claude
+
+Use the kickoff prompt at: `docs/handoffs/phase-5.4-O-kickoff-prompt.md`

--- a/docs/handoffs/phase-5.4-O-kickoff-prompt.md
+++ b/docs/handoffs/phase-5.4-O-kickoff-prompt.md
@@ -1,0 +1,65 @@
+Picking up after a heavy 2026-05-07 session that closed Phase 5.4-N. Three PRs shipped clean to main (PR #25 extension tier mislabel, PR #26 r8 band-aware calibration, PR #27 dev → main promotion). A fourth PR (#28 Recalc pill) was closed after preview testing surfaced architectural issues. The full rework is now spec'd as Phase 5.4-O — the "Market Expansions" redesign — and is the kickoff item for today.
+
+Read in this order:
+
+1. docs/handoffs/phase-5.4-N-shipped-and-lens-redesign.md — the full handoff. **Section 4 is the locked redesign spec for Phase 5.4-O.** It is detailed for a reason — Dave's testing surfaced 8 distinct issues with the previous attempt, and the redesign has to address all of them coherently. Read every subsection (4.0 through 4.10) before writing any code.
+2. MEMORY.md — durable rules, especially the new rule #15 (Adjustments and Expansions are separate concepts), `feedback_no_stripe_redirects.md`, `project_recalc_cap_enforcement_deferred.md` (now coupled with 5.4-O scope), and the existing rule #14 (effectiveTier ≠ tier).
+3. docs/handoffs/phase-5.4-N-kickoff-prompt.md — yesterday's kickoff for context on the V9 sprint order (A → E → D → B → C). Sprint A is mostly done; 5.4-O closes the last meaningful UX gap before Sprint E.
+
+Verify production is healthy first:
+git log -3 main           # top should be 3164865 "Merge pull request #27 from growwithfba/dev"
+curl -s -o /dev/null -w "%{http_code}\n" https://www.bloomengine.ai/api/subscription/usage    # expect 401
+curl -s -o /dev/null -w "%{http_code}\n" https://www.bloomengine.ai/api/extension/me   # expect 401
+
+---
+DON'T immediately code. This is the most important instruction.
+
+The Phase 5.4-O redesign spec is locked but it touches a lot of surface area — endpoints, data model, UI in two places. Before any code, walk Dave through three things:
+
+Step 1 — Confirm the spec is still current
+
+Read section 4 of the handoff doc carefully. Then ask Dave:
+- Anything he wants to change about the spec overnight? (Common: someone sleeps on a design and wants to tweak it.)
+- Should we proceed with the two-PR split (PR A backend + data model, PR B UI) recommended in section 4.8, or one big PR?
+- Cap enforcement on the manual recalc PATCH `action='adjust'` is bundled into 5.4-O scope per section 4.6 — is that still right, or does he want to defer that piece again?
+
+Step 2 — Pick the cleanup wins to start with (~5 min)
+
+A few small items should land BEFORE 5.4-O code starts:
+- Fast-forward `dev` to match `main` at session start (`git checkout dev && git pull --ff-only origin main` — they diverged because PR #27 created a merge commit on main only).
+- Delete the obsolete remote branch `phase-5.4-N-vetting-recalc-pill` after Dave confirms PR #28 closure is final and no salvage is needed beyond what section 2 of the handoff already documented.
+- Confirm Web Store v0.5.8 reviewer status — if approved + propagated, re-enable extension detection in src/hooks/useExtensionInstalled.ts (delete the `return false;` early-return).
+
+Step 3 — Sprint C item 1 design questions
+
+Sprint C item 1 (Mandatory-vs-nice field indicators) was started yesterday and paused at design questions. Two open calls (use AskUserQuestion):
+
+a. Indicator style:
+- Red asterisk on required only (HTML form convention, lowest noise)
+- Asterisk on required + "(optional)" suffix on optional (most explicit, matches Dave's "mandatory-vs-nice" framing)
+- Pill badges on each field (highest visibility, possibly too noisy for 30+ field forms)
+
+b. Scope:
+- Just SupplierQuotesTab (~30 min, highest-traffic form)
+- All sourcing tabs (60-90 min, full sweep)
+- SupplierQuotes + PlaceOrderChecklist (~45 min)
+
+Note: Sprint C item 1 should be a SECONDARY track for the day. 5.4-O is the priority. Only spin Sprint C up if 5.4-O is blocked or paused for review/testing.
+
+---
+
+Standing rules (don't break):
+- PRs target `dev`, never `main` without explicit instruction.
+- After commits, pause for push confirm.
+- Don't punt merges to Dave — push + PR + merge are mine to drive.
+- Never combine commit + merge + push.
+- No round numbers in displayed metrics.
+- No "Keepa" in user-facing copy.
+- "BloomLens" is one word.
+- No Stripe-hosted redirects.
+- Production = main, dev = preview.
+- effectiveTier is for cap gating only; display the user's tier.
+- Pixel-match Bloom Lens to BloomEngine app before any Lens UI change.
+- **NEW: Adjustments and Expansions are separate concepts.** Removals = submission_data.adjustment. Additions = submission_data.lensExpansions[]. Don't conflate them.
+
+5.4-O acceptance criteria are in section 4.10 of the handoff. Use those as the test plan when the Vercel preview is up — Dave will be testing this end-to-end, and the previous attempt taught us that subtle cross-page navigation issues only surface in real preview testing.

--- a/docs/handoffs/phase-5.4-O-shipped.md
+++ b/docs/handoffs/phase-5.4-O-shipped.md
@@ -1,0 +1,170 @@
+# Phase 5.4-O shipped — Market Expansions to production (2026-05-08 EOD)
+
+**Production state:** `main` at `476d48e` (deployed). Phase 5.4-O Market Expansions redesign is live end-to-end. Three PRs merged today; multi-expansion stacking validated on the Vercel preview before promotion.
+
+---
+
+## 1. What shipped
+
+### Production progressed `3164865` → `476d48e` (3 merge commits + 5 underlying)
+
+| Commit | What |
+|---|---|
+| `357ad79` (PR #29) | **Phase 5.4-O PR A — backend + data model.** New `submission_data.lensExpansions[]` append-only log with per-batch `preExpansionSnapshot`. New endpoints: `POST /api/submissions/[id]/lens-recalc` (fetches Keepa for unresolved-expansion ASINs ∪ top-5, backfills category/productWeight/variations/brand on Lens-sourced rows, recomputes score + AI summary, marks unresolved as resolved + acknowledged); `POST /api/submissions/[id]/undo-expansion` (per-batch restore from `preExpansionSnapshot`). Cap enforcement on lens-recalc AND PATCH `action='adjust'` — closes the spam-append → recalc loophole. `/api/analyze` GET surfaces `lensExpansions` + `hasUnacknowledgedExpansion`. Shared `deriveSummaryMetrics` helper extracted so generate-summary and lens-recalc share the AI-briefing input contract. `cap.ts` vetting cap now counts `submissions` rows + `usage_events.operation = 'vetting_recalc'`. |
+| `34f559a` (PR #30) | **Phase 5.4-O PR B — UI + cleanup.** Recalculate banner appears when `lensExpansions.some(e => e.scoreAfter == null)`. Click runs `lens-recalc` inline (no `/submission/[id]?triggerRecalc=1` redirect). `+N from BloomLens · X ago` emerald pill replaces the banner post-recalc; click toggles a history panel with per-entry `Undo` (window.confirm gated). `+N new` emerald badge on `/vetting` list rows where `hasUnacknowledgedExpansion`. PDP-only matrix tooltips on `__lens_origin` rows for fulfillment/sellerCount/activeSellers/soldBy ("Captured from Amazon search results — fills in when you vet from a Helium 10 CSV"). New `mark-expansions-read` endpoint clears the dashboard badge on detail-page mount. Drops the legacy `__lens_pending_recalc` dual-write from analyze-market. |
+| `e76d080` (PR #30) | **Fix-ups from preview testing.** `/api/extension/markets` joins `research_products.display_name` so the BloomLens "Add to existing market" picker shows the renamed market label (was showing the original ASIN listing title even after the user renamed in BloomEngine). Legacy `__lens_pending_recalc` fallback so the banner works on data created before this lands: `/api/analyze` exposes `lensPendingRecalcLegacy`, banner condition reads it, lens-recalc accepts the legacy-only path (uses `__lens_new` flagged competitors as the Keepa-backfill target) and synthesizes a `lensExpansions` entry post-recalc so the pill + history panel show. Synthesized entries have `preExpansionSnapshot: null` and the Undo button is gated on snapshot presence. |
+| `aced1a3` (PR #30) | **Banner copy tightening.** Old copy promised "refresh the score, market metrics, and AI summary" but Market Cap / Rev-per-Comp / Total Competitors don't change at recalc time (they're derived client-side from `competitors`, which already updated at BloomLens-append time). New copy: "refresh the score, stability signals, and AI briefing using the latest sales-rank data for the new competitors." |
+| `476d48e` (PR #31) | **dev → main promotion.** Both 5.4-O PRs shipped to production together. |
+
+### End-to-end validated on Vercel preview before promotion
+
+- ✅ Banner appears on legacy-data markets (legacy fallback path)
+- ✅ Click Recalculate → spinner inline, score updated `22.6% → 25.9%`
+- ✅ AI briefing fully regenerated to reflect new top-5 stats
+- ✅ BSR / Price Stability transitioned `Moderate → Stable` (Keepa-driven signals)
+- ✅ Banner replaced by `+1 from BloomLens · just now` pill
+- ✅ Expansion-history panel shows the entry with score delta
+- ✅ Dashboard `+N new` badge clears on detail-page open
+- ✅ **Multi-expansion stacking** — Dave sent two ASINs via two separate BloomLens search sessions to the same market, then ran a single Recalculate. The append-only log captured both expansion events; one recalc resolved both in a single pass with the same `scoreAfter`. Spec section 4.4 row 8 design intent confirmed working.
+
+---
+
+## 2. Files changed today (13 files; +1593 / -234)
+
+### New
+
+- `src/app/api/submissions/[id]/lens-recalc/route.ts` — 463 lines. Inline recalc endpoint.
+- `src/app/api/submissions/[id]/undo-expansion/route.ts` — 163 lines. Per-batch restore.
+- `src/app/api/submissions/[id]/mark-expansions-read/route.ts` — 113 lines. Dashboard badge clear.
+- `src/lib/vetting/deriveSummaryMetrics.ts` — 160 lines. Shared AI-briefing metric derivation.
+
+### Modified
+
+| File | Why |
+|---|---|
+| `src/app/api/analyze/route.ts` | GET response exposes `lensExpansions`, `hasUnacknowledgedExpansion`, `lensPendingRecalcLegacy`. |
+| `src/app/api/extension/analyze-market/route.ts` | mode=append snapshots + appends a `lensExpansions[]` entry on vetted markets. Field-name aliases `productWeight` + `variations` so the matrix reads them. Drops legacy `__lens_pending_recalc` dual-write at the end. |
+| `src/app/api/extension/markets/route.ts` | Joins `research_products.display_name` for the picker label. |
+| `src/app/api/submissions/[id]/route.ts` | PATCH `action='adjust'` adds cap-check (402 with cap-modal payload) + records `vetting_recalc` usage_event on success. |
+| `src/app/api/vetting/generate-summary/route.ts` | Refactored to import the shared `deriveSummaryMetrics`. |
+| `src/components/Results/ProductVettingResults.tsx` | `wrapWithLensTooltip` helper for PDP-only columns on `__lens_origin` rows. |
+| `src/components/Vetting/VettingDetailContent.tsx` | Banner + pill + history panel + handlers for lens-recalc, undo-expansion, mark-as-read. CapReachedModal hookup. Imports + state additions. |
+| `src/components/dashboard/Dashboard.tsx` | New `NewExpansionBadge` (emerald, mirrors AdjustedBadge style). Stacks beside AdjustedBadge in the score column. |
+| `src/lib/subscription/cap.ts` | `vetting` cap counts `submissions` rows + `usage_events.operation = 'vetting_recalc'`. |
+
+---
+
+## 3. Repo state (end of day 2026-05-08)
+
+| Repo | Branch | Tip | Status |
+|---|---|---|---|
+| bloomengine | `main` | `476d48e` | **Production. Vercel deployed.** Phase 5.4-O live. |
+| bloomengine | `dev` | `476d48e` | Synced with main (PR #31 promoted dev → main). |
+| bloom-lens-extension | `phase-5-2-bottom-drawer-pivot` | `46028a2` | **v0.5.8 still awaiting Web Store reviewer approval** (carried over from yesterday). |
+
+### Branches deleted today
+
+- `phase-5.4-N-vetting-recalc-pill` (closed PR #28; obsolete with 5.4-O shipped)
+- `phase-5.4-O-backend` (PR #29 merged)
+- `phase-5.4-O-ui` (PR #30 merged)
+
+### MEMORY.md additions today
+
+- `feedback_bloomlens_hits_production.md` — testing rule about BloomLens always hitting prod regardless of which preview is active.
+- `project_phase_5_4_o_state.md` — full shipped state.
+
+---
+
+## 4. What's blocked / open
+
+### Carry-overs (not blocked, just awaiting external)
+
+1. **Web Store v0.5.8 reviewer approval** — Google review in progress. Once approved + propagated (typically 1–7 days), delete the `return false;` early-return at the top of `src/hooks/useExtensionInstalled.ts` to re-enable detection.
+
+### Real-data E2E now possible (was blocked yesterday)
+
+2. **Undo on fresh expansions** — `lensExpansions` now writes proper `preExpansionSnapshot` on every BloomLens-append because production has PR A code. Any new expansion the user creates from this point forward gets a real snapshot, so the Undo button appears in the history panel for those entries. Dave should validate this when he naturally hits the flow next session.
+
+3. **Markets-popup display_name** — works on production now. When Dave next opens BloomLens "Add to existing market", market rows should show their renamed labels (e.g., "Frozen Meat Slicer" instead of "Manual Frozen Meat Slicer, Upgraded Stainless Steel Meat Cutter fo…").
+
+### Follow-ups (low priority, separate work)
+
+4. **BloomLens repo: score pill color coding in markets picker.** All score pills currently render emerald regardless of `submission.status`. `/api/extension/markets` already returns `status`; the extension client just doesn't read it for color classes. Should mirror BloomEngine app: PASS → emerald, RISKY → amber, FAIL → red. Pure client-side fix in `bloom-lens-extension`. Repo URL on Dave's machine; not in this repo's scope.
+
+5. **Drop legacy `__lens_pending_recalc` fallback** — after one full deploy cycle on production (~1 week of stable operation), remove the transitional fallback code in three places:
+   - `src/app/api/analyze/route.ts` — drop `lensPendingRecalcLegacy` from response
+   - `src/components/Vetting/VettingDetailContent.tsx` — drop `hasLegacyPendingRecalc`, simplify `showRecalcBanner` to `unresolvedExpansions.length > 0`
+   - `src/app/api/submissions/[id]/lens-recalc/route.ts` — drop the `isLegacyOnly` branch and the synthesized-entry path
+   Plus the residual `__lens_pending_recalc: false` writes in `lens-recalc/route.ts:255` and `undo-expansion/route.ts:125`.
+
+---
+
+## 5. Lessons captured to memory
+
+1. **BloomLens always hits production** regardless of whether Dave is testing on a preview URL. The extension is hardcoded to `bloomengine.ai`. Means feature work that depends on extension-write paths can't be E2E validated on a preview alone — either ship to prod first OR build a transitional fallback path that operates on legacy data shapes (as today's PR B fix-up did).
+
+2. **Some matrix metrics are client-side derived, not Keepa-driven.** Market Cap, Revenue per Competitor, Total Competitors, Top 5 Concentration, Unique Brands, Strong/Decent/Weak counts, FBA Dominance, Mature Listings — all derived in `ProductVettingResults` from `activeCompetitors`. They update the moment `productData.competitors` changes (e.g., at BloomLens-append time), not at recalc time. The things that DO change at recalc are score, AI briefing, and BSR/Price stability badges — anything that depends on fresh Keepa data. Banner copy needs to be honest about this contract.
+
+3. **Multi-expansion stacking validated.** The append-only `lensExpansions[]` log + "resolve all unresolved on a single recalc" pattern handles the realistic flow (user does multiple BloomLens searches with different terms over time, then recalcs once). Spec section 4.4 design intent confirmed.
+
+---
+
+## 6. Sprint A status (V9 roadmap)
+
+| Item | Status |
+|---|---|
+| 5.4-I sub-category granularity | ✅ shipped 2026-05-06 |
+| 6 new band-aware category calibrations | ✅ shipped 2026-05-06 |
+| Web Store v0.5.7 | ✅ shipped earlier this week |
+| Web Store v0.5.8 | 🟡 uploaded 2026-05-07, awaiting Google review |
+| r8: refit existing 12 categories with bands | ✅ shipped 2026-05-07 |
+| Recalc pill on /vetting/[asin] | ✅ shipped 2026-05-08 (this phase, full redesign) |
+| Re-enable extension detection | ⏳ pending v0.5.8 propagation |
+| BloomLens UI polish backlog | ⏳ ongoing |
+| BloomLens markets-picker score colors | ⏳ separate repo follow-up |
+
+**Sprint A is effectively closed.** Two carry-overs are external (Google review) or repo-external (BloomLens client). Next sprint per V9 roadmap is Sprint E (public launch readiness).
+
+---
+
+## 7. Sprint E preview (next session candidates)
+
+Per `project_v9_roadmap.md`, Sprint E open scope:
+
+- Soft-launch shape (invite-only beta cohort vs open Web Store)
+- Monitoring (Sentry vs Vercel logs)
+- Support channel (email vs Skool vs in-app chat)
+- Pricing page polish vs full marketing site
+- Onboarding tour scope
+- Demo video timing
+- Real case-study testimonials
+
+These are strategy decisions Dave owes; nothing to implement until directions are picked.
+
+Alternative next-session paths if Sprint E feels too open-ended:
+
+- **BloomLens follow-up #4** — score pill color coding in the markets picker. Quick win, ~30 min in the extension repo.
+- **Sprint C item 1** — Mandatory-vs-nice field indicators (started yesterday, paused at design questions). Two open calls: indicator style (asterisk only / asterisk + "(optional)" / pill badges) and scope (just SupplierQuotesTab / all sourcing tabs / SupplierQuotes + PlaceOrderChecklist).
+- **Sprint B** — Pre-Vetting / Market Climate v2 polish backlog (9 items in `project_market_climate_v2_polish.md`, vintage 2026-04-25; verify still current).
+
+---
+
+## 8. Standing rules (don't break)
+
+1. PRs target `dev`, never `main` without explicit instruction.
+2. After committing, pause and wait for confirmation before merging or pushing.
+3. Don't punt the merge to Dave — push + PR + merge are mine to drive after testing greenlight.
+4. Never combine commit + merge + push in one chained command.
+5. **NO ROUND NUMBERS in displayed metrics.** BSR-curve drives display.
+6. No "Keepa" in user-facing copy. Helium 10 is the documented exception (PDP-tooltip per 5.4-O acceptance criteria).
+7. "BloomLens" is one word in user-facing surfaces.
+8. **No Stripe-hosted page redirects.** All billing flows render in-app via Stripe Embedded.
+9. Tolerance-based numeric checks for AI / rounded values (`Math.abs(sum - 100) < 2`).
+10. Production deploys from `main`. Dev = preview.
+11. Never sacrifice one BSR band's accuracy for another's.
+12. Any new button in `entrypoints/content/` must use `window.open` (or message background SW), not `chrome.tabs.*`.
+13. Sensitive env vars in Vercel must drop the Development environment scope.
+14. **`effectiveTier` ≠ `tier` for display.** `effectiveTier` gates caps; `tier` is what the customer purchased — display the latter.
+15. **Adjustments and Expansions are separate concepts.** Removals = `submission_data.adjustment`. Additions = `submission_data.lensExpansions[]`.
+16. **NEW (2026-05-08):** BloomLens always hits production, regardless of which preview URL is active. Feature work that depends on extension-write paths needs either a prod ship or a transitional legacy-data fallback to be E2E testable.
+17. **NEW (2026-05-08):** Some `/vetting/[asin]` matrix metrics are client-side derived from `competitors`, not from a persisted column. Market Cap / Rev-per-Comp / Total Competitors / Market Structure stats update at append-time, NOT at recalc-time. Recalc changes score, AI briefing, BSR/Price stability — that's it.

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -53,6 +53,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import { checkCap } from '@/lib/subscription';
+import { calculateMarketScore } from '@/utils/scoring';
 import {
   corsPreflight,
   deriveEffectiveLensTier,
@@ -384,21 +385,31 @@ async function handleCreate(
     0
   );
 
+  // Auto-score on create so the /vetting dashboard list shows a real
+  // score and PASS/RISKY/FAIL pill instead of "0% / N/A". calculateMarketScore
+  // accepts an empty keepaResults array — the score will be computed from
+  // competitor metadata only (no BSR/price stability factor). When the user
+  // later runs Recalculate via the BloomLens recalc banner, lens-recalc
+  // fetches Keepa and recomputes a higher-fidelity score.
+  const initialMarketScore = competitors.length > 0
+    ? calculateMarketScore(competitors, [])
+    : null;
+
   const submissionPayload = {
     user_id: resolved.userId,
     title: name,
     product_name: name,
-    score: null,
-    status: null,
+    score: initialMarketScore?.score ?? null,
+    status: initialMarketScore?.status ?? null,
     research_products_id: researchProductId,
     submission_data: {
       productData: { competitors },
       keepaResults: [],
-      marketScore: null,
+      marketScore: initialMarketScore,
       createdAt: nowIso,
       __lens_origin: true,
       __lens_primary_asin: primaryAsinRaw,
-      __lens_pending_recalc: false,
+      __lens_pending_recalc: true, // signals to /vetting/[asin] that Keepa enrichment is still pending
     },
     metrics: {
       totalCompetitors: competitors.length,

--- a/src/components/Offer/OfferDetailContent.tsx
+++ b/src/components/Offer/OfferDetailContent.tsx
@@ -614,7 +614,8 @@ export function OfferDetailContent({ asin, onTabChange, onInsightsChange }: { as
 
   return (
     <>
-    <div>
+    {/* min-h prevents the ProductHeader sticky-toggle flicker on short pages — same fix as sourcing detail. */}
+    <div className="min-h-[calc(100vh+12rem)]">
       {error && (
         <div className="mb-6 bg-red-600 text-white px-6 py-4 rounded-xl shadow-lg flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/src/components/Offer/tabs/OfferTab.tsx
+++ b/src/components/Offer/tabs/OfferTab.tsx
@@ -342,7 +342,7 @@ export function OfferTab({
 
       {/* ===================== HAND OFF TO SOURCING ===================== */}
       <section>
-        <div className="rounded-2xl border border-slate-700/60 bg-gradient-to-br from-blue-900/20 via-slate-800/40 to-emerald-900/20 p-6">
+        <div className="rounded-2xl border border-purple-500/30 bg-gradient-to-br from-purple-900/20 via-indigo-900/15 to-slate-800/40 p-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="max-w-xl">
               <h3 className="text-lg font-bold text-white mb-1">Ready to source it?</h3>
@@ -358,7 +358,7 @@ export function OfferTab({
               type="button"
               onClick={handleContinueToSourcing}
               disabled={pushing || !asin}
-              className="inline-flex items-center justify-center gap-2 px-5 py-3 bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg text-white font-semibold shadow-lg shadow-emerald-500/20 transition-all"
+              className="inline-flex items-center justify-center gap-2 px-5 py-3 bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg text-white font-semibold shadow-lg shadow-purple-500/30 transition-all"
             >
               Continue to Sourcing
               <ArrowRight className="w-4 h-4" />

--- a/src/components/Offer/tabs/OfferTab.tsx
+++ b/src/components/Offer/tabs/OfferTab.tsx
@@ -79,9 +79,23 @@ function derivePriceBand(competitors: any[]): PriceBand {
 }
 
 function defaultPriceForStrategy(strategy: PriceStrategy, band: PriceBand): number | null {
-  if (strategy === 'premium')     return band.premium ?? band.top5Avg ?? band.median;
-  if (strategy === 'value')       return band.value   ?? band.median;
-  return band.top5Avg ?? band.median ?? band.premium;
+  let raw: number | null;
+  if (strategy === 'premium')        raw = band.premium ?? band.top5Avg ?? band.median;
+  else if (strategy === 'value')     raw = band.value   ?? band.median;
+  else                                raw = band.top5Avg ?? band.median ?? band.premium;
+  return roundToCharm99(raw);
+}
+
+// Snap a price to the nearest charm-pricing .99 (e.g. 46.97 -> 46.99,
+// 50.74 -> 50.99, 43.30 -> 42.99). Picks whichever .99 is numerically
+// closer; ties favor rounding up. Returns null for null/non-finite input
+// so callers don't have to null-check upfront.
+function roundToCharm99(price: number | null | undefined): number | null {
+  if (price == null || !Number.isFinite(price)) return null;
+  const floor = Math.floor(price);
+  const upper = floor + 0.99;        // e.g. price=46.97 -> upper=46.99
+  const lower = floor - 0.01;        // e.g. price=46.97 -> lower=45.99
+  return Math.abs(price - upper) <= Math.abs(price - lower) ? upper : lower;
 }
 
 function formatPrice(value: number | null | undefined): string {
@@ -291,7 +305,7 @@ export function OfferTab({
                 onClick={() => setStrategy('value')}
                 title="Value"
                 subtitle="Undercut the market"
-                price={priceBand.value}
+                price={roundToCharm99(priceBand.value)}
                 accent="emerald"
               />
               <StrategyCard
@@ -299,7 +313,7 @@ export function OfferTab({
                 onClick={() => setStrategy('competitive')}
                 title="Competitive"
                 subtitle="Match the market"
-                price={priceBand.top5Avg ?? priceBand.median}
+                price={roundToCharm99(priceBand.top5Avg ?? priceBand.median)}
                 accent="blue"
               />
               <StrategyCard
@@ -307,7 +321,7 @@ export function OfferTab({
                 onClick={() => setStrategy('premium')}
                 title="Premium"
                 subtitle="Price above the field"
-                price={priceBand.premium}
+                price={roundToCharm99(priceBand.premium)}
                 accent="amber"
               />
             </div>

--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -757,11 +757,11 @@ export function PlaceOrderTab({
           />
 
           {/* Download PDF Button */}
-          {/* <div className="flex items-center justify-between bg-slate-800/50 border border-slate-700/50 rounded-lg p-6">
+          <div className="flex items-center justify-between bg-slate-800/50 border border-slate-700/50 rounded-lg p-6">
             <div>
               <h3 className="text-lg font-semibold text-white mb-1">Purchase Order</h3>
               <p className="text-sm text-slate-400">
-                {allRequiredConfirmed 
+                {allRequiredConfirmed
                   ? 'All required fields confirmed. Ready to generate PDF.'
                   : 'Please confirm all required fields above to generate PDF.'}
               </p>
@@ -771,14 +771,14 @@ export function PlaceOrderTab({
               disabled={!allRequiredConfirmed || !selectedSupplier}
               className={`px-6 py-3 rounded-lg font-medium flex items-center gap-2 transition-colors ${
                 allRequiredConfirmed && selectedSupplier
-                  ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                  ? 'bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white shadow-lg shadow-purple-500/30'
                   : 'bg-slate-700 text-slate-400 cursor-not-allowed'
               }`}
             >
               <Download className="w-5 h-5" />
               Download Purchase Order (PDF)
             </button>
-          </div> */}
+          </div>
         </>
       )}
     </div>

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -2592,21 +2592,21 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                             />
                           </div>
                           <div className="grid grid-cols-2 gap-2">
-                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40">
-                              <label className="block text-xs font-medium text-slate-500 mb-1 flex items-center gap-1">
-                                CBM/Carton
-                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold">auto</span>
-                              </label>
+                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40 overflow-hidden">
+                              <div className="flex items-center justify-between gap-1 mb-1">
+                                <label className="text-xs font-medium text-slate-500 truncate min-w-0">CBM/Carton</label>
+                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold shrink-0">auto</span>
+                              </div>
                               <div className="text-sm font-medium text-slate-300 tabular-nums">
                                 {formatValue(quote.cbmPerCarton ?? null)}
                                 {quote.cbmPerCarton !== null && !isNaN(quote.cbmPerCarton ?? NaN) ? ' m³' : ''}
                               </div>
                             </div>
-                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40">
-                              <label className="block text-xs font-medium text-slate-500 mb-1 flex items-center gap-1">
-                                Total CBM
-                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold">auto</span>
-                              </label>
+                            <div className="bg-slate-900/60 rounded-lg p-2 border border-dashed border-slate-700/40 overflow-hidden">
+                              <div className="flex items-center justify-between gap-1 mb-1">
+                                <label className="text-xs font-medium text-slate-500 truncate min-w-0">Total CBM</label>
+                                <span className="text-[9px] uppercase tracking-wider text-slate-600 font-semibold shrink-0">auto</span>
+                              </div>
                               <div className="text-sm font-medium text-slate-300 tabular-nums">
                                 {formatValue(quote.totalCbm ?? null)}
                                 {quote.totalCbm !== null && !isNaN(quote.totalCbm ?? NaN) ? ' m³' : ''}

--- a/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
+++ b/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
@@ -59,7 +59,7 @@ export function PlaceOrderChecklist({
   });
 
   // Global filter state
-  const [showOnlyConfirmed, setShowOnlyConfirmed] = useState(false);
+  const [showOnlyUnmapped, setShowOnlyUnmapped] = useState(false);
   const [showOnlyUnconfirmed, setShowOnlyUnconfirmed] = useState(false);
 
   // Value mapper context
@@ -201,16 +201,17 @@ export function PlaceOrderChecklist({
     }
   }, [selectedSupplier, effectiveTier, onSaveEdit, onUpdateSupplierQuote]);
 
-  // Filter fields based on showOnlyConfirmed / showOnlyUnconfirmed
+  // Filter fields based on showOnlyUnmapped / showOnlyUnconfirmed
   const getFilteredFields = useCallback((fields: PlaceOrderField[]) => {
-    if (showOnlyConfirmed) {
-      return fields.filter(f => confirmedFields.has(f.key));
+    if (showOnlyUnmapped) {
+      // Items that don't auto-populate from supplier data — user must enter manually
+      return fields.filter(f => !f.mapped);
     }
     if (showOnlyUnconfirmed) {
       return fields.filter(f => !confirmedFields.has(f.key));
     }
     return fields;
-  }, [showOnlyConfirmed, showOnlyUnconfirmed, confirmedFields]);
+  }, [showOnlyUnmapped, showOnlyUnconfirmed, confirmedFields]);
 
   return (
     <div className="bg-slate-800/50 border border-slate-700/50 rounded-lg overflow-hidden">
@@ -219,17 +220,25 @@ export function PlaceOrderChecklist({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <h3 className="text-lg font-semibold text-white">Purchase Order Checklist</h3>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-slate-400">
-                {progress.confirmed}/{progress.total} Required Confirmed
-              </span>
-              <div className="w-32 h-2 bg-slate-700/50 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-emerald-500 transition-all duration-300"
-                  style={{ width: `${progress.total > 0 ? (progress.confirmed / progress.total) * 100 : 0}%` }}
-                />
-              </div>
-            </div>
+            {(() => {
+              const pct = progress.total > 0 ? (progress.confirmed / progress.total) * 100 : 0;
+              // App-standard tiering: red <25, amber 25-49, yellow 50-74, emerald 75+
+              const barClass = pct >= 75 ? 'bg-emerald-500' : pct >= 50 ? 'bg-yellow-500' : pct >= 25 ? 'bg-amber-500' : 'bg-red-500';
+              const textClass = pct >= 75 ? 'text-emerald-400' : pct >= 50 ? 'text-yellow-400' : pct >= 25 ? 'text-amber-400' : 'text-red-400';
+              return (
+                <div className="flex items-center gap-2">
+                  <span className={`text-sm font-medium ${textClass}`}>
+                    {progress.confirmed}/{progress.total} Required Confirmed
+                  </span>
+                  <div className="w-32 h-2 bg-slate-700/50 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full ${barClass} transition-all duration-300`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })()}
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -246,21 +255,22 @@ export function PlaceOrderChecklist({
             </button>
             <button
               onClick={() => {
-                setShowOnlyConfirmed(!showOnlyConfirmed);
+                setShowOnlyUnmapped(!showOnlyUnmapped);
                 setShowOnlyUnconfirmed(false);
               }}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
-                showOnlyConfirmed
-                  ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30'
+                showOnlyUnmapped
+                  ? 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
                   : 'text-slate-300 hover:text-white bg-slate-700/50 hover:bg-slate-700'
               }`}
+              title="Show only fields that don't auto-populate from supplier data"
             >
-              Show Agreed
+              Show Unmapped
             </button>
             <button
               onClick={() => {
                 setShowOnlyUnconfirmed(!showOnlyUnconfirmed);
-                setShowOnlyConfirmed(false);
+                setShowOnlyUnmapped(false);
               }}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyUnconfirmed

--- a/src/components/Sourcing/tabs/placeOrder/valueMapper.ts
+++ b/src/components/Sourcing/tabs/placeOrder/valueMapper.ts
@@ -12,6 +12,13 @@ import type { PlaceOrderField } from './placeOrderSchema';
 import { formatCurrency } from '@/utils/formatters';
 import { calculateQuoteMetrics } from '../SupplierQuotesTab';
 
+// Guards numeric mapped values: optional fields can be null OR undefined
+// OR NaN, and a `value !== null` check accepts undefined/NaN, which then
+// gets passed to formatCurrency producing "$NaN" in the checklist.
+function isFiniteNumber(value: number | null | undefined): boolean {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 export interface ValueSource {
   value: string | null;
   source: 'supplier_quote' | 'profit_overview' | 'product_data' | 'local' | 'calculated';
@@ -245,18 +252,18 @@ function getMappedValue(
         source: 'supplier_quote' 
       };
     case 'packaging_cost':
-      return { 
-        value: selectedSupplier.packagingCostPerUnit !== null 
-          ? formatCurrency(selectedSupplier.packagingCostPerUnit) 
-          : null, 
-        source: 'supplier_quote' 
+      return {
+        value: isFiniteNumber(selectedSupplier.packagingCostPerUnit)
+          ? formatCurrency(selectedSupplier.packagingCostPerUnit as number)
+          : null,
+        source: 'supplier_quote'
       };
     case 'labelling_cost':
-      return { 
-        value: selectedSupplier.labellingCostPerUnit !== null 
-          ? formatCurrency(selectedSupplier.labellingCostPerUnit) 
-          : null, 
-        source: 'supplier_quote' 
+      return {
+        value: isFiniteNumber(selectedSupplier.labellingCostPerUnit)
+          ? formatCurrency(selectedSupplier.labellingCostPerUnit as number)
+          : null,
+        source: 'supplier_quote'
       };
 
     // Super Selling Points
@@ -311,27 +318,27 @@ function getMappedValue(
         source: 'supplier_quote' 
       };
     case 'freight_cost_per_unit':
-      return { 
-        value: selectedSupplier.freightCostPerUnit !== null 
-          ? formatCurrency(selectedSupplier.freightCostPerUnit) 
-          : (selectedSupplier.ddpShippingPerUnit !== null 
-            ? formatCurrency(selectedSupplier.ddpShippingPerUnit) 
-            : null), 
-        source: 'supplier_quote' 
+      return {
+        value: isFiniteNumber(selectedSupplier.freightCostPerUnit)
+          ? formatCurrency(selectedSupplier.freightCostPerUnit as number)
+          : (isFiniteNumber(selectedSupplier.ddpShippingPerUnit)
+            ? formatCurrency(selectedSupplier.ddpShippingPerUnit as number)
+            : null),
+        source: 'supplier_quote'
       };
     case 'duty_cost_per_unit':
-      return { 
-        value: selectedSupplier.dutyCostPerUnit !== null 
-          ? formatCurrency(selectedSupplier.dutyCostPerUnit) 
-          : null, 
-        source: 'supplier_quote' 
+      return {
+        value: isFiniteNumber(selectedSupplier.dutyCostPerUnit)
+          ? formatCurrency(selectedSupplier.dutyCostPerUnit as number)
+          : null,
+        source: 'supplier_quote'
       };
     case 'tariff_cost_per_unit':
-      return { 
-        value: selectedSupplier.tariffCostPerUnit !== null 
-          ? formatCurrency(selectedSupplier.tariffCostPerUnit) 
-          : null, 
-        source: 'supplier_quote' 
+      return {
+        value: isFiniteNumber(selectedSupplier.tariffCostPerUnit)
+          ? formatCurrency(selectedSupplier.tariffCostPerUnit as number)
+          : null,
+        source: 'supplier_quote'
       };
 
     default:

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1169,7 +1169,7 @@ export function Dashboard({ onTabChange }: { onTabChange?: (tab: string) => void
                               className="relative text-left p-4 text-xs font-medium text-gray-600 dark:text-slate-400 uppercase tracking-wider"
                               style={{ width: productColumnWidth }}
                             >
-                              <span className="block">Product</span>
+                              <span className="block">Market</span>
                               <div
                                 onMouseDown={(event) => {
                                   productResizeStartX.current = event.clientX;


### PR DESCRIPTION
## Summary

Pre-main punch list. Fixes that need to ship before dev → main.

## Commits

| Commit | What |
|---|---|
| \`216b4a3\` | Vetting list "Product" column → "Market"; Continue to Sourcing button uses purple/indigo branding; CBM/AUTO tag overflow fixed; PO checklist progress bar uses app-standard tier coloring; Show Agreed → Show Unmapped (new filter, surfaces fields user must enter manually); $NaN bug in Place Order mapped Freight/Duty/Tariff cells |
| \`27b48e1\` | Offering tab flicker fix (same min-h pattern as sourcing); Value/Competitive/Premium prices snap to nearest $0.99 charm pricing |
| \`14b7044\` | BloomLens-created markets now auto-score on creation — dashboard list shows real PASS/RISKY/FAIL + score % instead of "0% / N/A" |
| \`1bbd1ea\` | Re-enabled Download Purchase Order PDF button (was commented out); restyled to match purple/indigo Sourcing branding |

## Test plan

- [ ] Vetting list: header reads "Market"; BloomLens-imported markets now show real score + status pill
- [ ] Offering tab: scroll to bottom on a short page — no flicker
- [ ] Offering tab Target Launch Price: Value/Competitive/Premium cards all show $X.99; Your Target Launch Price input shows clean 2-decimal $X.99 instead of "46.970000000000006"
- [ ] Offering tab "Continue to Sourcing" button: purple/indigo gradient
- [ ] Sourcing detail Carton/Logistics: CBM/Carton + Total CBM stay inside their boxes; "AUTO" tag aligned to the right
- [ ] Place Order checklist progress bar: changes color (red → amber → yellow → emerald) as you confirm fields
- [ ] Place Order checklist: "Show Unmapped" filter button shows only fields user must enter manually
- [ ] Place Order Freight/Duty/Tariff Cost rows: show "—" instead of "$NaN" when supplier hasn't filled those fields
- [ ] Place Order: Download Purchase Order (PDF) button visible at bottom; disabled until all required fields confirmed; purple/indigo gradient when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)