### PR TITLE
Phase 6 V9 iter2: 7 polish items from prod feedback (A-G)

### DIFF
--- a/src/components/Offer/tabs/SspBuilderHubTab.tsx
+++ b/src/components/Offer/tabs/SspBuilderHubTab.tsx
@@ -1327,19 +1327,30 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                           />
                         </div>
                         <div className="flex-1 min-w-0">
-                          {/* Top action bar — Top Pick badge on the left,
-                              Ask AI + Lock on the right. The min-h reservation
-                              only applies when the badge is present so rows
-                              without a badge collapse to the natural button
-                              height instead of leaving a ghost gap. */}
-                          <div className={`flex items-center justify-between gap-3 mb-3 ${showTopPickBadge ? 'min-h-[28px]' : ''}`}>
-                            {showTopPickBadge && (
-                              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-300 border border-amber-500/40 shadow-[0_0_8px_rgba(251,191,36,0.15)]">
-                                <Sparkles className="w-3 h-3" />
-                                Top Pick
-                              </span>
-                            )}
-                            <div className="flex flex-wrap justify-end gap-2 ml-auto">
+                          {/* Action buttons sit inline with the title row so
+                              there's no separate bar leaving a ghost gap when
+                              there's no Top Pick badge. The badge (when
+                              present) renders inline above the title. */}
+                          <div className="flex items-start gap-3">
+                            <div className="flex-1 min-w-0">
+                              {showTopPickBadge && (
+                                <div className="mb-2">
+                                  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-300 border border-amber-500/40 shadow-[0_0_8px_rgba(251,191,36,0.15)]">
+                                    <Sparkles className="w-3 h-3" />
+                                    Top Pick
+                                  </span>
+                                </div>
+                              )}
+                              {item.recommendation?.trim() ? (
+                                <p className="text-base font-semibold text-slate-100 whitespace-pre-wrap leading-snug">{item.recommendation}</p>
+                              ) : (
+                                <p className="text-base font-medium text-slate-500 italic">New SSP</p>
+                              )}
+                              {item.why_it_matters && (
+                                <p className="text-sm text-slate-400 mt-2 leading-relaxed">{item.why_it_matters}</p>
+                              )}
+                            </div>
+                            <div className="flex flex-wrap justify-end gap-2 shrink-0">
                               <button
                                 onClick={() => setRowMode(itemId, 'ask', item)}
                                 className="px-2.5 py-1 rounded-full text-xs font-medium text-blue-50 bg-gradient-to-r from-blue-500/30 via-indigo-500/25 to-blue-500/30 hover:from-blue-500/40 hover:via-indigo-500/35 hover:to-blue-500/40 border border-blue-400/40 hover:border-blue-300/60 hover:shadow-[0_0_12px_rgba(59,130,246,0.35)] transition-shadow flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1372,19 +1383,6 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                 </button>
                               )}
                             </div>
