### PR TITLE
Phase 6 V9 critical bugs: 3 fixes from prod validation (#13/14/16)

### DIFF
--- a/src/components/Offer/tabs/OfferTab.tsx
+++ b/src/components/Offer/tabs/OfferTab.tsx
@@ -82,7 +82,9 @@ function defaultPriceForStrategy(strategy: PriceStrategy, band: PriceBand): numb
   let raw: number | null;
   if (strategy === 'premium')        raw = band.premium ?? band.top5Avg ?? band.median;
   else if (strategy === 'value')     raw = band.value   ?? band.median;
-  else                                raw = band.top5Avg ?? band.median ?? band.premium;
+  // Competitive == "Match the market" → market median is the anchor.
+  // Falls back to top-5 avg only when median is missing.
+  else                                raw = band.median  ?? band.top5Avg ?? band.premium;
   return roundToCharm99(raw);
 }
 
@@ -160,15 +162,28 @@ export function OfferTab({
     setPushError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
+      const authHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+      };
+
+      // Carry the user's selected target launch price into the Sourcing Hub
+      // via the sourcing_hub.offerTargetSalesPrice field. Sourcing Hub reads
+      // this as the "From Offering" default ahead of the original ASIN price.
+      const initialSourcingHub = {
+        targetSalesPrice: null,
+        categoryOverride: null,
+        referralFeePct: null,
+        offerTargetSalesPrice: targetPrice,
+      };
+
       const res = await fetch('/api/sourcing', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
-        },
+        headers: authHeaders,
         body: JSON.stringify({
           productId,
           asin,
+          sourcingHub: initialSourcingHub,
           offerContext: {
             lockedSsps: lockedByCategory.flatMap((c) =>
               c.items.map((item) => ({ category: c.key, ...item }))
@@ -178,12 +193,41 @@ export function OfferTab({
           },
         }),
       });
+
+      if (res.status === 409) {
+        // Record already exists. Merge offerTargetSalesPrice into the existing
+        // sourcing_hub so a fresh strategy pick from Offer flows through, then
+        // navigate to the existing sourcing page.
+        try {
+          const getRes = await fetch(`/api/sourcing?productId=${encodeURIComponent(productId)}`, {
+            headers: authHeaders,
+          });
+          if (getRes.ok) {
+            const payload = await getRes.json();
+            const existingHub = payload?.data?.sourcing_hub || {};
+            await fetch('/api/sourcing', {
+              method: 'PATCH',
+              headers: authHeaders,
+              body: JSON.stringify({
+                productId,
+                sourcingHub: {
+                  ...existingHub,
+                  offerTargetSalesPrice: targetPrice,
+                },
+              }),
+            });
+          }
+        } catch {
+          // Non-fatal — navigate even if the patch fails so the user isn't blocked.
+        }
+        router.push(`/sourcing/${encodeURIComponent(asin)}`);
+        return;
+      }
+
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
-        // 409 = record already exists. That's expected for re-entry; we
-        //       just navigate to the existing sourcing page.
         // 404/405 = sourcing endpoint missing; fall back to navigation.
-        if (res.status === 409 || res.status === 404 || res.status === 405) {
+        if (res.status === 404 || res.status === 405) {
           router.push(`/sourcing/${encodeURIComponent(asin)}`);
           return;
         }
@@ -314,7 +358,7 @@ export function OfferTab({
                 onClick={() => setStrategy('competitive')}
                 title="Competitive"
                 subtitle="Match the market"
-                price={roundToCharm99(priceBand.top5Avg ?? priceBand.median)}
+                price={roundToCharm99(priceBand.median ?? priceBand.top5Avg)}
                 accent="blue"
               />
               <StrategyCard

--- a/src/components/Sourcing/SourcingDetailContent.tsx
+++ b/src/components/Sourcing/SourcingDetailContent.tsx
@@ -88,8 +88,9 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
     const dataHash = JSON.stringify({
       supplierQuotes: data.supplierQuotes,
       fieldsConfirmed: data.fieldsConfirmed,
+      sourcingHub: data.sourcingHub,
     });
-    
+
     // Skip if data hasn't changed
     if (dataHash === lastSavedRef.current) {
       console.log('[SourcingDetail] Skipping save - data unchanged');
@@ -132,6 +133,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
           asin: asin,
           supplierQuotes: data.supplierQuotes,
           fieldsConfirmed: data.fieldsConfirmed || {},
+          sourcingHub: data.sourcingHub,
         }),
       });
       
@@ -179,6 +181,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
     const currentHash = JSON.stringify({
       supplierQuotes: debouncedSourcingData.supplierQuotes,
       fieldsConfirmed: debouncedSourcingData.fieldsConfirmed,
+      sourcingHub: debouncedSourcingData.sourcingHub,
     });
     
     // Don't save if it's the same as what we just loaded
@@ -277,6 +280,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
             const dataHash = JSON.stringify({
               supplierQuotes: dbData.supplierQuotes,
               fieldsConfirmed: dbData.fieldsConfirmed,
+              sourcingHub: dbData.sourcingHub,
             });
             console.log('[SourcingDetail] Data loaded from DB:', {
               supplierCount: dbData.supplierQuotes?.length || 0,
@@ -295,6 +299,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
             const dataHash = JSON.stringify({
               supplierQuotes: defaultData.supplierQuotes,
               fieldsConfirmed: defaultData.fieldsConfirmed,
+              sourcingHub: defaultData.sourcingHub,
             });
             console.log('[SourcingDetail] No DB record, using default data');
             lastSavedRef.current = dataHash;
@@ -310,6 +315,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
           const dataHash = JSON.stringify({
             supplierQuotes: defaultData.supplierQuotes,
             fieldsConfirmed: defaultData.fieldsConfirmed,
+            sourcingHub: defaultData.sourcingHub,
           });
           console.log('[SourcingDetail] No product ID, using default data');
           lastSavedRef.current = dataHash;

--- a/src/components/Sourcing/sourcingStorage.ts
+++ b/src/components/Sourcing/sourcingStorage.ts
@@ -94,6 +94,7 @@ function migrateSourcingData(data: any): SourcingData {
       targetSalesPrice: null,
       categoryOverride: null,
       referralFeePct: null,
+      offerTargetSalesPrice: null,
     },
     profitCalculator: data.profitCalculator || {
       sampleOrdered: false,
@@ -179,6 +180,7 @@ export function getDefaultSourcingData(productId: string): SourcingData {
       targetSalesPrice: null,
       categoryOverride: null,
       referralFeePct: null,
+      offerTargetSalesPrice: null,
     },
     fieldsConfirmed: {},
   };
@@ -206,7 +208,7 @@ export function getDefaultSupplierQuote(index: number): SupplierQuoteRow {
     supplierName: '',
     costPerUnitShortTerm: null,
     exwUnitCost: null,
-    incoterms: 'DDP', // Default to DDP
+    incoterms: '', // Unset until user picks — keeps Calculation Accuracy at 0% on add
     ddpPrice: null,
     moqShortTerm: null,
     moq: null,

--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -385,9 +385,9 @@ export function PlaceOrderTab({
 
   // Calculate sales price (for referral fee percentage calculation)
   const salesPrice = useMemo(() => {
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    return hub.targetSalesPrice ?? originalPrice ?? selectedSupplier?.salesPrice ?? null;
+    return hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier?.salesPrice ?? null;
   }, [hubData, productData, selectedSupplier]);
 
   // Handle supplier quote updates (for write-back)
@@ -566,9 +566,9 @@ export function PlaceOrderTab({
   const handleDownloadPDF = () => {
     if (!selectedSupplier || !supplierWithMetrics || !allRequiredConfirmed) return;
 
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
+    const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
     const originalCategory = productData?.category || '';
     const category = hub.categoryOverride || originalCategory || '';
     const referralFeePct = hub.referralFeePct !== null 

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -616,9 +616,9 @@ export function ProfitCalculatorTab({
 
   // Get target sales price
   const getTargetSalesPrice = (): number | null => {
-    const hub = hubData || { targetSalesPrice: null };
+    const hub = hubData || { targetSalesPrice: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    return hub.targetSalesPrice ?? originalPrice ?? null;
+    return hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? null;
   };
 
   // Get category for referral fee display

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -320,6 +320,7 @@ export function SourcingHub({
     targetSalesPrice: null,
     categoryOverride: null,
     referralFeePct: null,
+    offerTargetSalesPrice: null,
   };
 
   // Get original product values
@@ -327,8 +328,9 @@ export function SourcingHub({
   const originalCategory = productData?.category || '';
   const productName = getProductDisplayName(productData);
 
-  // Use overrides if available, otherwise use original values
-  const targetSalesPrice = hub.targetSalesPrice ?? originalPrice;
+  // Precedence: Hub-level user override > Offer page handoff > Original ASIN price
+  const offerTargetSalesPrice = hub.offerTargetSalesPrice ?? null;
+  const targetSalesPrice = hub.targetSalesPrice ?? offerTargetSalesPrice ?? originalPrice;
   const category = hub.categoryOverride || originalCategory || '';
   
   // Note: Referral fee calculation logic is still used in SupplierQuotesTab
@@ -631,14 +633,16 @@ export function SourcingHub({
                 <DollarSign className="w-3 h-3" />
                 Target Sales Price
               </span>
-              {hub.targetSalesPrice !== null && originalPrice !== null && hub.targetSalesPrice !== originalPrice && (
+              {hub.targetSalesPrice !== null && (offerTargetSalesPrice !== null || originalPrice !== null) && (
                 <button
                   type="button"
                   onClick={() => handleTargetSalesPriceChange(null)}
                   className="text-[10px] font-medium text-emerald-400 hover:text-emerald-300 normal-case tracking-normal transition-colors"
-                  title={`Reset to Offering price (${formatCurrency(originalPrice)})`}
+                  title={offerTargetSalesPrice !== null
+                    ? `Reset to Offering price (${formatCurrency(offerTargetSalesPrice)})`
+                    : `Reset to original ASIN price (${formatCurrency(originalPrice)})`}
                 >
-                  Reset to Offering
+                  Reset
                 </button>
               )}
             </div>
@@ -665,7 +669,7 @@ export function SourcingHub({
                     }
                   }
                 }}
-                placeholder={originalPrice ? formatCurrency(originalPrice) : '0.00'}
+                placeholder={offerTargetSalesPrice ? formatCurrency(offerTargetSalesPrice) : (originalPrice ? formatCurrency(originalPrice) : '0.00')}
                 className="w-full pl-5 pr-10 py-0 bg-transparent border-0 text-white placeholder-slate-500 focus:outline-none text-sm font-medium"
                 autoComplete="off"
                 autoCorrect="off"
@@ -674,11 +678,13 @@ export function SourcingHub({
               />
               <span className="absolute right-0 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-xs z-10">USD</span>
             </div>
-            {originalPrice !== null && (
+            {(offerTargetSalesPrice !== null || originalPrice !== null) && (
               <div className="mt-1 text-[10px] text-slate-500">
-                {hub.targetSalesPrice === null || hub.targetSalesPrice === originalPrice
+                {hub.targetSalesPrice !== null
+                  ? `Overridden (${offerTargetSalesPrice !== null ? `Offering: ${formatCurrency(offerTargetSalesPrice)}` : `Original: ${formatCurrency(originalPrice)}`})`
+                  : offerTargetSalesPrice !== null
                   ? `From Offering`
-                  : `Overridden (Offering: ${formatCurrency(originalPrice)})`}
+                  : `From Original ASIN`}
               </div>
             )}
           </div>

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -223,9 +223,9 @@ const extractLeadTimeDays = (leadTime: string): number | null => {
 // We'll handle that in the component where we have access to hubData/productData
 export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: SourcingHubData, productData?: any): SupplierQuoteRow => {
   // Get target sales price: hubData.targetSalesPrice ?? productData.price ?? quote.salesPrice
-  const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+  const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
   const originalPrice = productData?.price || productData?.salesPrice || null;
-  const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? quote.salesPrice ?? 0;
+  const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice ?? 0;
   
   // Get category for referral fee calculation
   const originalCategory = productData?.category || '';
@@ -1266,11 +1266,11 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
   };
 
   const getReferralFeeForQuote = (quote: SupplierQuoteRow) => {
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
     const originalCategory = productData?.category || '';
     
-    const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? quote.salesPrice;
+    const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice;
     const category = hub.categoryOverride || originalCategory || '';
     
     const referralFeePct = hub.referralFeePct !== null 
@@ -1946,19 +1946,13 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                               Incoterms<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
                             </label>
                             <select
-                              value={quote.incoterms || 'DDP'}
+                              value={quote.incoterms || ''}
                               onChange={(e) => {
-                                const newValue = e.target.value || 'DDP';
-                                handleUpdateQuote(quote.id, { incoterms: newValue });
-                              }}
-                              onBlur={(e) => {
-                                // Ensure DDP is saved if field was empty
-                                if (!quote.incoterms) {
-                                  handleUpdateQuote(quote.id, { incoterms: 'DDP' });
-                                }
+                                handleUpdateQuote(quote.id, { incoterms: e.target.value });
                               }}
                               className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white focus:outline-none ${getRequiredFieldClass(isFieldFilled(quote.incoterms))}`}
                             >
+                              <option value="" disabled>Select…</option>
                               <option value="DDP">DDP</option>
                               <option value="EXW">EXW</option>
                               <option value="FOB">FOB</option>

--- a/src/components/Sourcing/types.ts
+++ b/src/components/Sourcing/types.ts
@@ -209,6 +209,7 @@ export interface SourcingHubData {
   targetSalesPrice: number | null; // Override sales price for this page
   categoryOverride: string | null; // Override category for this page
   referralFeePct: number | null; // Calculated from category, but can be manually overridden
+  offerTargetSalesPrice?: number | null; // Carried over from Offer page's Continue to Sourcing handoff
 }
 
 export interface SourcingData {


### PR DESCRIPTION
## Summary

Three bugs caught during production validation of the V9 ship today (2026-05-09). Tight, scoped fixes — no scope creep.

### 1. Competitive launch price collided with Premium ($33.99 / $33.99)
Repro: a market with `top5Avg=$34.19, premium=$33.99`. The Competitive card computed `roundToCharm99(top5Avg ?? median)` → $34.19 charm-snaps DOWN to $33.99, identical to Premium. User selecting Competitive vs Premium got the same number.

**Fix:** Competitive now anchors on `priceBand.median` ("Match the market" → market median, the true center). Top-5 avg only serves as fallback if median is null. With the example data, Competitive becomes $23.99 and Premium stays $33.99 — clean separation.

Both the card display and `defaultPriceForStrategy` updated so the strategy chip + override input + Hand-off summary all reflect the same number.

### 2. Target launch price didn't flow from Offer to Sourcing Hub
Repro: pick Premium ($33.99) on the Offer page, click Continue to Sourcing → Sourcing Hub still shows $23.99 (the original ASIN's listed price), labeled "From Offering" — which was misleading because nothing from Offering was actually flowing through.

**Root cause:** `originalPrice` in SourcingHub / SupplierQuotesTab / PlaceOrderTab / ProfitCalculatorTab read `productData.price || productData.salesPrice` — the ASIN's price. Offer's `targetPrice` was sent in `offerContext` but discarded by the API.

**Fix:** New `offerTargetSalesPrice` field on `SourcingHubData` (stored in the existing `sourcing_hub` JSON column — no migration).
- OfferTab `handleContinueToSourcing` now sends it as `sourcingHub.offerTargetSalesPrice` on first POST.
- On 409 (record exists), it GETs current `sourcing_hub`, merges the new value in, PATCHes back, then navigates — so picking a different strategy and re-clicking Continue correctly updates Sourcing.
- Read precedence everywhere is now: hub.targetSalesPrice (Hub user override) ?? hub.offerTargetSalesPrice (Offer handoff) ?? originalPrice (ASIN price).
- Hub label is now 3-state and accurate: **"Overridden"** / **"From Offering"** / **"From Original ASIN"**. Reset button only shows when there's a Hub-level override AND a real source to reset to.

### 3. Calculation Accuracy ring defaulted to 6% on add
Root: `incoterms` was pre-set to `'DDP'` on new suppliers, counted as a filled basic field. `(1/8 basic × 15) / 30 = 6.25%` → 6%. Confusing because the user hasn't entered any data yet.

**Fix:** Default `incoterms` to `''` (empty). Dropdown shows a "Select…" disabled placeholder until picked. Ring stays at 0% until the user fills at least one real field. Downstream math is unaffected — the `quote.incoterms || 'DDP'` fallback pattern still handles empty values correctly.

## Files changed (7)

- `src/components/Offer/tabs/OfferTab.tsx` — Competitive card anchor; defaultPriceForStrategy; Continue-to-Sourcing 409 merge.
- `src/components/Sourcing/types.ts` — SourcingHubData.offerTargetSalesPrice.
- `src/components/Sourcing/sourcingStorage.ts` — incoterms default; sourcing_hub default.
- `src/components/Sourcing/tabs/SourcingHub.tsx` — read precedence, Reset button, 3-state label.
- `src/components/Sourcing/tabs/SupplierQuotesTab.tsx` — read precedence; incoterms dropdown placeholder.
- `src/components/Sourcing/tabs/PlaceOrderTab.tsx` — read precedence.
- `src/components/Sourcing/tabs/ProfitCalculatorTab.tsx` — read precedence.

## Test plan

- [ ] Open Offer page on a market with top-5 avg near 75th percentile. Competitive ≠ Premium after charm-99 snap.
- [ ] Pick Premium strategy → Target Launch Price = premium band value.
- [ ] Click Continue to Sourcing → Sourcing Hub shows the selected target price with **"From Offering"** label.
- [ ] Override target price in Sourcing Hub → label flips to **"Overridden (Offering: \$X.XX)"**. Reset button visible.
- [ ] Click Reset → falls back to Offer's price, label flips back to "From Offering".
- [ ] Go back to Offer, switch from Premium to Value, click Continue again → Sourcing Hub reads the new lower target.
- [ ] On a fresh sourcing record, Add Supplier → Calculation Accuracy ring shows **0%** (was 6%).
- [ ] Incoterms dropdown shows "Select…"; picking DDP/EXW/FOB advances accuracy correctly.
- [ ] Existing sourcing records (no offerTargetSalesPrice) display unchanged with "From Original ASIN" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)