### PR TITLE
Phase 6 V9 pre-main 4: Vetting badge for BloomLens markets

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -309,9 +309,11 @@ async function handleCreate(
     // (which reads research_products.display_name first via
     // getProductDisplayName). If they want the product's original
     // title back, the pencil icon on the header lets them rename.
+    // is_vetted=true so the /vetting list PROGRESS column shows the
+    // vetted-stage badge (since analyze-market now auto-scores below).
     await supabaseAdmin
       .from('research_products')
-      .update({ display_name: name, updated_at: nowIso })
+      .update({ display_name: name, is_vetted: true, updated_at: nowIso })
       .eq('id', existing.id)
       .eq('user_id', resolved.userId);
   } else {
@@ -348,6 +350,10 @@ async function handleCreate(
         price: scraped?.price ?? null,
         monthly_revenue: scraped?.monthlyRevenue ?? null,
         monthly_units_sold: scraped?.monthlyUnits ?? null,
+        // Mark as vetted so the /vetting list PROGRESS column shows the
+        // vetted-stage badge for this market — analyze-market now
+        // auto-scores the submission below, so it IS vetted.
+        is_vetted: true,
         extra_data: {
           rating: scraped?.rating ?? null,
           reviews: scraped?.reviews ?? null,

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -439,11 +439,18 @@ export function Dashboard({ onTabChange }: { onTabChange?: (tab: string) => void
         const updatedSubmissions: any[] = submissionsData.submissions.map((submission: any) => {
           const foundResearchProduct = researchData.data.find((product: any) => product.id === submission.research_product_id);
           if (foundResearchProduct) {
+            // Derive is_vetted from the submission score as a fallback for
+            // BloomLens-origin markets created before analyze-market started
+            // setting is_vetted=true. Any submission with a numeric score
+            // is by definition vetted, so the PROGRESS column should show
+            // the vetted-stage badge regardless of the stored flag.
+            const isVettedDerived =
+              foundResearchProduct.is_vetted || typeof submission.score === 'number';
             return {
               ...submission,
               asin: foundResearchProduct.asin,
               display_name: foundResearchProduct.display_name ?? null,
-              is_vetted: foundResearchProduct.is_vetted,
+              is_vetted: isVettedDerived,
               is_offered: foundResearchProduct.is_offered,
               is_sourced: foundResearchProduct.is_sourced,
               // Carry tags from the linked research_product onto the


### PR DESCRIPTION
Last fix before dev → main. analyze-market now sets research_products.is_vetted=true on create, and Dashboard.tsx derives is_vetted from score as a self-healing fallback for existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)