-                          </div>
-
-                          {/* Title + body — full width now that the
-                              actions live above. */}
-                          <div>
-                            {item.recommendation?.trim() ? (
-                              <p className="text-base font-semibold text-slate-100 whitespace-pre-wrap leading-snug">{item.recommendation}</p>
-                            ) : (
-                              <p className="text-base font-medium text-slate-500 italic">New SSP</p>
-                            )}
-                            {item.why_it_matters && (
-                              <p className="text-sm text-slate-400 mt-2 leading-relaxed">{item.why_it_matters}</p>
-                            )}
                           </div>
                           {isExpanded && (
                             <div className="mt-3 rounded-lg border border-slate-700/60 bg-slate-900/50 p-3 space-y-3">

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -8,7 +8,6 @@ import {
   AlertCircle, 
   TrendingUp,
   BarChart3,
-  Trophy,
   Eye,
   EyeOff,
   GripVertical,
@@ -18,11 +17,12 @@ import {
   Lock
 } from 'lucide-react';
 import type { SupplierQuoteRow, SourcingHubData } from '../types';
-import { 
-  calculateQuoteMetrics, 
-  getAccuracyState, 
-  getRoiTier, 
+import {
+  calculateQuoteMetrics,
+  getAccuracyState,
+  getRoiTier,
   getMarginTier,
+  getTotalGrossProfitTier,
   type AccuracyState
 } from './SupplierQuotesTab';
 import { formatCurrency } from '@/utils/formatters';
@@ -199,7 +199,9 @@ export function ProfitCalculatorTab({
   
   // Matrix-specific state
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
-  const [hiddenSuppliers, setHiddenSuppliers] = useState<Set<string>>(new Set());
+  // Hidden state lives on the supplier row itself (q.isHidden) so it's
+  // bidirectional with Supplier Quotes — hiding here also hides on the
+  // Quotes tab (and excludes from the Sourcing Hub accuracy ring).
   const [supplierOrder, setSupplierOrder] = useState<string[]>([]);
   const [isDirty, setIsDirty] = useState(false);
   const [editingCell, setEditingCell] = useState<{ quoteId: string; rowKey: string } | null>(null);
@@ -419,13 +421,13 @@ export function ProfitCalculatorTab({
   
   // Get visible suppliers (for matrix display - excludes hidden)
   const visibleQuotes = useMemo(() => {
-    return filteredQuotes.filter(q => !hiddenSuppliers.has(q.id));
-  }, [filteredQuotes, hiddenSuppliers]);
+    return filteredQuotes.filter(q => !q.isHidden);
+  }, [filteredQuotes]);
   
   // Get hidden suppliers list
   const hiddenQuotesList = useMemo(() => {
-    return supplierQuotes.filter(q => hiddenSuppliers.has(q.id));
-  }, [supplierQuotes, hiddenSuppliers]);
+    return supplierQuotes.filter(q => q.isHidden);
+  }, [supplierQuotes]);
 
   // Sort quotes
   const sortedQuotes = useMemo(() => {
@@ -998,12 +1000,13 @@ export function ProfitCalculatorTab({
     { key: 'fbaFeePerUnit', label: 'FBA Fee/Unit', section: 'Amazon Fees', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', editable: true, inputType: 'number' },
     { key: 'totalFeesPerUnit', label: 'Total Fees/Unit', section: 'Amazon Fees', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
 
-    // SECTION 6 - Totals & Profit
+    // SECTION 6 - Bottom Line
+    // Cost rows first (slate band), outcome rows after (emerald band).
     { key: 'totalLandedUnitCost', label: 'Total Landed Unit Cost', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
+    { key: 'totalInvestment', label: 'Total Investment', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
     { key: 'profitPerUnit', label: 'Profit Per Unit', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', isProfitMetric: true },
     { key: 'margin', label: 'Margin', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? `${v.toFixed(1)}%` : '—', isProfitMetric: true },
     { key: 'roi', label: 'ROI', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? `${v.toFixed(1)}%` : '—', isProfitMetric: true },
-    { key: 'totalInvestment', label: 'Total Investment', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
     { key: 'totalGrossProfit', label: 'Total Gross Profit', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', isProfitMetric: true },
   ];
 
@@ -1104,25 +1107,16 @@ export function ProfitCalculatorTab({
     return collapsedSections.has(section);
   };
   
-  // Column hide/show handlers
+  // Column hide/show — toggles the persisted isHidden flag on the supplier
+  // row so the Supplier Quotes tab + Sourcing Hub also see the change.
   const toggleSupplierVisibility = (quoteId: string) => {
-    setHiddenSuppliers(prev => {
-      const next = new Set(prev);
-      if (next.has(quoteId)) {
-        next.delete(quoteId);
-      } else {
-        next.add(quoteId);
-      }
-      return next;
-    });
+    const quote = supplierQuotes.find(q => q.id === quoteId);
+    if (!quote) return;
+    handleUpdateQuote(quoteId, { isHidden: !quote.isHidden });
   };
   
   const showSupplier = (quoteId: string) => {
-    setHiddenSuppliers(prev => {
-      const next = new Set(prev);
-      next.delete(quoteId);
-      return next;
-    });
+    handleUpdateQuote(quoteId, { isHidden: false });
   };
   
   // Map matrix row key to SupplierQuoteRow field name based on tier
@@ -1556,19 +1550,38 @@ export function ProfitCalculatorTab({
         cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
       }
     } else if (rowDef.isProfitMetric) {
-      // Profit-metric cells: only emphasize Best (emerald). Best gets a
-      // soft glow + slightly larger typography to read as the bottom-line
-      // answer. Non-best cells stay readable but quiet.
-      if (isBest) {
-        cellClasses += ' bg-gradient-to-br from-emerald-900/50 via-emerald-800/30 to-teal-900/40 border border-emerald-400/50 text-emerald-200 font-bold text-base shadow-[0_0_16px_rgba(16,185,129,0.25)]';
+      // Profit-metric cells use the supplier-quotes tier coloring —
+      // red for bad, yellow for mediocre, emerald for good — so the
+      // user can scan the row and see quality at a glance, not just
+      // "best vs not-best." Best gets a slightly stronger ring to
+      // mark the winner without going boxy.
+      const cellNum = typeof displayValue === 'number' ? displayValue : null;
+      let tier: { textColor: string; bgColor: string; borderColor: string } | null = null;
+      if (rowDef.key === 'profitPerUnit') {
+        const t = getProfitPerUnitTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'margin') {
+        const t = getMarginTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'roi') {
+        const t = getRoiTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'totalGrossProfit') {
+        const t = getTotalGrossProfitTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      }
+      if (tier) {
+        cellClasses += ` ${tier.bgColor} ${tier.textColor} font-semibold`;
+        if (isBest) {
+          cellClasses += ` ring-1 ring-emerald-400/40 font-bold`;
+        }
       } else {
         cellClasses += ' bg-slate-800/20 text-slate-200';
       }
     } else if (rowDef.section === 'Totals & Profit') {
-      // Secondary totals (Total Landed Unit Cost / Total Investment) sit
-      // on a quieter slate band so they don't compete with the profit
-      // metrics above.
-      cellClasses += ' text-slate-400';
+      // Cost rows (Total Landed Unit Cost / Total Investment) sit on a
+      // continuous quiet slate band so they read as inputs, not outcomes.
+      cellClasses += ' bg-slate-800/40 text-slate-300';
     } else {
       cellClasses += ' text-slate-300';
     }
@@ -1606,96 +1619,47 @@ export function ProfitCalculatorTab({
         {isEditing ? (
           <div className="flex items-center justify-center gap-1 w-full">
             {rowDef.inputType === 'select' || rowDef.inputType === 'incoterms' ? (
-              <>
-                <select
-                  ref={inputRef as React.RefObject<HTMLSelectElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                >
-                  {rowDef.selectOptions?.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <select
+                ref={inputRef as React.RefObject<HTMLSelectElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              >
+                {rowDef.selectOptions?.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
             ) : rowDef.inputType === 'yesno' ? (
-              <>
-                <select
-                  ref={inputRef as React.RefObject<HTMLSelectElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                >
-                  <option value="Yes">Yes</option>
-                  <option value="No">No</option>
-                </select>
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <select
+                ref={inputRef as React.RefObject<HTMLSelectElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              >
+                <option value="Yes">Yes</option>
+                <option value="No">No</option>
+              </select>
             ) : rowDef.inputType === 'textarea' ? (
-              <div className="w-full">
-                <textarea
-                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500 resize-none mb-1"
-                  rows={3}
-                  autoFocus
-                  placeholder="Enter text... (Ctrl+Enter to save, Esc to cancel)"
-                />
-                <div className="flex gap-1 justify-end">
-                  <button
-                    onClick={handleSave}
-                    className="px-2 py-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Save"
-                  >
-                    <Check className="w-3 h-3" />
-                    Save
-                  </button>
-                  <button
-                    onClick={handleCancel}
-                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Cancel"
-                  >
-                    <X className="w-3 h-3" />
-                    Cancel
-                  </button>
-                </div>
-              </div>
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none resize-none"
+                rows={3}
+                autoFocus
+                placeholder="Ctrl+Enter to save, Esc to cancel"
+              />
             ) : rowDef.inputType === 'dimensions' || rowDef.inputType === 'cartonDimensions' ? (
               <div className="w-full">
-                <div className="grid grid-cols-3 gap-2 mb-1">
+                <div className="grid grid-cols-3 gap-2">
                   <div>
                     <label className="text-xs text-slate-400 block mb-0.5">L (cm)</label>
                     <input
@@ -1705,8 +1669,15 @@ export function ProfitCalculatorTab({
                       value={dimLength}
                       onChange={(e) => setDimLength(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Length"
+                      onBlur={(e) => {
+                        // Save when blur leaves the dimensions editor entirely.
+                        // currentTarget is the input, relatedTarget is the next focused element.
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="L"
                       autoFocus
                     />
                   </div>
@@ -1718,8 +1689,13 @@ export function ProfitCalculatorTab({
                       value={dimWidth}
                       onChange={(e) => setDimWidth(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Width"
+                      onBlur={(e) => {
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="W"
                     />
                   </div>
                   <div>
@@ -1730,83 +1706,40 @@ export function ProfitCalculatorTab({
                       value={dimHeight}
                       onChange={(e) => setDimHeight(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Height"
+                      onBlur={(e) => {
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="H"
                     />
                   </div>
                 </div>
-                <div className="flex gap-1 justify-end">
-                  <button
-                    onClick={handleSave}
-                    className="px-2 py-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Save"
-                  >
-                    <Check className="w-3 h-3" />
-                    Save
-                  </button>
-                  <button
-                    onClick={handleCancel}
-                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Cancel"
-                  >
-                    <X className="w-3 h-3" />
-                    Cancel
-                  </button>
-                </div>
               </div>
             ) : rowDef.inputType === 'text' ? (
-              <>
-                <input
-                  ref={inputRef as React.RefObject<HTMLInputElement>}
-                  type="text"
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                />
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                type="text"
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              />
             ) : (
-              <>
-                <input
-                  ref={inputRef as React.RefObject<HTMLInputElement>}
-                  type="number"
-                  step="any"
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                />
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                type="number"
+                step="any"
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              />
             )}
           </div>
         ) : (
@@ -1831,12 +1764,8 @@ export function ProfitCalculatorTab({
                 )}
               </>
             )}
-            {isBest && rowDef.isProfitMetric && (
-              <div className="flex items-center gap-1">
-                <Trophy className="w-4 h-4 text-emerald-400" aria-label="Best value" />
-                <span className="text-xs text-emerald-400 font-medium">Best</span>
-              </div>
-            )}
+            {/* "Best" is now communicated by a stronger ring on the cell
+                itself rather than a trophy — keeps the row scan-friendly. */}
           </div>
         )}
       </td>
@@ -1970,9 +1899,12 @@ export function ProfitCalculatorTab({
               <div className="overflow-x-auto">
                 <div className="inline-block min-w-full">
                   <table className="w-full border-collapse">
-                    <thead className="bg-slate-900/50 border-b border-slate-700/50 sticky top-0 z-10">
+                    {/* Supplier-name header sticks below the AppHeader (h-16 = 64px)
+                        so the names stay visible as the user scrolls through the
+                        matrix rows. z-30 keeps it above sticky cells (z-10/z-20) */}
+                    <thead className="bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50 sticky top-16 z-30">
                       <tr>
-                        <th className="sticky left-0 bg-slate-900/50 z-20 px-4 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-r border-slate-700/50 min-w-[200px]">
+                        <th className="sticky left-0 bg-slate-900/95 z-40 px-4 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-r border-slate-700/50 min-w-[200px]">
                           Key Supplier Info
                         </th>
                         <SortableContext
@@ -2035,7 +1967,6 @@ export function ProfitCalculatorTab({
                                 ) : (
                                   <ChevronUp className={isBottomLine ? 'w-4 h-4 text-emerald-300' : 'w-4 h-4'} />
                                 )}
-                                {isBottomLine && <Trophy className="w-4 h-4 text-emerald-300" />}
                                 <span className={isBottomLine ? 'text-emerald-200' : ''}>
                                   {isBottomLine ? 'Bottom Line — Profit, Margin & ROI' : rowDef.section}
                                 </span>
@@ -2057,24 +1988,24 @@ export function ProfitCalculatorTab({
                       
                       const hasRelativeData = hasAnyDataForRow(rowDef.key);
                       
-                      // Bottom-line section gets a richer treatment so it
-                      // visually reads as the answer, not just another row in
-                      // the matrix. Profit metrics (profitPerUnit, margin, roi,
-                      // totalGrossProfit) get an emerald-tinted gradient row;
-                      // secondary metrics (totalLandedUnitCost, totalInvestment)
-                      // sit on a quieter slate band.
+                      // Bottom-line section: cost rows (totalLandedUnitCost,
+                      // totalInvestment) form a continuous slate band; outcome
+                      // rows (profitPerUnit, margin, roi, totalGrossProfit)
+                      // form a continuous emerald band — no gaps. Each cell
+                      // within an outcome row picks up its own tier color
+                      // (red/yellow/emerald) for scan-friendly quality signal.
                       const isBottomLine = rowDef.section === 'Totals & Profit';
                       const rowClassName = isBottomLine
                         ? rowDef.isProfitMetric
-                          ? 'bg-gradient-to-r from-emerald-900/20 via-slate-900/0 to-emerald-900/10 font-semibold'
+                          ? 'bg-emerald-950/30 font-semibold'
                           : 'bg-slate-800/40'
                         : rowDef.isProfitMetric
                           ? 'bg-slate-800/30 font-semibold'
                           : 'hover:bg-slate-800/20';
                       const labelClassName = isBottomLine
                         ? rowDef.isProfitMetric
-                          ? 'sticky left-0 z-10 px-4 py-4 text-sm text-emerald-200 border-r border-emerald-500/20 font-bold uppercase tracking-wider bg-gradient-to-r from-emerald-900/40 via-slate-900/40 to-transparent'
-                          : 'sticky left-0 z-10 px-4 py-3 text-xs text-slate-400 border-r border-slate-700/50 font-medium uppercase tracking-wide bg-slate-800/60'
+                          ? 'sticky left-0 z-10 px-4 py-4 text-sm text-emerald-200 font-bold uppercase tracking-wider bg-emerald-950/60'
+                          : 'sticky left-0 z-10 px-4 py-3 text-xs text-slate-400 font-medium uppercase tracking-wide bg-slate-800/60'
                         : 'sticky left-0 bg-slate-800/50 z-10 px-4 py-3 text-sm text-slate-300 border-r border-slate-700/50 font-medium';
 
                       // Add data row

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -814,13 +814,13 @@ export const getProfitPerUnitTier = (value: number | null | undefined): ProfitPe
 };
 
 // Get Total Gross Profit tier and styling
-type TotalGrossProfitTier = {
+export type TotalGrossProfitTier = {
   label: string;
   textColor: string;
   bgColor: string;
   borderColor: string;
 };
-const getTotalGrossProfitTier = (value: number | null | undefined): TotalGrossProfitTier => {
+export const getTotalGrossProfitTier = (value: number | null | undefined): TotalGrossProfitTier => {
   if (value === null || value === undefined || isNaN(value)) {
     return {
       label: '—',
@@ -1572,6 +1572,13 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         handleUpdateQuote(quote.id, { displayName: e.target.value });
                       }}
                       onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => {
+                        // Enter blurs (commits the value); Tab is browser default.
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          e.currentTarget.blur();
+                        }
+                      }}
                       autoComplete="off"
                       autoCorrect="off"
                       autoCapitalize="off"

--- a/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
+++ b/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { ChevronDown, ChevronUp, Pencil, X, Save, CheckCircle2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Pencil, CheckCircle2 } from 'lucide-react';
 import { PLACE_ORDER_SCHEMA, type PlaceOrderField, type PlaceOrderSection } from './placeOrderSchema';
 import { getFieldValue, type ValueMapperContext } from './valueMapper';
 import { formatCurrency } from '@/utils/formatters';
@@ -590,43 +590,25 @@ function ChecklistRow({
       </td>
       <td className="py-3 px-3 overflow-hidden">
         {isEditing ? (
-          <div className="space-y-1">
-            <p className="text-xs text-slate-400">Confirm change?</p>
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                className="flex-1 px-2 py-1.5 bg-slate-700/50 border border-slate-600/50 rounded text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                autoFocus
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                spellCheck="false"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleSave();
-                  } else if (e.key === 'Escape') {
-                    onCancelEdit();
-                  }
-                }}
-              />
-              <button
-                onClick={handleSave}
-                className="p-1.5 text-emerald-400 hover:text-emerald-300 transition-colors"
-                title="Save"
-              >
-                <Save className="w-4 h-4" />
-              </button>
-              <button
-                onClick={onCancelEdit}
-                className="p-1.5 text-slate-400 hover:text-slate-300 transition-colors"
-                title="Cancel"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
+          <input
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            className="w-full px-2 py-1.5 bg-slate-700/50 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+            autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSave();
+              } else if (e.key === 'Escape') {
+                onCancelEdit();
+              }
+            }}
+            onBlur={handleSave}
+          />
         ) : (
           <div className="flex items-center gap-2">
             <span


### PR DESCRIPTION
## Summary

7 follow-up items from the iter1 testing round, bundled into one branch for one-link testing.

- **A** — SSP ghost gap fix. Buttons now render inline with the title; no separate action bar. Applies to both old and new SSP rows.
- **B** — Enter on the supplier displayName input now blurs (commits + exits edit). Tab is browser default.
- **C** — Bidirectional hide between Supplier Quotes and Profit Matrix. Both tabs now read/write the same persisted `isHidden` flag.
- **D** — Profit Matrix Bottom Line refinements: reordered (cost rows first, outcomes after), continuous emerald band, no Trophy, tier-based cell coloring (red/yellow/emerald per value), Best emphasized via ring not badge, less boxy.
- **E** — Sticky supplier-name header. `thead` uses `sticky top-16` (offset by AppHeader) with backdrop-blur + z-30.
- **F** — Profit Matrix cell editing: dropped green/red Save/Cancel buttons. Blur saves, Enter saves, Escape cancels.
- **G** — PO Checklist value editing: same treatment. No more Save/X icons.

4 files, +199 / −281 (net cleanup — drop a lot of UI chrome).

## Will merge to dev once you greenlight on this preview

Test on the iter2 preview (Vercel comment will post URL on this PR). One link.

## Test plan

**SSP page:**
- [ ] Older SSPs (re-open a previously generated batch) — no ghost gap above titles.
- [ ] New SSPs after an Ask AI run — same clean layout.
- [ ] Top Pick badge still renders inline above the title for top-picks.

**Supplier Quotes:**
- [ ] Click into supplier name field → type → hit Enter → input blurs (cursor leaves), value persists.
- [ ] Tab cycles through fields normally.
- [ ] Hide a supplier in Supplier Quotes → switch to Profit Matrix → it's hidden there too.
- [ ] Unhide from Profit Matrix → it reappears in Supplier Quotes too.

**Profit Matrix:**
- [ ] Bottom Line section: order is Total Landed Unit Cost, Total Investment, Profit Per Unit, Margin, ROI, Total Gross Profit (cost first, outcomes after).
- [ ] No Trophy icon anywhere. "Best" cell has a stronger emerald ring/font.
- [ ] Outcome cells colored per tier — bad values look red/yellow, good ones emerald.
- [ ] Continuous emerald band across outcome rows; no slate gap in the middle.
- [ ] Scroll the page → supplier names stick at top (below the AppHeader).
- [ ] Click a cell → input only, no Save/X buttons. Enter saves. Blur saves. Escape cancels.

**PO Checklist:**
- [ ] Click a value → input only, no Save/X icons. Enter saves. Blur saves. Escape cancels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)