### PR TITLE
Phase 6 V9 pre-main 3: 5 final fixes before ship

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/utils/supabaseServer'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { checkCap } from '@/lib/subscription'
+import { calculateMarketScore } from '@/utils/scoring'
 
 export async function POST(request: NextRequest) {
   try {
@@ -246,12 +247,36 @@ export async function GET(request: NextRequest) {
           const lensExpansions = Array.isArray(sub.submission_data?.lensExpansions)
             ? sub.submission_data.lensExpansions
             : [];
+
+          // Transitional fallback: BloomLens-origin submissions created before
+          // the auto-score-on-create fix landed have score: null + status: null
+          // even though they have competitors. Compute on-the-fly so the
+          // /vetting list shows a meaningful pill instead of "0% / N/A".
+          // Once the auto-score fix is in production for ~7 days this fallback
+          // can be retired.
+          let derivedScore: number | null = sub.score;
+          let derivedStatus: string | null = sub.status;
+          if (
+            (sub.score == null || sub.status == null) &&
+            sub.submission_data?.__lens_origin === true
+          ) {
+            const competitors = sub.submission_data?.productData?.competitors || [];
+            if (competitors.length > 0) {
+              const computed = calculateMarketScore(
+                competitors,
+                sub.submission_data?.keepaResults || []
+              );
+              derivedScore = computed.score;
+              derivedStatus = computed.status;
+            }
+          }
+
           return {
             id: sub.id,
             userId: sub.user_id,
             title: sub.title,
-            score: sub.score,
-            status: sub.status,
+            score: derivedScore,
+            status: derivedStatus,
             productName: sub.product_name,
             createdAt: sub.created_at,
             productData: sub.submission_data?.productData || {},

--- a/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
+++ b/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
@@ -4,7 +4,28 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { ChevronDown, ChevronUp, Pencil, X, Save, CheckCircle2 } from 'lucide-react';
 import { PLACE_ORDER_SCHEMA, type PlaceOrderField, type PlaceOrderSection } from './placeOrderSchema';
 import { getFieldValue, type ValueMapperContext } from './valueMapper';
+import { formatCurrency } from '@/utils/formatters';
 import type { SupplierQuoteRow, SourcingHubData } from '../../types';
+
+// Field labels that should render their CURRENT value as USD currency.
+// Detected by label keyword (case-insensitive). Local overrides come in as
+// raw strings (user typed "0.5") so we format on display; mapped values
+// already come pre-formatted from valueMapper but get re-formatted here
+// safely (already-formatted "$0.50" parses to NaN and we leave it alone).
+function isCurrencyField(label: string): boolean {
+  const l = label.toLowerCase();
+  return /\b(cost|price|fee|investment|profit|total|payment)\b/.test(l);
+}
+
+function formatValueIfCurrency(value: string | null, label: string): string | null {
+  if (value == null) return value;
+  if (!isCurrencyField(label)) return value;
+  // Already formatted ($X.XX) — leave alone
+  if (value.startsWith('$')) return value;
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return value;
+  return formatCurrency(n);
+}
 
 interface PlaceOrderChecklistProps {
   selectedSupplier: SupplierQuoteRow | null;
@@ -61,6 +82,7 @@ export function PlaceOrderChecklist({
   // Global filter state
   const [showOnlyUnmapped, setShowOnlyUnmapped] = useState(false);
   const [showOnlyUnconfirmed, setShowOnlyUnconfirmed] = useState(false);
+  const [showOnlyMissing, setShowOnlyMissing] = useState(false);
 
   // Value mapper context
   const valueContext: ValueMapperContext = useMemo(() => ({
@@ -201,17 +223,25 @@ export function PlaceOrderChecklist({
     }
   }, [selectedSupplier, effectiveTier, onSaveEdit, onUpdateSupplierQuote]);
 
-  // Filter fields based on showOnlyUnmapped / showOnlyUnconfirmed
+  // Filter fields based on the currently active filter.
+  // Filters are mutually exclusive — toggling one clears the others.
   const getFilteredFields = useCallback((fields: PlaceOrderField[]) => {
     if (showOnlyUnmapped) {
       // Items that don't auto-populate from supplier data — user must enter manually
       return fields.filter(f => !f.mapped);
     }
+    if (showOnlyMissing) {
+      // Items where the current value is null/empty regardless of mapped status
+      return fields.filter(f => {
+        const v = getFieldValue(f, valueContext);
+        return v.value == null || v.value.toString().trim() === '';
+      });
+    }
     if (showOnlyUnconfirmed) {
       return fields.filter(f => !confirmedFields.has(f.key));
     }
     return fields;
-  }, [showOnlyUnmapped, showOnlyUnconfirmed, confirmedFields]);
+  }, [showOnlyUnmapped, showOnlyMissing, showOnlyUnconfirmed, confirmedFields, valueContext]);
 
   return (
     <div className="bg-slate-800/50 border border-slate-700/50 rounded-lg overflow-hidden">
@@ -257,6 +287,7 @@ export function PlaceOrderChecklist({
               onClick={() => {
                 setShowOnlyUnmapped(!showOnlyUnmapped);
                 setShowOnlyUnconfirmed(false);
+                setShowOnlyMissing(false);
               }}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyUnmapped
@@ -269,8 +300,24 @@ export function PlaceOrderChecklist({
             </button>
             <button
               onClick={() => {
+                setShowOnlyMissing(!showOnlyMissing);
+                setShowOnlyUnmapped(false);
+                setShowOnlyUnconfirmed(false);
+              }}
+              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                showOnlyMissing
+                  ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
+                  : 'text-slate-300 hover:text-white bg-slate-700/50 hover:bg-slate-700'
+              }`}
+              title="Show only fields where the current value is empty"
+            >
+              Show Missing
+            </button>
+            <button
+              onClick={() => {
                 setShowOnlyUnconfirmed(!showOnlyUnconfirmed);
                 setShowOnlyUnmapped(false);
+                setShowOnlyMissing(false);
               }}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyUnconfirmed
@@ -305,7 +352,7 @@ export function PlaceOrderChecklist({
             // it entirely. Otherwise the user clicks the expand chevron
             // and sees nothing (e.g. Show Unmapped on FBA Fees, where
             // every field is mapped from supplier data).
-            const filterIsActive = showOnlyUnmapped || showOnlyUnconfirmed;
+            const filterIsActive = showOnlyUnmapped || showOnlyUnconfirmed || showOnlyMissing;
             const filteredOutEntirely =
               filterIsActive && filteredRequired.length === 0 && filteredOptional.length === 0;
             if (filteredOutEntirely) return null;
@@ -361,42 +408,27 @@ export function PlaceOrderChecklist({
                       </div>
                     )}
 
-                    {/* Optional Fields - hidden */}
-                    {/* {optionalFields.length > 0 && (
-                      <div className="px-4 py-2">
-                        <button
-                          onClick={() => toggleOptional(section.key)}
-                          className="flex items-center gap-2 text-xs font-medium text-slate-400 hover:text-slate-300 mb-3"
-                        >
-                          {sectionState.optionalExpanded ? (
-                            <ChevronDown className="w-3 h-3" />
-                          ) : (
-                            <ChevronUp className="w-3 h-3" />
-                          )}
-                          {hasFilledOptionals && !sectionState.optionalExpanded && (
-                            <span className="text-emerald-400">(Filled)</span>
-                          )}
-                          <span>+ Add Optional</span>
-                        </button>
-                        {(sectionState.optionalExpanded || hasFilledOptionals) && (
-                          <div className="mt-2">
-                            <ChecklistTable
-                              fields={sectionState.optionalExpanded ? filteredOptional : filteredOptional.filter(f => {
-                                const valueSource = getFieldValue(f, valueContext);
-                                return valueSource.value !== null;
-                              })}
-                              valueContext={valueContext}
-                              confirmedFields={confirmedFields}
-                              editingField={editingField}
-                              onConfirm={handleConfirm}
-                              onStartEdit={onStartEdit}
-                              onSaveEdit={(field, value) => handleSaveEdit(field, value)}
-                              onCancelEdit={onCancelEdit}
-                            />
-                          </div>
-                        )}
+                    {/* Optional Fields — render inline when present so the user
+                        can confirm them too. Critical for sections like Super
+                        Selling Points where every field is optional but the
+                        user still needs to confirm them for the PO PDF. */}
+                    {filteredOptional.length > 0 && (
+                      <div className="px-4 py-2 bg-slate-900/30">
+                        <h5 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+                          {filteredRequired.length > 0 ? 'Optional' : 'Confirm to include in PO'}
+                        </h5>
+                        <ChecklistTable
+                          fields={filteredOptional}
+                          valueContext={valueContext}
+                          confirmedFields={confirmedFields}
+                          editingField={editingField}
+                          onConfirm={handleConfirm}
+                          onStartEdit={onStartEdit}
+                          onSaveEdit={(field, value) => handleSaveEdit(field, value)}
+                          onCancelEdit={onCancelEdit}
+                        />
                       </div>
-                    )} */}
+                    )}
                   </div>
                 )}
               </div>
@@ -509,7 +541,10 @@ function ChecklistRow({
     onSaveEdit(editValue.trim());
   };
 
-  const canConfirm = valueSource.value !== null && valueSource.value.trim() !== '';
+  // Block Confirm when the row is being edited (unsaved value) or the
+  // current value is empty — prevents accidentally confirming a stale
+  // or empty value before the user finishes typing.
+  const canConfirm = !isEditing && valueSource.value !== null && valueSource.value.trim() !== '';
 
   // Row click enters edit mode unless already editing or confirmed.
   // Buttons inside (Confirm, Save, Cancel, pencil) all stopPropagation
@@ -574,7 +609,7 @@ function ChecklistRow({
                 valueSource.value ? 'text-slate-300' : 'text-slate-500 italic'
               }`}
             >
-              {valueSource.value || '—'}
+              {formatValueIfCurrency(valueSource.value, field.label) || '—'}
             </span>
             {valueSource.isMapped && valueSource.value && (
               <span className="text-xs px-1.5 py-0.5 bg-slate-700/50 text-slate-400 rounded">


### PR DESCRIPTION
## Summary

Final pre-main batch. Five targeted fixes from Dave's last review pass.

## Commits

\`8fc5604\` —

1. BloomLens markets that show 0% / N/A on the vetting list now compute their score on-the-fly in /api/analyze GET when sub.score is null AND \_\_lens_origin === true. Closes the gap where main hasn't shipped the auto-score-on-create fix yet but Dave's BloomLens markets hit production immediately.

2. Cost / Price / Fee / Investment / Profit / Payment mapped fields in the PO Checklist render as USD currency ("$0.50") instead of raw numbers ("0.5") regardless of source (local override or mapped).

3. SSP section (and any all-optional section) is now expandable with content. Optional fields render inline with a "Confirm to include in PO" header when there are no required peers, or "Optional" when they sit below required fields.

4. Confirm button is blocked while the row is being edited — was previously enabled against the stale persisted value while user typed a new one.

5. New "Show Missing" filter on the PO Checklist toolbar. Mutually exclusive with Show Unmapped + Show Unconfirmed.

PO PDF redesign explicitly deferred per Dave's last message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)