### PR TITLE
Phase 6 V9 iter1+iter2: ship 8 PRs of polish to production

### DIFF
--- a/docs/handoffs/phase-6-v10-kickoff-prompt.md
+++ b/docs/handoffs/phase-6-v10-kickoff-prompt.md
@@ -1,0 +1,108 @@
+# Phase 6 V10 + Sprint E kickoff prompt
+
+Paste the block below into the next session.
+
+---
+
+```
+Picking up after Phase 6 V9 sourcing polish (shipped EOD 2026-05-08).
+Production at main 69cda8f — six PRs squash-merged via PR #38. Phase 6
+V9 is closed; Sprint C item 1 (mandatory-vs-nice indicators) finally
+landed after being paused for four sessions.
+
+Read in this order:
+1. docs/handoffs/phase-6-v9-shipped.md — full session summary. Section 4
+   has open follow-ups; section 7 lists candidate paths for next session.
+2. MEMORY.md — durable rules. New entries since last session:
+   feedback_push_freely_except_main.md (workflow rule),
+   project_phase_6_v9_ship_state.md (V9 ship state + V10 backlog).
+
+Verify production is healthy:
+git log -3 main          # top should be 69cda8f "Merge pull request #38 from growwithfba/dev"
+curl -s -o /dev/null -w "%{http_code}\n" https://www.bloomengine.ai/api/subscription/usage    # expect 401
+curl -s -o /dev/null -w "%{http_code}\n" https://www.bloomengine.ai/api/extension/me          # expect 401
+git checkout dev && git pull --ff-only origin main    # ensure dev is at 69cda8f
+
+---
+
+DON'T immediately code. Four path options for this session — present
+them via AskUserQuestion and let Dave choose:
+
+PATH A (recommended — quick prod validation, then pick a real track)
+Open BloomLens, create a fresh market, navigate to /vetting on
+production, confirm the V9 ship landed cleanly:
+- Real score + PASS/RISKY/FAIL pill on the dashboard list
+- Vetted-stage badge in the PROGRESS column
+- Detail page renders Sourcing Hub gauge in header band
+- Supplier Quotes mandatory asterisks visible
+- Profit Matrix tab labeled correctly with no Christmas red
+- Place Order Show Unmapped/Show Missing/Show Unconfirmed filters work
+- Download Purchase Order PDF renders the new branded layout
+
+After validating, Dave picks PATH B / C / D for the bulk of the
+session.
+
+PATH B (Sprint E launch readiness — strategic, conversational)
+V9 sourcing polish is done. The major remaining V9 track is public
+launch readiness. Several decisions Dave owes before code can start:
+- Soft-launch shape (invite-only beta cohort vs open Web Store)
+- Monitoring (Sentry vs Vercel logs)
+- Support channel (email vs Skool vs in-app chat)
+- Pricing page polish vs full marketing site
+- Onboarding tour scope
+- Demo video timing
+- Real case-study testimonials
+
+This session would be conversational — picking directions — not
+heavy coding.
+
+PATH C (V10 Phase 6 redesign — heavy code, ~3-4 weeks total)
+Per the Flavor 1 plan locked at the start of V9, V10 is the bigger
+redesign track that V9 deferred. Sub-phases:
+- 6.A FBA fee infra (hardcoded table + quarterly maintenance workflow)
+- 6.B Supplier Quotes 3-tab restructure (Supplier Info / Basic Calc /
+       Advanced Calc) + Advanced cleanup with SSP+Sampling separation
+- 6.C Profit Matrix full data-presentation redesign
+- 6.D Place Order Agreed Order Summary + checklist front-loading
+       walk-through
+- 6.E Sourced Products dashboard expansion (column-picker + cross-
+       funnel data integration)
+- 6.F Adds (subset of B1-B8 from the original 15-item plan)
+
+Best done after Sprint E ships, but Dave can elect to start now if
+launch readiness can wait. Pick a sub-phase to scope.
+
+PATH D (BloomLens follow-ups — small, contained)
+- bloom-lens-extension has a local-only commit (d56f1a4) for markets
+  picker score color coding. Push, zip into v0.5.9 once v0.5.8 clears
+  Web Store review.
+- Investigate whether v0.5.8 has been approved (Google review in
+  progress as of 2026-05-08).
+
+---
+
+Standing rules (don't break):
+- PRs target dev, never main without explicit instruction
+- Push to feature/dev branches without asking; only main needs OK
+- Don't punt merges to Dave — push + PR + merge are mine to drive
+- Never combine commit + merge + push in one chained command
+- No round numbers in displayed metrics
+- No "Keepa" in user-facing copy
+- "BloomLens" is one word
+- No Stripe-hosted redirects
+- Production = main, dev = preview
+- effectiveTier ≠ tier for display
+- Adjustments and Expansions are separate concepts
+- BloomLens always hits production — feature work touching extension
+  writes needs prod-ship OR legacy-fallback to E2E test
+- Some /vetting matrix metrics are client-side derived, not recalc-
+  driven
+- Charm-pricing — Value/Competitive/Premium tiers snap to nearest .99
+  via roundToCharm99()
+- Optional numeric schema fields land as undefined not just null;
+  use isFiniteNumber() for value guards
+```
+
+---
+
+That's the prompt. The block between the triple-backticks is what gets pasted into the next session.

--- a/docs/handoffs/phase-6-v9-shipped.md
+++ b/docs/handoffs/phase-6-v9-shipped.md
@@ -1,0 +1,207 @@
+# Phase 6 V9 sourcing polish — shipped to production (2026-05-08 EOD)
+
+**Production state:** `main` at `69cda8f` (Vercel deployed). Phase 6 V9 closes the sourcing-page polish work that started as Sprint C item 1 (mandatory-vs-nice indicators) and grew into a full sweep across the Sourcing Hub, Supplier Quotes tab, Profit Matrix tab, Place Order tab, and the BloomLens-import → /vetting flow.
+
+---
+
+## 1. What shipped
+
+### Production progressed `476d48e` → `69cda8f` (1 merge commit + 6 squash commits)
+
+| Squash | PR | What |
+|---|---|---|
+| `c74f0a3` | #32 | **V9 polish (foundational).** DDP-Basic field-mapping bug fixes (Cost row showed shipping value, Freight/Duty was empty, ROI inflated, totalInvestment understated). Sticky-header flicker fix on short pages. Hub gauge sizing. Profit "Overview" → "Profit Matrix" rename + dropped Christmas-tree red. Sourced Products pill consistency. Sandbox tightening. Supplier Info dropdown bug + "Show/Hide" affordance. **Sprint C item 1: mandatory-vs-nice asterisks** (8 Basic + 12 Advanced fields). Multi-supplier row chrome (alternating blue/purple left accent). Section visual hierarchy. Target Sales Price reads from Offering w/ override. |
+| `3e3849d` | #33 | **V9 polish 2.** Product Category mirrors From-Research/Reset pattern. Supplier Quotes empty state cleanup. CBM/Total CBM derived-field demote. Agreed Order Summary visual hierarchy (4 emphasized money cards + 5 demoted secondary stats). SSP+Sampling visual separation under "Quality & Differentiation" caption. |
+| `75e0689` | #34 | **Pre-main 1.** Vetting list "Product" → "Market". Continue to Sourcing button purple/indigo branding. CBM AUTO-tag overflow fix. PO Checklist progress bar tier-colored. "Show Agreed" → "Show Unmapped" filter (rewired to filter on `mapped===false`). $NaN bug in Place Order mapped Freight/Duty/Tariff cells. Offering-tab flicker fix. Value/Competitive/Premium prices snap to nearest $0.99. BloomLens auto-score on creation. Re-enabled Download Purchase Order PDF button. |
+| `1458ff9` | #35 | **Pre-main 2.** Continue to Sourcing 409 → silent navigate. Whole supplier row click-to-toggle. Profit Matrix toolbar trim (View toggle, Hide Incomplete, Hide Pending dropped). SSP Remove → small trash icon. Drop AUTO tag from CBM. Sample Quality slider polish (tier label + colored fill + bigger thumb). PO row click-to-edit. Show Unmapped no longer leaves empty ghost sections. **Redesigned Purchase Order PDF** (branded header, Buyer/Supplier blocks, emerald money-stats box, full sections, dual signature block, page footers). |
+| `a55b240` | #36 | **Pre-main 3.** /api/analyze GET transitional fallback — derives score on-the-fly when `sub.score` is null AND `__lens_origin === true`. Currency formatting on cost / price / fee mapped fields. SSP section now expandable with optional fields rendered inline ("Confirm to include in PO"). Confirm button blocked while editing. New "Show Missing" filter on PO Checklist. |
+| `0063183` | #37 | **Pre-main 4.** analyze-market sets `research_products.is_vetted=true` on create. Dashboard.tsx derives is_vetted from score as self-healing fallback for existing data — Bento Box and other already-existing BloomLens markets render the vetted-stage badge without a DB backfill. |
+| `69cda8f` | #38 | **dev → main promotion.** All six PRs land in production together. |
+
+### End-to-end validated on Vercel preview before promotion
+
+- ✅ DDP-Basic supplier on Profit Matrix shows correct Cost row + Freight/Duty Combined row + ROI matches profit math
+- ✅ Profit Matrix incoterms cell editable bidirectionally; Supplier Quotes Pricing/Terms dropdown updates in lockstep
+- ✅ Sourcing detail pages with no supplier quotes — scrolling to the bottom no longer flickers the ProductHeader
+- ✅ Sourcing Hub gauge sized to L/R column heights; "CALCULATION ACCURACY" label sits in the header band
+- ✅ Supplier Quotes mandatory fields show red `*`; nice-to-haves no longer amber-tint when empty
+- ✅ Whole supplier row click toggles expand/collapse (except name field, pencil, checkbox)
+- ✅ PO Checklist progress bar: red → amber → yellow → emerald as fields confirm
+- ✅ Show Unmapped / Show Missing / Show Unconfirmed filters mutually exclusive
+- ✅ Place Order row click-to-edit; Confirm blocked during edit
+- ✅ Currency formatting on PO cost cells: `0.5` → `$0.50`, `0.245` → `$0.25`
+- ✅ SSP section expandable with "Confirm to include in PO" header
+- ✅ Redesigned PO PDF — branded header, two-col Buyer/Supplier, emerald money-stats box
+- ✅ BloomLens-imported markets show real PASS/RISKY/FAIL pill + vetted-stage badge (Bento Box, Double Rods Rack)
+
+---
+
+## 2. Files changed today (16 files; +1750 / -540)
+
+### New
+- `docs/handoffs/phase-5.4-M-rotations-shipped.md` (carried over)
+- `docs/handoffs/phase-5.4-N-kickoff-prompt.md` (carried over)
+- `docs/handoffs/phase-5.4-N-shipped-and-lens-redesign.md` (carried over)
+- `docs/handoffs/phase-5.4-O-kickoff-prompt.md` (carried over)
+- `docs/handoffs/phase-5.4-O-shipped.md` (carried over)
+- `.claude/settings.json`
+
+### Modified
+
+| File | Why |
+|---|---|
+| `src/components/Sourcing/tabs/ProfitCalculatorTab.tsx` | DDP cost-row replacement dropped; freightDutyCombined fallback picks up `ddpPrice` for DDP; renamed everywhere; Christmas-tree styling stripped (no red `isWorst`, only emerald Best); peer-missing two-tier amber/slate; bidirectional incoterms edit; toolbar trim. |
+| `src/components/Sourcing/tabs/SupplierQuotesTab.tsx` | landedUnitCost reuses `shippingCost`; `costPrice` cascade adds `exwUnitCost`; mandatory asterisks on 20 labels + nice-to-have `getOptionalFieldClass()`; multi-supplier row chrome with blue/purple accent; section header normalization; CBM derived-field demote (then dropped AUTO tag in pre-main 2); Sample Quality slider polish; whole-row click-to-toggle; Inspection Cost/Unit relabeled (was "Misc"). |
+| `src/components/Sourcing/tabs/SourcingHub.tsx` | Gauge sized 200→170→200 (settled); CALCULATION ACCURACY label in header band; Target Sales Price + Product Category override pattern with Reset link. |
+| `src/components/Sourcing/tabs/SourcingSandbox.tsx` | Tightened padding/gaps; right column stretches via flex-1 to match left column height. |
+| `src/components/Sourcing/SourcingDetailContent.tsx` | min-h-[calc(100vh+12rem)] guard against sticky-toggle flicker; tab nav "Profit Overview" → "Profit Matrix". |
+| `src/components/Sourcing/SourcingPageContent.tsx` | Status pill px-3 py-1 to match Vetting; Margin/ROI dropped to plain colored text. |
+| `src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx` | Show Unmapped/Show Missing/Show Unconfirmed filters; tier-colored progress bar; row click-to-edit; Confirm blocked during edit; optional fields render inline; section hide when filter empties; currency formatting helper. |
+| `src/components/Sourcing/tabs/placeOrder/valueMapper.ts` | `isFiniteNumber()` guard for mapped numeric fields fixed `$NaN` bug. |
+| `src/components/Sourcing/tabs/placeOrder/pdf.ts` | Full rewrite — branded header, Buyer/Supplier two-col blocks, emerald money-stats box, sectioned details, dual signature block, footers. ~407 added / 145 deleted. |
+| `src/components/Sourcing/tabs/PlaceOrderTab.tsx` | Agreed Order Summary visual hierarchy (4 cards + 5 demoted); Download PDF re-enabled with purple gradient. |
+| `src/components/Offer/tabs/OfferTab.tsx` | Charm-pricing helper `roundToCharm99()`; Continue to Sourcing 409 silent-navigate; purple/indigo branding. |
+| `src/components/Offer/OfferDetailContent.tsx` | Sticky-flicker min-h guard. |
+| `src/components/dashboard/Dashboard.tsx` | "Product" column → "Market"; client-side `isVettedDerived` fallback. |
+| `src/utils/learnVideos.ts` | "Profit Overview Tab" → "Profit Matrix Tab" + title. |
+| `src/app/api/analyze/route.ts` | GET endpoint computes `derivedScore` + `derivedStatus` on-the-fly for Lens-origin submissions with null score. |
+| `src/app/api/extension/analyze-market/route.ts` | Auto-score on create via `calculateMarketScore`; `is_vetted=true` set on research_products in both upsert branches. |
+
+---
+
+## 3. Repo state (end of day 2026-05-08)
+
+| Repo | Branch | Tip | Status |
+|---|---|---|---|
+| bloomengine | `main` | `69cda8f` | **Production. Vercel deployed.** Phase 6 V9 live. |
+| bloomengine | `dev` | `0063183` | Synced via PR #38 promotion. |
+| bloom-lens-extension | `phase-5-2-bottom-drawer-pivot` | `d56f1a4` | Local commit (markets-picker score colors) — **not pushed**. v0.5.8 still awaiting Web Store review; will roll into v0.5.9 zip. |
+
+### Branches deleted today
+- `phase-6-v9-field-mapping` (renamed to `phase-6-v9-polish` mid-session, then merged + deleted via #32)
+- `phase-6-v9-polish-2` (#33)
+- `phase-6-v9-pre-main-fixes` (#34)
+- `phase-6-v9-pre-main-fixes-2` (#35)
+- `phase-6-v9-pre-main-fixes-3` (#36)
+- `phase-6-v9-pre-main-fixes-4` (#37)
+
+### MEMORY.md additions today
+- `feedback_push_freely_except_main.md` — "Push to feature/dev branches without asking; only main needs explicit OK."
+- `project_phase_6_v9_ship_state.md` — full shipped state + V10 backlog.
+
+---
+
+## 4. What's open / blocked
+
+### Carry-overs (not blocked, just awaiting external)
+1. **Web Store v0.5.8 reviewer approval** — Google review still in progress. Once approved + propagated, delete the `return false;` early-return at the top of `src/hooks/useExtensionInstalled.ts` to re-enable detection.
+2. **bloom-lens-extension `d56f1a4`** — local-only commit (markets-picker score colors). Will roll into v0.5.9 zip after v0.5.8 lands.
+
+### V10 backlog (per project_phase_6_v9_ship_state.md memory)
+1. **Sourcing dashboard column-picker** with vetting/offering data (was #1 in Dave's original 15-item Phase 6 ask)
+2. **FBA fee auto-populate** via SP-API + quarterly maintenance agent (#2/#8)
+3. **Supplier Quotes 3-tab restructure** — Supplier Info / Basic Calc / Advanced Calc (#7's bigger ask)
+4. **Profit Matrix full data-presentation redesign** (#11's bigger ask)
+5. **Place Order Agreed Order Summary full redesign** + checklist front-loading walk-through (#13/#14)
+6. **Hub treatment full overhaul** across all three tabs (#15)
+7. **Auto-trigger Market Climate generation** on first BloomLens-market detail-page view (currently manual)
+8. **Drop the `__lens_origin` score-derivation fallback** in `/api/analyze` — once the auto-score-on-create fix has been in production for ~7 days and existing pre-fix markets have either been manually recalced or expired
+
+### Sprint E (V9 launch readiness — separate track)
+Strategic decisions still owed:
+- Soft-launch shape (invite-only beta vs open Web Store)
+- Monitoring (Sentry vs Vercel logs)
+- Support channel (email vs Skool vs in-app chat)
+- Pricing page polish vs full marketing site
+- Onboarding tour scope
+- Demo video timing
+
+---
+
+## 5. Lessons captured to memory
+
+1. **Push-to-feature-branch rule** — Dave updated the global "pause before push" instruction: push freely on any branch except `main`. Saved to `feedback_push_freely_except_main.md`.
+2. **BloomLens always hits production** (carried over) — feature work that depends on extension-write paths can't be E2E validated on a Vercel preview alone. Either ship to prod first OR build a transitional read-side fallback (as today's score-derivation in `/api/analyze` did).
+3. **Optional schema fields can land as `undefined`, not just `null`** — `field !== null` accepts `undefined`, which slipped past in `valueMapper.ts` and produced `$NaN` in mapped checklist cells. Use `isFiniteNumber()` (the helper introduced in pre-main 1) for any numeric guard going forward.
+4. **Charm-pricing semantics** — when rounding marketing prices, snap to the nearest `.99` (favoring round-up on ties). Helper `roundToCharm99()` in `OfferTab.tsx` is the reference impl.
+
+---
+
+## 6. Sprint status (V9 roadmap)
+
+| Item | Status |
+|---|---|
+| Phase 6 V9 Sourcing polish | ✅ shipped 2026-05-08 (this batch) |
+| Phase 6 V9 — Sprint C item 1 (mandatory-vs-nice) | ✅ shipped (was paused for 4 sessions) |
+| Web Store v0.5.8 propagation | 🟡 pending Google review |
+| Re-enable extension detection | ⏳ pending v0.5.8 propagation |
+| BloomLens UI polish backlog | ⏳ ongoing |
+| Sprint E launch readiness | 🔜 next major track |
+
+**V9 sourcing polish is closed.** Two carry-overs are external (Google review). Next major track per the V9 roadmap is Sprint E (public launch readiness).
+
+---
+
+## 7. Next session candidates
+
+### PATH A — Validate the V9 ship in production (10 min)
+Open BloomLens, create a fresh market, navigate to /vetting, confirm:
+- Real score shows up
+- PASS/RISKY/FAIL pill renders
+- Vetted-stage badge in PROGRESS column
+- Detail page Sourcing Hub + Supplier Quotes + Profit Matrix + Place Order tabs all reflect the V9 polish
+
+Probably worth doing FIRST in next session before picking other work.
+
+### PATH B — Sprint E launch readiness (strategic, conversational)
+Pick directions on:
+- Soft-launch shape
+- Monitoring stack (Sentry vs Vercel logs)
+- Support channel
+- Pricing page polish vs full marketing site
+- Onboarding tour scope
+- Demo video timing
+
+These are decisions Dave owes; nothing to implement until directions are picked.
+
+### PATH C — V10 Phase 6 redesign track
+Big work. Per the locked Flavor 1 plan (V9 ships fast, V10 rebuilds):
+- 6.A FBA fee infra (hardcoded table + quarterly maintenance workflow)
+- 6.B Supplier Quotes 3-tab restructure + Advanced cleanup with SSP+Sampling separation
+- 6.C Profit Matrix overhaul
+- 6.D Place Order Agreed Order Summary + checklist walk-through
+- 6.E Sourced Products dashboard expansion (column-picker + cross-funnel data)
+- 6.F Adds (subset to be picked from B1-B8)
+
+Estimated 3-4 weeks of focused work. Best done after Sprint E ships.
+
+### PATH D — BloomLens follow-ups
+- Score pill color coding in markets picker (`d56f1a4` local commit ready to bundle)
+- Roll into v0.5.9 zip + Web Store upload once v0.5.8 is approved
+
+---
+
+## 8. Standing rules (don't break)
+
+1. PRs target `dev`, never `main` without explicit instruction.
+2. Push to feature/dev branches without asking; only `main` requires explicit OK (per `feedback_push_freely_except_main.md`).
+3. Don't punt the merge to Dave — push + PR + merge are mine to drive after testing greenlight.
+4. Never combine commit + merge + push in one chained command.
+5. **NO ROUND NUMBERS in displayed metrics.** BSR-curve drives display.
+6. No "Keepa" in user-facing copy.
+7. "BloomLens" is one word in user-facing surfaces.
+8. **No Stripe-hosted page redirects.**
+9. Tolerance-based numeric checks for AI / rounded values.
+10. Production deploys from `main`. Dev = preview.
+11. **`effectiveTier` ≠ `tier` for display.**
+12. **Adjustments and Expansions are separate concepts.**
+13. **BloomLens always hits production**, regardless of preview URL. Feature work that depends on extension-write paths needs prod ship OR a transitional legacy-data fallback.
+14. Some `/vetting/[asin]` matrix metrics are client-side derived from `competitors`, not from a persisted column. Recalc only changes score, AI briefing, BSR/Price stability.
+15. **NEW (2026-05-08):** Charm-pricing — Value/Competitive/Premium tiers snap to nearest `.99` via `roundToCharm99()`.
+16. **NEW (2026-05-08):** Optional numeric schema fields land as `undefined` not just `null`. Use `isFiniteNumber()` for value guards.
+
+---
+
+## 9. Tomorrow's first message to Claude
+
+Use the kickoff prompt at: `docs/handoffs/phase-6-v10-kickoff-prompt.md`

--- a/src/app/api/extension/markets/route.ts
+++ b/src/app/api/extension/markets/route.ts
@@ -31,6 +31,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
+import { calculateMarketScore } from '@/utils/scoring';
 import {
   corsPreflight,
   deriveEffectiveLensTier,
@@ -111,11 +112,39 @@ export async function GET(request: NextRequest) {
         : r.research_products;
       const displayName =
         typeof research?.display_name === 'string' ? research.display_name.trim() : '';
+      // Transitional fallback: BloomLens-origin submissions created before
+      // the auto-score-on-create fix landed (PR #37, 2026-05-08) have score
+      // null even though they have competitors. Compute on-the-fly so the
+      // markets picker shows a real score badge instead of "Pre-vet" until
+      // the next user-driven Recalc heals the row. Mirrors the same fallback
+      // in /api/analyze GET; remove both once pre-fix rows have been
+      // recalced or have aged out.
+      let derivedScore: number | null = typeof r.score === 'number' ? r.score : null;
+      let derivedStatus: string | null = r.status ?? null;
+      if (
+        (derivedScore === null || derivedStatus === null) &&
+        r.submission_data?.__lens_origin === true
+      ) {
+        const competitors = r.submission_data?.productData?.competitors || [];
+        if (competitors.length > 0) {
+          try {
+            const computed = calculateMarketScore(
+              competitors,
+              r.submission_data?.keepaResults || []
+            );
+            derivedScore = computed.score;
+            derivedStatus = computed.status;
+          } catch (e) {
+            console.error('extension/markets: score derivation failed for', r.id, e);
+          }
+        }
+      }
+
       return {
         id: r.id,
         title: displayName || r.product_name || r.title || 'Untitled market',
-        score: typeof r.score === 'number' ? r.score : null,
-        status: r.status ?? null,
+        score: derivedScore,
+        status: derivedStatus,
         competitorCount: metricsCount ?? fallbackCount,
         updatedAt: r.updated_at ?? r.created_at,
       };

--- a/src/components/Offer/tabs/OfferTab.tsx
+++ b/src/components/Offer/tabs/OfferTab.tsx
@@ -82,7 +82,9 @@ function defaultPriceForStrategy(strategy: PriceStrategy, band: PriceBand): numb
   let raw: number | null;
   if (strategy === 'premium')        raw = band.premium ?? band.top5Avg ?? band.median;
   else if (strategy === 'value')     raw = band.value   ?? band.median;
-  else                                raw = band.top5Avg ?? band.median ?? band.premium;
+  // Competitive == "Match the market" → market median is the anchor.
+  // Falls back to top-5 avg only when median is missing.
+  else                                raw = band.median  ?? band.top5Avg ?? band.premium;
   return roundToCharm99(raw);
 }
 
@@ -160,15 +162,28 @@ export function OfferTab({
     setPushError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
+      const authHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+      };
+
+      // Carry the user's selected target launch price into the Sourcing Hub
+      // via the sourcing_hub.offerTargetSalesPrice field. Sourcing Hub reads
+      // this as the "From Offering" default ahead of the original ASIN price.
+      const initialSourcingHub = {
+        targetSalesPrice: null,
+        categoryOverride: null,
+        referralFeePct: null,
+        offerTargetSalesPrice: targetPrice,
+      };
+
       const res = await fetch('/api/sourcing', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
-        },
+        headers: authHeaders,
         body: JSON.stringify({
           productId,
           asin,
+          sourcingHub: initialSourcingHub,
           offerContext: {
             lockedSsps: lockedByCategory.flatMap((c) =>
               c.items.map((item) => ({ category: c.key, ...item }))
@@ -178,12 +193,41 @@ export function OfferTab({
           },
         }),
       });
+
+      if (res.status === 409) {
+        // Record already exists. Merge offerTargetSalesPrice into the existing
+        // sourcing_hub so a fresh strategy pick from Offer flows through, then
+        // navigate to the existing sourcing page.
+        try {
+          const getRes = await fetch(`/api/sourcing?productId=${encodeURIComponent(productId)}`, {
+            headers: authHeaders,
+          });
+          if (getRes.ok) {
+            const payload = await getRes.json();
+            const existingHub = payload?.data?.sourcing_hub || {};
+            await fetch('/api/sourcing', {
+              method: 'PATCH',
+              headers: authHeaders,
+              body: JSON.stringify({
+                productId,
+                sourcingHub: {
+                  ...existingHub,
+                  offerTargetSalesPrice: targetPrice,
+                },
+              }),
+            });
+          }
+        } catch {
+          // Non-fatal — navigate even if the patch fails so the user isn't blocked.
+        }
+        router.push(`/sourcing/${encodeURIComponent(asin)}`);
+        return;
+      }
+
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
-        // 409 = record already exists. That's expected for re-entry; we
-        //       just navigate to the existing sourcing page.
         // 404/405 = sourcing endpoint missing; fall back to navigation.
-        if (res.status === 409 || res.status === 404 || res.status === 405) {
+        if (res.status === 404 || res.status === 405) {
           router.push(`/sourcing/${encodeURIComponent(asin)}`);
           return;
         }
@@ -314,7 +358,7 @@ export function OfferTab({
                 onClick={() => setStrategy('competitive')}
                 title="Competitive"
                 subtitle="Match the market"
-                price={roundToCharm99(priceBand.top5Avg ?? priceBand.median)}
+                price={roundToCharm99(priceBand.median ?? priceBand.top5Avg)}
                 accent="blue"
               />
               <StrategyCard

--- a/src/components/Offer/tabs/SspBuilderHubTab.tsx
+++ b/src/components/Offer/tabs/SspBuilderHubTab.tsx
@@ -1327,19 +1327,30 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                           />
                         </div>
                         <div className="flex-1 min-w-0">
-                          {/* Top action bar — Top Pick badge on the left,
-                              Ask AI + Lock on the right. The min-h reservation
-                              only applies when the badge is present so rows
-                              without a badge collapse to the natural button
-                              height instead of leaving a ghost gap. */}
-                          <div className={`flex items-center justify-between gap-3 mb-3 ${showTopPickBadge ? 'min-h-[28px]' : ''}`}>
-                            {showTopPickBadge && (
-                              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-300 border border-amber-500/40 shadow-[0_0_8px_rgba(251,191,36,0.15)]">
-                                <Sparkles className="w-3 h-3" />
-                                Top Pick
-                              </span>
-                            )}
-                            <div className="flex flex-wrap justify-end gap-2 ml-auto">
+                          {/* Action buttons sit inline with the title row so
+                              there's no separate bar leaving a ghost gap when
+                              there's no Top Pick badge. The badge (when
+                              present) renders inline above the title. */}
+                          <div className="flex items-start gap-3">
+                            <div className="flex-1 min-w-0">
+                              {showTopPickBadge && (
+                                <div className="mb-2">
+                                  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-300 border border-amber-500/40 shadow-[0_0_8px_rgba(251,191,36,0.15)]">
+                                    <Sparkles className="w-3 h-3" />
+                                    Top Pick
+                                  </span>
+                                </div>
+                              )}
+                              {item.recommendation?.trim() ? (
+                                <p className="text-base font-semibold text-slate-100 whitespace-pre-wrap leading-snug">{item.recommendation}</p>
+                              ) : (
+                                <p className="text-base font-medium text-slate-500 italic">New SSP</p>
+                              )}
+                              {item.why_it_matters && (
+                                <p className="text-sm text-slate-400 mt-2 leading-relaxed">{item.why_it_matters}</p>
+                              )}
+                            </div>
+                            <div className="flex flex-wrap justify-end gap-2 shrink-0">
                               <button
                                 onClick={() => setRowMode(itemId, 'ask', item)}
                                 className="px-2.5 py-1 rounded-full text-xs font-medium text-blue-50 bg-gradient-to-r from-blue-500/30 via-indigo-500/25 to-blue-500/30 hover:from-blue-500/40 hover:via-indigo-500/35 hover:to-blue-500/40 border border-blue-400/40 hover:border-blue-300/60 hover:shadow-[0_0_12px_rgba(59,130,246,0.35)] transition-shadow flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1372,19 +1383,6 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                 </button>
                               )}
                             </div>
-                          </div>
-
-                          {/* Title + body — full width now that the
-                              actions live above. */}
-                          <div>
-                            {item.recommendation?.trim() ? (
-                              <p className="text-base font-semibold text-slate-100 whitespace-pre-wrap leading-snug">{item.recommendation}</p>
-                            ) : (
-                              <p className="text-base font-medium text-slate-500 italic">New SSP</p>
-                            )}
-                            {item.why_it_matters && (
-                              <p className="text-sm text-slate-400 mt-2 leading-relaxed">{item.why_it_matters}</p>
-                            )}
                           </div>
                           {isExpanded && (
                             <div className="mt-3 rounded-lg border border-slate-700/60 bg-slate-900/50 p-3 space-y-3">

--- a/src/components/Offer/tabs/SspBuilderHubTab.tsx
+++ b/src/components/Offer/tabs/SspBuilderHubTab.tsx
@@ -1328,26 +1328,26 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                         </div>
                         <div className="flex-1 min-w-0">
                           {/* Top action bar — Top Pick badge on the left,
-                              Refine + Lock on the right. Keeps the title +
-                              body underneath full-width and uncluttered. */}
-                          <div className="flex items-center justify-between gap-3 mb-3 min-h-[28px]">
-                            {showTopPickBadge ? (
+                              Ask AI + Lock on the right. The min-h reservation
+                              only applies when the badge is present so rows
+                              without a badge collapse to the natural button
+                              height instead of leaving a ghost gap. */}
+                          <div className={`flex items-center justify-between gap-3 mb-3 ${showTopPickBadge ? 'min-h-[28px]' : ''}`}>
+                            {showTopPickBadge && (
                               <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-300 border border-amber-500/40 shadow-[0_0_8px_rgba(251,191,36,0.15)]">
                                 <Sparkles className="w-3 h-3" />
                                 Top Pick
                               </span>
-                            ) : (
-                              <span aria-hidden />
                             )}
                             <div className="flex flex-wrap justify-end gap-2 ml-auto">
                               <button
-                                onClick={() => setRowMode(itemId, 'refine', item)}
-                                className="px-2.5 py-1 rounded-full text-xs font-medium text-indigo-50 bg-gradient-to-r from-indigo-500/30 via-purple-500/25 to-blue-500/30 hover:from-indigo-500/40 hover:via-purple-500/35 hover:to-blue-500/40 border border-indigo-400/40 hover:border-indigo-300/60 hover:shadow-[0_0_12px_rgba(99,102,241,0.35)] transition-shadow flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
-                                disabled={refineDisabled}
-                                title={refineDisabled ? 'Add an SSP before refining.' : undefined}
+                                onClick={() => setRowMode(itemId, 'ask', item)}
+                                className="px-2.5 py-1 rounded-full text-xs font-medium text-blue-50 bg-gradient-to-r from-blue-500/30 via-indigo-500/25 to-blue-500/30 hover:from-blue-500/40 hover:via-indigo-500/35 hover:to-blue-500/40 border border-blue-400/40 hover:border-blue-300/60 hover:shadow-[0_0_12px_rgba(59,130,246,0.35)] transition-shadow flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                                disabled={askDisabled}
+                                title={askDisabled ? 'Add an SSP before asking.' : undefined}
                               >
                                 <Wand2 className="w-3 h-3" />
-                                Refine
+                                Ask AI
                               </button>
                               <button
                                 onClick={() => handleToggleLock(category.key, idx, item)}
@@ -1400,18 +1400,6 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                   Edit
                                 </button>
                                 <button
-                                  onClick={() => setRowMode(itemId, 'refine', item)}
-                                  className={`px-3 py-1 rounded-full text-xs border disabled:opacity-50 disabled:cursor-not-allowed ${
-                                    activeMode === 'refine'
-                                      ? 'bg-indigo-500/20 text-indigo-200 border-indigo-400/50'
-                                      : 'bg-slate-800/70 text-slate-300 border-slate-700/60 hover:border-slate-500/70'
-                                  }`}
-                                  disabled={refineDisabled}
-                                  title={refineDisabled ? 'Add an SSP before refining.' : undefined}
-                                >
-                                  Refine
-                                </button>
-                                <button
                                   onClick={() => setRowMode(itemId, 'ask', item)}
                                   className={`px-3 py-1 rounded-full text-xs border disabled:opacity-50 disabled:cursor-not-allowed ${
                                     activeMode === 'ask'
@@ -1419,7 +1407,7 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                       : 'bg-slate-800/70 text-slate-300 border-slate-700/60 hover:border-slate-500/70'
                                   }`}
                                   disabled={askDisabled}
-                                  title={askDisabled ? 'Add an SSP before refining.' : undefined}
+                                  title={askDisabled ? 'Add an SSP before asking.' : undefined}
                                 >
                                   Ask AI
                                 </button>
@@ -1469,63 +1457,6 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                   </div>
                                 </div>
                               )}
-                              {activeMode === 'refine' && (
-                                <div className="space-y-2">
-                                  <textarea
-                                    rows={3}
-                                    value={refinePrompt}
-                                    onChange={(e) =>
-                                      setRefinePromptById(prev => ({ ...prev, [itemId]: e.target.value }))
-                                    }
-                                    maxLength={400}
-                                    placeholder="Refine prompt"
-                                    className="w-full px-3 py-2 bg-slate-900/60 border border-slate-700/50 rounded-md text-sm text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500/70"
-                                  />
-                                  <div className="text-xs text-slate-500 whitespace-pre-wrap">
-                                    {refineSuggestionLines.join('\n')}
-                                  </div>
-                                  <div className="flex items-center justify-end gap-3">
-                                    {refineLoading && (
-                                      <span className="text-xs text-slate-400 flex items-center gap-1">
-                                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                                        Generating...
-                                      </span>
-                                    )}
-                                    <button
-                                      onClick={() => closeRowWorkshop(itemId)}
-                                      className="px-3 py-1.5 rounded-md bg-slate-800 text-slate-300 text-xs border border-slate-700/60 hover:border-slate-500/60 disabled:opacity-50 disabled:cursor-not-allowed"
-                                      disabled={refineLoading}
-                                    >
-                                      Cancel
-                                    </button>
-                                    <button
-                                      onClick={() => handleInlineRefineSubmit(category.key, idx, item, itemId)}
-                                      className="px-3 py-1.5 rounded-md bg-indigo-600 text-white text-xs hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                                      disabled={!refinePrompt.trim() || refineLoading}
-                                      title={!refinePrompt.trim() ? 'Enter a prompt to continue.' : undefined}
-                                    >
-                                      Send to AI
-                                    </button>
-                                  </div>
-                                  {refineDraft && (
-                                    <div className="rounded-lg border border-slate-700/60 bg-slate-950/40 p-3 space-y-2">
-                                      <p className="text-xs text-slate-400">Draft preview</p>
-                                      <p className="text-sm text-slate-100 whitespace-pre-wrap">{refineDraft.title}</p>
-                                      {refineDraft.body && (
-                                        <p className="text-xs text-slate-300 whitespace-pre-wrap">{refineDraft.body}</p>
-                                      )}
-                                      <div className="flex justify-end">
-                                        <button
-                                          onClick={() => handleApplyRefineDraft(category.key, idx, itemId)}
-                                          className="px-3 py-1.5 rounded-md bg-emerald-600/80 text-white text-xs hover:bg-emerald-500"
-                                        >
-                                          Save
-                                        </button>
-                                      </div>
-                                    </div>
-                                  )}
-                                </div>
-                              )}
                               {activeMode === 'ask' && (
                                 <div className="space-y-2">
                                   <textarea
@@ -1562,9 +1493,12 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                                     </button>
                                   </div>
                                   {askAnswer && (
-                                    <div className="rounded-lg border border-slate-700/60 bg-slate-950/40 p-3 space-y-2">
-                                      <p className="text-xs text-slate-400">AI Note</p>
-                                      <p className="text-xs text-slate-300 whitespace-pre-wrap">
+                                    <div className="rounded-lg border border-blue-500/30 bg-gradient-to-br from-blue-950/40 via-slate-950/40 to-indigo-950/30 p-4 space-y-3 shadow-[0_0_12px_rgba(59,130,246,0.08)]">
+                                      <div className="flex items-center gap-2">
+                                        <Sparkles className="w-4 h-4 text-blue-300" />
+                                        <p className="text-sm font-semibold text-blue-200 uppercase tracking-wider">AI Note</p>
+                                      </div>
+                                      <p className="text-sm text-slate-100 whitespace-pre-wrap leading-relaxed">
                                         {formatNoteAnswer({
                                           answer: askAnswer.answer,
                                           supplierSpecs: askAnswer.supplierSpecs,
@@ -1604,11 +1538,11 @@ export function SspBuilderHubTab({ productId, data, reviewInsights, onChange, on
                               {notesExpanded && (
                                 <div className="px-3 pb-3 space-y-2">
                                   {notes.map((note) => (
-                                    <div key={note.id} className="rounded-md border border-slate-700/50 bg-slate-900/40 p-2">
+                                    <div key={note.id} className="rounded-md border border-blue-500/20 bg-gradient-to-br from-blue-950/30 via-slate-900/40 to-indigo-950/20 p-3">
                                       {note.question && (
-                                        <p className="text-[11px] text-slate-400 mb-1">Q: {note.question}</p>
+                                        <p className="text-xs font-semibold text-blue-300 mb-1.5 uppercase tracking-wider">Q: {note.question}</p>
                                       )}
-                                      <p className="text-xs text-slate-300 whitespace-pre-wrap">{note.answer}</p>
+                                      <p className="text-sm text-slate-100 whitespace-pre-wrap leading-relaxed">{note.answer}</p>
                                     </div>
                                   ))}
                                 </div>

--- a/src/components/Sourcing/SourcingDetailContent.tsx
+++ b/src/components/Sourcing/SourcingDetailContent.tsx
@@ -88,8 +88,9 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
     const dataHash = JSON.stringify({
       supplierQuotes: data.supplierQuotes,
       fieldsConfirmed: data.fieldsConfirmed,
+      sourcingHub: data.sourcingHub,
     });
-    
+
     // Skip if data hasn't changed
     if (dataHash === lastSavedRef.current) {
       console.log('[SourcingDetail] Skipping save - data unchanged');
@@ -132,6 +133,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
           asin: asin,
           supplierQuotes: data.supplierQuotes,
           fieldsConfirmed: data.fieldsConfirmed || {},
+          sourcingHub: data.sourcingHub,
         }),
       });
       
@@ -179,6 +181,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
     const currentHash = JSON.stringify({
       supplierQuotes: debouncedSourcingData.supplierQuotes,
       fieldsConfirmed: debouncedSourcingData.fieldsConfirmed,
+      sourcingHub: debouncedSourcingData.sourcingHub,
     });
     
     // Don't save if it's the same as what we just loaded
@@ -277,6 +280,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
             const dataHash = JSON.stringify({
               supplierQuotes: dbData.supplierQuotes,
               fieldsConfirmed: dbData.fieldsConfirmed,
+              sourcingHub: dbData.sourcingHub,
             });
             console.log('[SourcingDetail] Data loaded from DB:', {
               supplierCount: dbData.supplierQuotes?.length || 0,
@@ -295,6 +299,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
             const dataHash = JSON.stringify({
               supplierQuotes: defaultData.supplierQuotes,
               fieldsConfirmed: defaultData.fieldsConfirmed,
+              sourcingHub: defaultData.sourcingHub,
             });
             console.log('[SourcingDetail] No DB record, using default data');
             lastSavedRef.current = dataHash;
@@ -310,6 +315,7 @@ export function SourcingDetailContent({ asin, onTabChange }: { asin: string; onT
           const dataHash = JSON.stringify({
             supplierQuotes: defaultData.supplierQuotes,
             fieldsConfirmed: defaultData.fieldsConfirmed,
+            sourcingHub: defaultData.sourcingHub,
           });
           console.log('[SourcingDetail] No product ID, using default data');
           lastSavedRef.current = dataHash;

--- a/src/components/Sourcing/sourcingStorage.ts
+++ b/src/components/Sourcing/sourcingStorage.ts
@@ -94,6 +94,7 @@ function migrateSourcingData(data: any): SourcingData {
       targetSalesPrice: null,
       categoryOverride: null,
       referralFeePct: null,
+      offerTargetSalesPrice: null,
     },
     profitCalculator: data.profitCalculator || {
       sampleOrdered: false,
@@ -179,6 +180,7 @@ export function getDefaultSourcingData(productId: string): SourcingData {
       targetSalesPrice: null,
       categoryOverride: null,
       referralFeePct: null,
+      offerTargetSalesPrice: null,
     },
     fieldsConfirmed: {},
   };
@@ -206,7 +208,7 @@ export function getDefaultSupplierQuote(index: number): SupplierQuoteRow {
     supplierName: '',
     costPerUnitShortTerm: null,
     exwUnitCost: null,
-    incoterms: 'DDP', // Default to DDP
+    incoterms: '', // Unset until user picks — keeps Calculation Accuracy at 0% on add
     ddpPrice: null,
     moqShortTerm: null,
     moq: null,

--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -385,9 +385,9 @@ export function PlaceOrderTab({
 
   // Calculate sales price (for referral fee percentage calculation)
   const salesPrice = useMemo(() => {
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    return hub.targetSalesPrice ?? originalPrice ?? selectedSupplier?.salesPrice ?? null;
+    return hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier?.salesPrice ?? null;
   }, [hubData, productData, selectedSupplier]);
 
   // Handle supplier quote updates (for write-back)
@@ -566,9 +566,9 @@ export function PlaceOrderTab({
   const handleDownloadPDF = () => {
     if (!selectedSupplier || !supplierWithMetrics || !allRequiredConfirmed) return;
 
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
+    const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
     const originalCategory = productData?.category || '';
     const category = hub.categoryOverride || originalCategory || '';
     const referralFeePct = hub.referralFeePct !== null 

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -616,9 +616,9 @@ export function ProfitCalculatorTab({
 
   // Get target sales price
   const getTargetSalesPrice = (): number | null => {
-    const hub = hubData || { targetSalesPrice: null };
+    const hub = hubData || { targetSalesPrice: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
-    return hub.targetSalesPrice ?? originalPrice ?? null;
+    return hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? null;
   };
 
   // Get category for referral fee display

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -1556,15 +1556,19 @@ export function ProfitCalculatorTab({
         cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
       }
     } else if (rowDef.isProfitMetric) {
-      // Profit-metric cells: only emphasize Best (emerald). Drop the
-      // matching red "isWorst" treatment — it produced a Christmas-tree
-      // effect across the Totals & Profit section that visually competed
-      // with the legitimate signal (which supplier wins).
+      // Profit-metric cells: only emphasize Best (emerald). Best gets a
+      // soft glow + slightly larger typography to read as the bottom-line
+      // answer. Non-best cells stay readable but quiet.
       if (isBest) {
-        cellClasses += ' bg-emerald-900/30 border border-emerald-500/40 text-emerald-300 font-semibold';
+        cellClasses += ' bg-gradient-to-br from-emerald-900/50 via-emerald-800/30 to-teal-900/40 border border-emerald-400/50 text-emerald-200 font-bold text-base shadow-[0_0_16px_rgba(16,185,129,0.25)]';
       } else {
         cellClasses += ' bg-slate-800/20 text-slate-200';
       }
+    } else if (rowDef.section === 'Totals & Profit') {
+      // Secondary totals (Total Landed Unit Cost / Total Investment) sit
+      // on a quieter slate band so they don't compete with the profit
+      // metrics above.
+      cellClasses += ' text-slate-400';
     } else {
       cellClasses += ' text-slate-300';
     }
@@ -2007,20 +2011,34 @@ export function ProfitCalculatorTab({
                           return acc;
                         }
                         
+                        const isBottomLine = rowDef.section === 'Totals & Profit';
                         acc.push(
-                          <tr key={`section-${rowDef.section}`} className="bg-slate-700/30">
+                          <tr key={`section-${rowDef.section}`}>
                             <td
                               colSpan={visibleQuotes.length + 1}
-                              className="px-4 py-2 text-xs font-semibold text-slate-400 uppercase tracking-wider bg-slate-700/30 cursor-pointer hover:bg-slate-600/30 transition-colors"
+                              className={
+                                isBottomLine
+                                  ? 'px-4 py-3 text-sm font-bold uppercase tracking-wider cursor-pointer transition-colors text-transparent bg-clip-text bg-gradient-to-r from-emerald-300 via-teal-300 to-blue-300'
+                                    + ' [background-clip:text] [-webkit-background-clip:text]'
+                                  : 'px-4 py-2 text-xs font-semibold text-slate-400 uppercase tracking-wider bg-slate-700/30 cursor-pointer hover:bg-slate-600/30 transition-colors'
+                              }
+                              style={
+                                isBottomLine
+                                  ? { background: 'linear-gradient(90deg, rgba(16,185,129,0.18), rgba(20,184,166,0.12), rgba(59,130,246,0.18))' }
+                                  : undefined
+                              }
                               onClick={() => toggleSection(rowDef.section)}
                             >
-                              <div className="flex items-center gap-2">
+                              <div className={isBottomLine ? 'flex items-center gap-2 text-emerald-200' : 'flex items-center gap-2'}>
                                 {isCollapsed ? (
-                                  <ChevronDown className="w-4 h-4" />
+                                  <ChevronDown className={isBottomLine ? 'w-4 h-4 text-emerald-300' : 'w-4 h-4'} />
                                 ) : (
-                                  <ChevronUp className="w-4 h-4" />
+                                  <ChevronUp className={isBottomLine ? 'w-4 h-4 text-emerald-300' : 'w-4 h-4'} />
                                 )}
-                                {rowDef.section}
+                                {isBottomLine && <Trophy className="w-4 h-4 text-emerald-300" />}
+                                <span className={isBottomLine ? 'text-emerald-200' : ''}>
+                                  {isBottomLine ? 'Bottom Line — Profit, Margin & ROI' : rowDef.section}
+                                </span>
                               </div>
                             </td>
                           </tr>
@@ -2039,18 +2057,31 @@ export function ProfitCalculatorTab({
                       
                       const hasRelativeData = hasAnyDataForRow(rowDef.key);
                       
+                      // Bottom-line section gets a richer treatment so it
+                      // visually reads as the answer, not just another row in
+                      // the matrix. Profit metrics (profitPerUnit, margin, roi,
+                      // totalGrossProfit) get an emerald-tinted gradient row;
+                      // secondary metrics (totalLandedUnitCost, totalInvestment)
+                      // sit on a quieter slate band.
+                      const isBottomLine = rowDef.section === 'Totals & Profit';
+                      const rowClassName = isBottomLine
+                        ? rowDef.isProfitMetric
+                          ? 'bg-gradient-to-r from-emerald-900/20 via-slate-900/0 to-emerald-900/10 font-semibold'
+                          : 'bg-slate-800/40'
+                        : rowDef.isProfitMetric
+                          ? 'bg-slate-800/30 font-semibold'
+                          : 'hover:bg-slate-800/20';
+                      const labelClassName = isBottomLine
+                        ? rowDef.isProfitMetric
+                          ? 'sticky left-0 z-10 px-4 py-4 text-sm text-emerald-200 border-r border-emerald-500/20 font-bold uppercase tracking-wider bg-gradient-to-r from-emerald-900/40 via-slate-900/40 to-transparent'
+                          : 'sticky left-0 z-10 px-4 py-3 text-xs text-slate-400 border-r border-slate-700/50 font-medium uppercase tracking-wide bg-slate-800/60'
+                        : 'sticky left-0 bg-slate-800/50 z-10 px-4 py-3 text-sm text-slate-300 border-r border-slate-700/50 font-medium';
+
                       // Add data row
                       acc.push(
-                        <tr
-                          key={rowDef.key}
-                          className={`${
-                            rowDef.isProfitMetric
-                              ? 'bg-slate-800/30 font-semibold'
-                              : 'hover:bg-slate-800/20'
-                          }`}
-                        >
+                        <tr key={rowDef.key} className={rowClassName}>
                           {/* Row Label */}
-                          <td className="sticky left-0 bg-slate-800/50 z-10 px-4 py-3 text-sm text-slate-300 border-r border-slate-700/50 font-medium">
+                          <td className={labelClassName}>
                             {rowDef.label}
                           </td>
                           

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -8,7 +8,6 @@ import {
   AlertCircle, 
   TrendingUp,
   BarChart3,
-  Trophy,
   Eye,
   EyeOff,
   GripVertical,
@@ -18,11 +17,12 @@ import {
   Lock
 } from 'lucide-react';
 import type { SupplierQuoteRow, SourcingHubData } from '../types';
-import { 
-  calculateQuoteMetrics, 
-  getAccuracyState, 
-  getRoiTier, 
+import {
+  calculateQuoteMetrics,
+  getAccuracyState,
+  getRoiTier,
   getMarginTier,
+  getTotalGrossProfitTier,
   type AccuracyState
 } from './SupplierQuotesTab';
 import { formatCurrency } from '@/utils/formatters';
@@ -199,7 +199,9 @@ export function ProfitCalculatorTab({
   
   // Matrix-specific state
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
-  const [hiddenSuppliers, setHiddenSuppliers] = useState<Set<string>>(new Set());
+  // Hidden state lives on the supplier row itself (q.isHidden) so it's
+  // bidirectional with Supplier Quotes — hiding here also hides on the
+  // Quotes tab (and excludes from the Sourcing Hub accuracy ring).
   const [supplierOrder, setSupplierOrder] = useState<string[]>([]);
   const [isDirty, setIsDirty] = useState(false);
   const [editingCell, setEditingCell] = useState<{ quoteId: string; rowKey: string } | null>(null);
@@ -419,13 +421,13 @@ export function ProfitCalculatorTab({
   
   // Get visible suppliers (for matrix display - excludes hidden)
   const visibleQuotes = useMemo(() => {
-    return filteredQuotes.filter(q => !hiddenSuppliers.has(q.id));
-  }, [filteredQuotes, hiddenSuppliers]);
+    return filteredQuotes.filter(q => !q.isHidden);
+  }, [filteredQuotes]);
   
   // Get hidden suppliers list
   const hiddenQuotesList = useMemo(() => {
-    return supplierQuotes.filter(q => hiddenSuppliers.has(q.id));
-  }, [supplierQuotes, hiddenSuppliers]);
+    return supplierQuotes.filter(q => q.isHidden);
+  }, [supplierQuotes]);
 
   // Sort quotes
   const sortedQuotes = useMemo(() => {
@@ -998,12 +1000,13 @@ export function ProfitCalculatorTab({
     { key: 'fbaFeePerUnit', label: 'FBA Fee/Unit', section: 'Amazon Fees', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', editable: true, inputType: 'number' },
     { key: 'totalFeesPerUnit', label: 'Total Fees/Unit', section: 'Amazon Fees', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
 
-    // SECTION 6 - Totals & Profit
+    // SECTION 6 - Bottom Line
+    // Cost rows first (slate band), outcome rows after (emerald band).
     { key: 'totalLandedUnitCost', label: 'Total Landed Unit Cost', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
+    { key: 'totalInvestment', label: 'Total Investment', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
     { key: 'profitPerUnit', label: 'Profit Per Unit', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', isProfitMetric: true },
     { key: 'margin', label: 'Margin', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? `${v.toFixed(1)}%` : '—', isProfitMetric: true },
     { key: 'roi', label: 'ROI', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? `${v.toFixed(1)}%` : '—', isProfitMetric: true },
-    { key: 'totalInvestment', label: 'Total Investment', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—' },
     { key: 'totalGrossProfit', label: 'Total Gross Profit', section: 'Totals & Profit', format: (v) => v !== null && v !== undefined ? formatCurrency(v) : '—', isProfitMetric: true },
   ];
 
@@ -1104,25 +1107,16 @@ export function ProfitCalculatorTab({
     return collapsedSections.has(section);
   };
   
-  // Column hide/show handlers
+  // Column hide/show — toggles the persisted isHidden flag on the supplier
+  // row so the Supplier Quotes tab + Sourcing Hub also see the change.
   const toggleSupplierVisibility = (quoteId: string) => {
-    setHiddenSuppliers(prev => {
-      const next = new Set(prev);
-      if (next.has(quoteId)) {
-        next.delete(quoteId);
-      } else {
-        next.add(quoteId);
-      }
-      return next;
-    });
+    const quote = supplierQuotes.find(q => q.id === quoteId);
+    if (!quote) return;
+    handleUpdateQuote(quoteId, { isHidden: !quote.isHidden });
   };
   
   const showSupplier = (quoteId: string) => {
-    setHiddenSuppliers(prev => {
-      const next = new Set(prev);
-      next.delete(quoteId);
-      return next;
-    });
+    handleUpdateQuote(quoteId, { isHidden: false });
   };
   
   // Map matrix row key to SupplierQuoteRow field name based on tier
@@ -1556,19 +1550,38 @@ export function ProfitCalculatorTab({
         cellClasses += ' bg-slate-800/30 border border-dashed border-slate-700/50 text-slate-500';
       }
     } else if (rowDef.isProfitMetric) {
-      // Profit-metric cells: only emphasize Best (emerald). Best gets a
-      // soft glow + slightly larger typography to read as the bottom-line
-      // answer. Non-best cells stay readable but quiet.
-      if (isBest) {
-        cellClasses += ' bg-gradient-to-br from-emerald-900/50 via-emerald-800/30 to-teal-900/40 border border-emerald-400/50 text-emerald-200 font-bold text-base shadow-[0_0_16px_rgba(16,185,129,0.25)]';
+      // Profit-metric cells use the supplier-quotes tier coloring —
+      // red for bad, yellow for mediocre, emerald for good — so the
+      // user can scan the row and see quality at a glance, not just
+      // "best vs not-best." Best gets a slightly stronger ring to
+      // mark the winner without going boxy.
+      const cellNum = typeof displayValue === 'number' ? displayValue : null;
+      let tier: { textColor: string; bgColor: string; borderColor: string } | null = null;
+      if (rowDef.key === 'profitPerUnit') {
+        const t = getProfitPerUnitTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'margin') {
+        const t = getMarginTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'roi') {
+        const t = getRoiTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      } else if (rowDef.key === 'totalGrossProfit') {
+        const t = getTotalGrossProfitTier(cellNum);
+        tier = { textColor: t.textColor, bgColor: t.bgColor, borderColor: t.borderColor };
+      }
+      if (tier) {
+        cellClasses += ` ${tier.bgColor} ${tier.textColor} font-semibold`;
+        if (isBest) {
+          cellClasses += ` ring-1 ring-emerald-400/40 font-bold`;
+        }
       } else {
         cellClasses += ' bg-slate-800/20 text-slate-200';
       }
     } else if (rowDef.section === 'Totals & Profit') {
-      // Secondary totals (Total Landed Unit Cost / Total Investment) sit
-      // on a quieter slate band so they don't compete with the profit
-      // metrics above.
-      cellClasses += ' text-slate-400';
+      // Cost rows (Total Landed Unit Cost / Total Investment) sit on a
+      // continuous quiet slate band so they read as inputs, not outcomes.
+      cellClasses += ' bg-slate-800/40 text-slate-300';
     } else {
       cellClasses += ' text-slate-300';
     }
@@ -1606,96 +1619,47 @@ export function ProfitCalculatorTab({
         {isEditing ? (
           <div className="flex items-center justify-center gap-1 w-full">
             {rowDef.inputType === 'select' || rowDef.inputType === 'incoterms' ? (
-              <>
-                <select
-                  ref={inputRef as React.RefObject<HTMLSelectElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                >
-                  {rowDef.selectOptions?.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <select
+                ref={inputRef as React.RefObject<HTMLSelectElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              >
+                {rowDef.selectOptions?.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
             ) : rowDef.inputType === 'yesno' ? (
-              <>
-                <select
-                  ref={inputRef as React.RefObject<HTMLSelectElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                >
-                  <option value="Yes">Yes</option>
-                  <option value="No">No</option>
-                </select>
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <select
+                ref={inputRef as React.RefObject<HTMLSelectElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              >
+                <option value="Yes">Yes</option>
+                <option value="No">No</option>
+              </select>
             ) : rowDef.inputType === 'textarea' ? (
-              <div className="w-full">
-                <textarea
-                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500 resize-none mb-1"
-                  rows={3}
-                  autoFocus
-                  placeholder="Enter text... (Ctrl+Enter to save, Esc to cancel)"
-                />
-                <div className="flex gap-1 justify-end">
-                  <button
-                    onClick={handleSave}
-                    className="px-2 py-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Save"
-                  >
-                    <Check className="w-3 h-3" />
-                    Save
-                  </button>
-                  <button
-                    onClick={handleCancel}
-                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Cancel"
-                  >
-                    <X className="w-3 h-3" />
-                    Cancel
-                  </button>
-                </div>
-              </div>
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none resize-none"
+                rows={3}
+                autoFocus
+                placeholder="Ctrl+Enter to save, Esc to cancel"
+              />
             ) : rowDef.inputType === 'dimensions' || rowDef.inputType === 'cartonDimensions' ? (
               <div className="w-full">
-                <div className="grid grid-cols-3 gap-2 mb-1">
+                <div className="grid grid-cols-3 gap-2">
                   <div>
                     <label className="text-xs text-slate-400 block mb-0.5">L (cm)</label>
                     <input
@@ -1705,8 +1669,15 @@ export function ProfitCalculatorTab({
                       value={dimLength}
                       onChange={(e) => setDimLength(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Length"
+                      onBlur={(e) => {
+                        // Save when blur leaves the dimensions editor entirely.
+                        // currentTarget is the input, relatedTarget is the next focused element.
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="L"
                       autoFocus
                     />
                   </div>
@@ -1718,8 +1689,13 @@ export function ProfitCalculatorTab({
                       value={dimWidth}
                       onChange={(e) => setDimWidth(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Width"
+                      onBlur={(e) => {
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="W"
                     />
                   </div>
                   <div>
@@ -1730,83 +1706,40 @@ export function ProfitCalculatorTab({
                       value={dimHeight}
                       onChange={(e) => setDimHeight(e.target.value)}
                       onKeyDown={handleKeyDown}
-                      className="w-full px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                      placeholder="Height"
+                      onBlur={(e) => {
+                        if (!e.currentTarget.parentElement?.parentElement?.parentElement?.contains(e.relatedTarget as Node)) {
+                          handleSave();
+                        }
+                      }}
+                      className="w-full px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                      placeholder="H"
                     />
                   </div>
                 </div>
-                <div className="flex gap-1 justify-end">
-                  <button
-                    onClick={handleSave}
-                    className="px-2 py-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Save"
-                  >
-                    <Check className="w-3 h-3" />
-                    Save
-                  </button>
-                  <button
-                    onClick={handleCancel}
-                    className="px-2 py-1 bg-red-600 hover:bg-red-500 rounded text-white text-xs flex items-center gap-1"
-                    title="Cancel"
-                  >
-                    <X className="w-3 h-3" />
-                    Cancel
-                  </button>
-                </div>
               </div>
             ) : rowDef.inputType === 'text' ? (
-              <>
-                <input
-                  ref={inputRef as React.RefObject<HTMLInputElement>}
-                  type="text"
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                />
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                type="text"
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              />
             ) : (
-              <>
-                <input
-                  ref={inputRef as React.RefObject<HTMLInputElement>}
-                  type="number"
-                  step="any"
-                  value={localEditValue}
-                  onChange={(e) => setLocalEditValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="flex-1 px-2 py-1 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-                  autoFocus
-                />
-                <button
-                  onClick={handleSave}
-                  className="p-1 bg-emerald-600 hover:bg-emerald-500 rounded text-white"
-                  title="Save"
-                >
-                  <Check className="w-3 h-3" />
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 bg-red-600 hover:bg-red-500 rounded text-white"
-                  title="Cancel"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                type="number"
+                step="any"
+                value={localEditValue}
+                onChange={(e) => setLocalEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSave}
+                className="flex-1 px-2 py-1 bg-slate-900 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+                autoFocus
+              />
             )}
           </div>
         ) : (
@@ -1831,12 +1764,8 @@ export function ProfitCalculatorTab({
                 )}
               </>
             )}
-            {isBest && rowDef.isProfitMetric && (
-              <div className="flex items-center gap-1">
-                <Trophy className="w-4 h-4 text-emerald-400" aria-label="Best value" />
-                <span className="text-xs text-emerald-400 font-medium">Best</span>
-              </div>
-            )}
+            {/* "Best" is now communicated by a stronger ring on the cell
+                itself rather than a trophy — keeps the row scan-friendly. */}
           </div>
         )}
       </td>
@@ -1970,9 +1899,12 @@ export function ProfitCalculatorTab({
               <div className="overflow-x-auto">
                 <div className="inline-block min-w-full">
                   <table className="w-full border-collapse">
-                    <thead className="bg-slate-900/50 border-b border-slate-700/50 sticky top-0 z-10">
+                    {/* Supplier-name header sticks below the AppHeader (h-16 = 64px)
+                        so the names stay visible as the user scrolls through the
+                        matrix rows. z-30 keeps it above sticky cells (z-10/z-20) */}
+                    <thead className="bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50 sticky top-16 z-30">
                       <tr>
-                        <th className="sticky left-0 bg-slate-900/50 z-20 px-4 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-r border-slate-700/50 min-w-[200px]">
+                        <th className="sticky left-0 bg-slate-900/95 z-40 px-4 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-r border-slate-700/50 min-w-[200px]">
                           Key Supplier Info
                         </th>
                         <SortableContext
@@ -2035,7 +1967,6 @@ export function ProfitCalculatorTab({
                                 ) : (
                                   <ChevronUp className={isBottomLine ? 'w-4 h-4 text-emerald-300' : 'w-4 h-4'} />
                                 )}
-                                {isBottomLine && <Trophy className="w-4 h-4 text-emerald-300" />}
                                 <span className={isBottomLine ? 'text-emerald-200' : ''}>
                                   {isBottomLine ? 'Bottom Line — Profit, Margin & ROI' : rowDef.section}
                                 </span>
@@ -2057,24 +1988,24 @@ export function ProfitCalculatorTab({
                       
                       const hasRelativeData = hasAnyDataForRow(rowDef.key);
                       
-                      // Bottom-line section gets a richer treatment so it
-                      // visually reads as the answer, not just another row in
-                      // the matrix. Profit metrics (profitPerUnit, margin, roi,
-                      // totalGrossProfit) get an emerald-tinted gradient row;
-                      // secondary metrics (totalLandedUnitCost, totalInvestment)
-                      // sit on a quieter slate band.
+                      // Bottom-line section: cost rows (totalLandedUnitCost,
+                      // totalInvestment) form a continuous slate band; outcome
+                      // rows (profitPerUnit, margin, roi, totalGrossProfit)
+                      // form a continuous emerald band — no gaps. Each cell
+                      // within an outcome row picks up its own tier color
+                      // (red/yellow/emerald) for scan-friendly quality signal.
                       const isBottomLine = rowDef.section === 'Totals & Profit';
                       const rowClassName = isBottomLine
                         ? rowDef.isProfitMetric
-                          ? 'bg-gradient-to-r from-emerald-900/20 via-slate-900/0 to-emerald-900/10 font-semibold'
+                          ? 'bg-emerald-950/30 font-semibold'
                           : 'bg-slate-800/40'
                         : rowDef.isProfitMetric
                           ? 'bg-slate-800/30 font-semibold'
                           : 'hover:bg-slate-800/20';
                       const labelClassName = isBottomLine
                         ? rowDef.isProfitMetric
-                          ? 'sticky left-0 z-10 px-4 py-4 text-sm text-emerald-200 border-r border-emerald-500/20 font-bold uppercase tracking-wider bg-gradient-to-r from-emerald-900/40 via-slate-900/40 to-transparent'
-                          : 'sticky left-0 z-10 px-4 py-3 text-xs text-slate-400 border-r border-slate-700/50 font-medium uppercase tracking-wide bg-slate-800/60'
+                          ? 'sticky left-0 z-10 px-4 py-4 text-sm text-emerald-200 font-bold uppercase tracking-wider bg-emerald-950/60'
+                          : 'sticky left-0 z-10 px-4 py-3 text-xs text-slate-400 font-medium uppercase tracking-wide bg-slate-800/60'
                         : 'sticky left-0 bg-slate-800/50 z-10 px-4 py-3 text-sm text-slate-300 border-r border-slate-700/50 font-medium';
 
                       // Add data row

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -1896,13 +1896,20 @@ export function ProfitCalculatorTab({
               collisionDetection={closestCenter}
               onDragEnd={handleDragEnd}
             >
-              <div className="overflow-x-auto">
+              {/* Matrix scroll container — bounded internal scroll (both axes)
+                  so the sticky thead has a real scroll context to stick against.
+                  Setting overflow-x: auto alone (the previous shape) coerces the
+                  browser into trapping sticky-y to this div as well, but with
+                  no fixed height the sticky never engages on page scroll. Giving
+                  the container a max-height makes the matrix scroll inside its
+                  own card, with supplier names pinned to the top. */}
+              <div className="overflow-auto max-h-[calc(100vh-12rem)]">
                 <div className="inline-block min-w-full">
                   <table className="w-full border-collapse">
-                    {/* Supplier-name header sticks below the AppHeader (h-16 = 64px)
-                        so the names stay visible as the user scrolls through the
-                        matrix rows. z-30 keeps it above sticky cells (z-10/z-20) */}
-                    <thead className="bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50 sticky top-16 z-30">
+                    {/* Supplier-name header sticks to the top of the scroll
+                        container as the user scrolls through matrix rows.
+                        z-30 keeps it above sticky cells (z-10/z-20). */}
+                    <thead className="bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50 sticky top-0 z-30">
                       <tr>
                         <th className="sticky left-0 bg-slate-900/95 z-40 px-4 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-r border-slate-700/50 min-w-[200px]">
                           Key Supplier Info

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -320,6 +320,7 @@ export function SourcingHub({
     targetSalesPrice: null,
     categoryOverride: null,
     referralFeePct: null,
+    offerTargetSalesPrice: null,
   };
 
   // Get original product values
@@ -327,8 +328,9 @@ export function SourcingHub({
   const originalCategory = productData?.category || '';
   const productName = getProductDisplayName(productData);
 
-  // Use overrides if available, otherwise use original values
-  const targetSalesPrice = hub.targetSalesPrice ?? originalPrice;
+  // Precedence: Hub-level user override > Offer page handoff > Original ASIN price
+  const offerTargetSalesPrice = hub.offerTargetSalesPrice ?? null;
+  const targetSalesPrice = hub.targetSalesPrice ?? offerTargetSalesPrice ?? originalPrice;
   const category = hub.categoryOverride || originalCategory || '';
   
   // Note: Referral fee calculation logic is still used in SupplierQuotesTab
@@ -631,14 +633,16 @@ export function SourcingHub({
                 <DollarSign className="w-3 h-3" />
                 Target Sales Price
               </span>
-              {hub.targetSalesPrice !== null && originalPrice !== null && hub.targetSalesPrice !== originalPrice && (
+              {hub.targetSalesPrice !== null && (offerTargetSalesPrice !== null || originalPrice !== null) && (
                 <button
                   type="button"
                   onClick={() => handleTargetSalesPriceChange(null)}
                   className="text-[10px] font-medium text-emerald-400 hover:text-emerald-300 normal-case tracking-normal transition-colors"
-                  title={`Reset to Offering price (${formatCurrency(originalPrice)})`}
+                  title={offerTargetSalesPrice !== null
+                    ? `Reset to Offering price (${formatCurrency(offerTargetSalesPrice)})`
+                    : `Reset to original ASIN price (${formatCurrency(originalPrice)})`}
                 >
-                  Reset to Offering
+                  Reset
                 </button>
               )}
             </div>
@@ -665,7 +669,7 @@ export function SourcingHub({
                     }
                   }
                 }}
-                placeholder={originalPrice ? formatCurrency(originalPrice) : '0.00'}
+                placeholder={offerTargetSalesPrice ? formatCurrency(offerTargetSalesPrice) : (originalPrice ? formatCurrency(originalPrice) : '0.00')}
                 className="w-full pl-5 pr-10 py-0 bg-transparent border-0 text-white placeholder-slate-500 focus:outline-none text-sm font-medium"
                 autoComplete="off"
                 autoCorrect="off"
@@ -674,11 +678,13 @@ export function SourcingHub({
               />
               <span className="absolute right-0 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-xs z-10">USD</span>
             </div>
-            {originalPrice !== null && (
+            {(offerTargetSalesPrice !== null || originalPrice !== null) && (
               <div className="mt-1 text-[10px] text-slate-500">
-                {hub.targetSalesPrice === null || hub.targetSalesPrice === originalPrice
+                {hub.targetSalesPrice !== null
+                  ? `Overridden (${offerTargetSalesPrice !== null ? `Offering: ${formatCurrency(offerTargetSalesPrice)}` : `Original: ${formatCurrency(originalPrice)}`})`
+                  : offerTargetSalesPrice !== null
                   ? `From Offering`
-                  : `Overridden (Offering: ${formatCurrency(originalPrice)})`}
+                  : `From Original ASIN`}
               </div>
             )}
           </div>

--- a/src/components/Sourcing/tabs/SourcingHub.tsx
+++ b/src/components/Sourcing/tabs/SourcingHub.tsx
@@ -305,17 +305,24 @@ interface SourcingHubProps {
   selectedSupplierId?: string | null; // Currently selected supplier in Place Order tab
 }
 
-export function SourcingHub({ 
-  productId, 
-  productData, 
-  hubData, 
-  supplierQuotes,
+export function SourcingHub({
+  productId,
+  productData,
+  hubData,
+  supplierQuotes: rawSupplierQuotes,
   fieldsConfirmed = {},
   onChange,
   onNavigateToTab,
   activeTab = 'quotes',
   selectedSupplierId = null
 }: SourcingHubProps) {
+  // Item 19: hidden suppliers are excluded from every Hub-level computation
+  // (accuracy ring, best-supplier, order readiness) so toggling Hide in
+  // Supplier Quotes/Profit Matrix doesn't pollute the gauge.
+  const supplierQuotes = useMemo(
+    () => (rawSupplierQuotes || []).filter(q => !q.isHidden),
+    [rawSupplierQuotes]
+  );
   const hub = hubData || {
     targetSalesPrice: null,
     categoryOverride: null,

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -814,13 +814,13 @@ export const getProfitPerUnitTier = (value: number | null | undefined): ProfitPe
 };
 
 // Get Total Gross Profit tier and styling
-type TotalGrossProfitTier = {
+export type TotalGrossProfitTier = {
   label: string;
   textColor: string;
   bgColor: string;
   borderColor: string;
 };
-const getTotalGrossProfitTier = (value: number | null | undefined): TotalGrossProfitTier => {
+export const getTotalGrossProfitTier = (value: number | null | undefined): TotalGrossProfitTier => {
   if (value === null || value === undefined || isNaN(value)) {
     return {
       label: '—',
@@ -1572,6 +1572,13 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                         handleUpdateQuote(quote.id, { displayName: e.target.value });
                       }}
                       onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => {
+                        // Enter blurs (commits the value); Tab is browser default.
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          e.currentTarget.blur();
+                        }
+                      }}
                       autoComplete="off"
                       autoCorrect="off"
                       autoCapitalize="off"

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Plus, Trash2, ExternalLink, Calculator, CheckCircle2, AlertCircle, Pencil, ChevronDown, ChevronUp, X, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import { Plus, Trash2, ExternalLink, Calculator, CheckCircle2, AlertCircle, Pencil, ChevronDown, ChevronUp, X, ArrowUpDown, ArrowUp, ArrowDown, Eye, EyeOff } from 'lucide-react';
 import type { SupplierQuoteRow } from '../types';
 import { formatCurrency } from '@/utils/formatters';
 import { getDefaultSupplierQuote } from '../sourcingStorage';
@@ -1045,6 +1045,12 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
     return sorted;
   }, [quotesWithMetrics, sortConfig]);
 
+  // Item 19: split sorted quotes into visible (rendered as the main list) and
+  // hidden (surfaced as a "Hidden suppliers:" pill row above the table for
+  // click-to-unhide). The Sourcing Hub does its own filter for the ring.
+  const hiddenQuotes = useMemo(() => sortedQuotes.filter(q => q.isHidden), [sortedQuotes]);
+  const visibleQuotes = useMemo(() => sortedQuotes.filter(q => !q.isHidden), [sortedQuotes]);
+
   const handleSort = (key: 'accuracy' | 'roi' | 'margin' | 'profitPerUnit') => {
     setSortConfig(prev => {
       if (prev.key === key) {
@@ -1057,8 +1063,23 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
   const handleAddSupplier = () => {
     const newQuote = getDefaultSupplierQuote(data.length);
     onChange([...data, newQuote]);
-    setCollapsedSuppliers(prev => ({ ...prev, [newQuote.id]: true }));
+    // Item 17: collapse all existing rows so the new one is the only thing
+    // open. The user just clicked Add Supplier — they want to fill IN that
+    // supplier, not stare at expanded forms for the previous ones.
+    setCollapsedSuppliers(() => {
+      const next: Record<string, boolean> = {};
+      data.forEach(q => { next[q.id] = true; });
+      next[newQuote.id] = false;
+      return next;
+    });
     setSupplierInfoExpanded(prev => ({ ...prev, [newQuote.id]: true }));
+    // Item 15 + 17: focus + select the displayName input and scroll the new
+    // row into view. setTimeout(0) so the ref is bound after the next paint.
+    setTimeout(() => {
+      const row = document.querySelector(`[data-supplier-id="${newQuote.id}"]`);
+      row?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      focusTitleInput(newQuote.id);
+    }, 50);
   };
 
   const handleDeleteSupplier = (id: string) => {
@@ -1112,6 +1133,26 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
 
   const isCollapsed = (quoteId: string): boolean => {
     return collapsedSuppliers[quoteId] ?? true; // Default to collapsed
+  };
+
+  // Item 18: Collapse All / Expand All — operate on every supplier row at once.
+  const collapseAllSuppliers = () => {
+    const next: Record<string, boolean> = {};
+    data.forEach(q => { next[q.id] = true; });
+    setCollapsedSuppliers(next);
+  };
+  const expandAllSuppliers = () => {
+    const next: Record<string, boolean> = {};
+    data.forEach(q => { next[q.id] = false; });
+    setCollapsedSuppliers(next);
+  };
+
+  // Item 19: Hide / unhide a supplier. Persisted on the row via isHidden so the
+  // Sourcing Hub accuracy ring also excludes it (and so it survives page reload).
+  const toggleHidden = (quoteId: string) => {
+    const quote = data.find(q => q.id === quoteId);
+    if (!quote) return;
+    handleUpdateQuote(quoteId, { isHidden: !quote.isHidden });
   };
 
   const focusTitleInput = (quoteId: string) => {
@@ -1297,6 +1338,22 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {visibleQuotes.length > 1 && (
+            <>
+              <button
+                onClick={collapseAllSuppliers}
+                className="px-3 py-1.5 text-xs text-slate-400 hover:text-white bg-slate-900/50 border border-slate-700/50 rounded-lg hover:bg-slate-800/50 transition-colors"
+              >
+                Collapse All
+              </button>
+              <button
+                onClick={expandAllSuppliers}
+                className="px-3 py-1.5 text-xs text-slate-400 hover:text-white bg-slate-900/50 border border-slate-700/50 rounded-lg hover:bg-slate-800/50 transition-colors"
+              >
+                Expand All
+              </button>
+            </>
+          )}
           {selectedSuppliers.size > 0 && (
             <button
               onClick={() => setShowDeleteModal('bulk')}
@@ -1338,6 +1395,27 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
         </div>
       ) : (
         <div className="space-y-6">
+          {/* Item 19: Hidden Suppliers row — surfaced above the table for
+              click-to-unhide. Mirrors the Profit Matrix pattern. */}
+          {hiddenQuotes.length > 0 && (
+            <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 p-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs text-slate-400 font-medium">Hidden suppliers:</span>
+                {hiddenQuotes.map((quote) => (
+                  <button
+                    key={quote.id}
+                    onClick={() => toggleHidden(quote.id)}
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs text-slate-300 bg-slate-900/60 border border-slate-700/60 hover:border-slate-500/70 hover:text-white transition-colors"
+                    title="Click to unhide"
+                  >
+                    <Eye className="w-3 h-3" />
+                    {quote.displayName || `Supplier`}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Table-like structure with sortable headers */}
           <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden">
             {/* Header Row */}
@@ -1346,10 +1424,10 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
               <div className="flex items-center">
                 <Checkbox
                   size="sm"
-                  checked={selectedSuppliers.size === sortedQuotes.length && sortedQuotes.length > 0}
+                  checked={selectedSuppliers.size === visibleQuotes.length && visibleQuotes.length > 0}
                   onChange={(e) => {
                     if (e.target.checked) {
-                      setSelectedSuppliers(new Set(sortedQuotes.map(q => q.id)));
+                      setSelectedSuppliers(new Set(visibleQuotes.map(q => q.id)));
                     } else {
                       setSelectedSuppliers(new Set());
                     }
@@ -1435,8 +1513,8 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
               <div></div>
             </div>
             
-            {/* Supplier Rows */}
-            {sortedQuotes.map((quote, index) => {
+            {/* Supplier Rows (hidden ones are surfaced above the table) */}
+            {visibleQuotes.map((quote, index) => {
             const activeView = getActiveView(quote.id);
             const displayName = quote.displayName;
             const collapsed = isCollapsed(quote.id);
@@ -1452,6 +1530,7 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
             return (
             <div
               key={quote.id}
+              data-supplier-id={quote.id}
               className={`border-b-2 border-slate-700/60 hover:bg-slate-800/50 transition-colors border-l-4 ${
                 index % 2 === 0
                   ? 'bg-slate-800/40 border-l-blue-500/40'
@@ -1558,6 +1637,16 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                 
                 {/* Actions column */}
                 <div className="flex items-center gap-1">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleHidden(quote.id);
+                    }}
+                    className="p-1.5 text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 rounded transition-colors flex-shrink-0"
+                    title="Hide supplier (excluded from accuracy ring)"
+                  >
+                    <EyeOff className="w-4 h-4" />
+                  </button>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -223,9 +223,9 @@ const extractLeadTimeDays = (leadTime: string): number | null => {
 // We'll handle that in the component where we have access to hubData/productData
 export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: SourcingHubData, productData?: any): SupplierQuoteRow => {
   // Get target sales price: hubData.targetSalesPrice ?? productData.price ?? quote.salesPrice
-  const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+  const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
   const originalPrice = productData?.price || productData?.salesPrice || null;
-  const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? quote.salesPrice ?? 0;
+  const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice ?? 0;
   
   // Get category for referral fee calculation
   const originalCategory = productData?.category || '';
@@ -1266,11 +1266,11 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
   };
 
   const getReferralFeeForQuote = (quote: SupplierQuoteRow) => {
-    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null };
+    const hub = hubData || { targetSalesPrice: null, categoryOverride: null, referralFeePct: null, offerTargetSalesPrice: null };
     const originalPrice = productData?.price || productData?.salesPrice || null;
     const originalCategory = productData?.category || '';
     
-    const targetSalesPrice = hub.targetSalesPrice ?? originalPrice ?? quote.salesPrice;
+    const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice;
     const category = hub.categoryOverride || originalCategory || '';
     
     const referralFeePct = hub.referralFeePct !== null 
@@ -1946,19 +1946,13 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
                               Incoterms<span className="text-red-400 ml-0.5" aria-hidden="true">*</span>
                             </label>
                             <select
-                              value={quote.incoterms || 'DDP'}
+                              value={quote.incoterms || ''}
                               onChange={(e) => {
-                                const newValue = e.target.value || 'DDP';
-                                handleUpdateQuote(quote.id, { incoterms: newValue });
-                              }}
-                              onBlur={(e) => {
-                                // Ensure DDP is saved if field was empty
-                                if (!quote.incoterms) {
-                                  handleUpdateQuote(quote.id, { incoterms: 'DDP' });
-                                }
+                                handleUpdateQuote(quote.id, { incoterms: e.target.value });
                               }}
                               className={`w-full px-3 py-2 bg-slate-900/50 border rounded-lg text-white focus:outline-none ${getRequiredFieldClass(isFieldFilled(quote.incoterms))}`}
                             >
+                              <option value="" disabled>Select…</option>
                               <option value="DDP">DDP</option>
                               <option value="EXW">EXW</option>
                               <option value="FOB">FOB</option>

--- a/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
+++ b/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { ChevronDown, ChevronUp, Pencil, X, Save, CheckCircle2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Pencil, CheckCircle2 } from 'lucide-react';
 import { PLACE_ORDER_SCHEMA, type PlaceOrderField, type PlaceOrderSection } from './placeOrderSchema';
 import { getFieldValue, type ValueMapperContext } from './valueMapper';
 import { formatCurrency } from '@/utils/formatters';
@@ -590,43 +590,25 @@ function ChecklistRow({
       </td>
       <td className="py-3 px-3 overflow-hidden">
         {isEditing ? (
-          <div className="space-y-1">
-            <p className="text-xs text-slate-400">Confirm change?</p>
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                className="flex-1 px-2 py-1.5 bg-slate-700/50 border border-slate-600/50 rounded text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                autoFocus
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                spellCheck="false"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleSave();
-                  } else if (e.key === 'Escape') {
-                    onCancelEdit();
-                  }
-                }}
-              />
-              <button
-                onClick={handleSave}
-                className="p-1.5 text-emerald-400 hover:text-emerald-300 transition-colors"
-                title="Save"
-              >
-                <Save className="w-4 h-4" />
-              </button>
-              <button
-                onClick={onCancelEdit}
-                className="p-1.5 text-slate-400 hover:text-slate-300 transition-colors"
-                title="Cancel"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
+          <input
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            className="w-full px-2 py-1.5 bg-slate-700/50 border border-blue-500/60 rounded text-white text-sm focus:outline-none"
+            autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSave();
+              } else if (e.key === 'Escape') {
+                onCancelEdit();
+              }
+            }}
+            onBlur={handleSave}
+          />
         ) : (
           <div className="flex items-center gap-2">
             <span

--- a/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
+++ b/src/components/Sourcing/tabs/placeOrder/PlaceOrderChecklist.tsx
@@ -223,6 +223,43 @@ export function PlaceOrderChecklist({
     }
   }, [selectedSupplier, effectiveTier, onSaveEdit, onUpdateSupplierQuote]);
 
+  // Item 21: applying a filter (Show Unmapped / Show Missing / Show
+  // Unconfirmed) auto-expands sections that have matching fields and
+  // collapses those that don't. The user shouldn't have to click chevrons
+  // to find what the filter found. Mode = null deactivates all filters
+  // and leaves section state untouched.
+  const applyFilter = useCallback(
+    (mode: 'unmapped' | 'missing' | 'unconfirmed' | null) => {
+      setShowOnlyUnmapped(mode === 'unmapped');
+      setShowOnlyMissing(mode === 'missing');
+      setShowOnlyUnconfirmed(mode === 'unconfirmed');
+      if (!mode) return;
+
+      const matchesByKey: Record<string, boolean> = {};
+      PLACE_ORDER_SCHEMA.forEach(section => {
+        const matches = section.fields.filter(f => {
+          if (mode === 'unmapped') return !f.mapped;
+          if (mode === 'missing') {
+            const v = getFieldValue(f, valueContext);
+            return v.value == null || v.value.toString().trim() === '';
+          }
+          if (mode === 'unconfirmed') return !confirmedFields.has(f.key);
+          return false;
+        });
+        matchesByKey[section.key] = matches.length > 0;
+      });
+
+      setSectionStates(prev => {
+        const next: Record<string, SectionState> = {};
+        Object.keys(prev).forEach(key => {
+          next[key] = { ...prev[key], expanded: matchesByKey[key] || false };
+        });
+        return next;
+      });
+    },
+    [valueContext, confirmedFields]
+  );
+
   // Filter fields based on the currently active filter.
   // Filters are mutually exclusive — toggling one clears the others.
   const getFilteredFields = useCallback((fields: PlaceOrderField[]) => {
@@ -284,11 +321,7 @@ export function PlaceOrderChecklist({
               Collapse All
             </button>
             <button
-              onClick={() => {
-                setShowOnlyUnmapped(!showOnlyUnmapped);
-                setShowOnlyUnconfirmed(false);
-                setShowOnlyMissing(false);
-              }}
+              onClick={() => applyFilter(showOnlyUnmapped ? null : 'unmapped')}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyUnmapped
                   ? 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
@@ -299,11 +332,7 @@ export function PlaceOrderChecklist({
               Show Unmapped
             </button>
             <button
-              onClick={() => {
-                setShowOnlyMissing(!showOnlyMissing);
-                setShowOnlyUnmapped(false);
-                setShowOnlyUnconfirmed(false);
-              }}
+              onClick={() => applyFilter(showOnlyMissing ? null : 'missing')}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyMissing
                   ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
@@ -314,11 +343,7 @@ export function PlaceOrderChecklist({
               Show Missing
             </button>
             <button
-              onClick={() => {
-                setShowOnlyUnconfirmed(!showOnlyUnconfirmed);
-                setShowOnlyUnmapped(false);
-                setShowOnlyMissing(false);
-              }}
+              onClick={() => applyFilter(showOnlyUnconfirmed ? null : 'unconfirmed')}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
                 showOnlyUnconfirmed
                   ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30'

--- a/src/components/Sourcing/types.ts
+++ b/src/components/Sourcing/types.ts
@@ -209,6 +209,7 @@ export interface SourcingHubData {
   targetSalesPrice: number | null; // Override sales price for this page
   categoryOverride: string | null; // Override category for this page
   referralFeePct: number | null; // Calculated from category, but can be manually overridden
+  offerTargetSalesPrice?: number | null; // Carried over from Offer page's Continue to Sourcing handoff
 }
 
 export interface SourcingData {

--- a/src/components/Sourcing/types.ts
+++ b/src/components/Sourcing/types.ts
@@ -12,6 +12,7 @@ export interface SupplierQuoteRow {
   
   // Display
   displayName?: string; // Editable supplier title (defaults to "Supplier 1", "Supplier 2", etc.)
+  isHidden?: boolean;   // When true, row is hidden in Supplier Quotes and excluded from the Sourcing Hub accuracy ring (parity with Profit Matrix)
   
   // Supplier Info (Basic)
   supplierName: string;


### PR DESCRIPTION
## Summary

Promotes everything from today's session to production. 9 squash commits since the last main ship (\`69cda8f\`, 2026-05-08 EOD).

| Commit | What |
|---|---|
| \`b5ea64f\` (#39) | **Critical bugs**: Competitive/Premium price collision, Offer→Sourcing target price flow (incl. new \`sourcing_hub\` JSONB column), Calculation Accuracy 6% default. |
| \`1d072e4\` (#40) | **SSP polish**: dropped Refine button (Ask AI only), AI Note redesign with blue accent + larger body, Top Pick badge spacing. |
| \`bbc43a9\` (#41) | **Supplier Quotes UX**: focus + select-all on Add, collapse-others on Add, Collapse All / Expand All toggle, Hide supplier (persisted via new \`isHidden\` field, excluded from Sourcing Hub accuracy ring). |
| \`2977ec4\` (#42) | **PO Checklist filter** auto-expands matching sections. |
| \`b671668\` (#43) | **Profit Matrix Totals redesign** (later refined in iter2). |
| \`fec7a7b\` (#44) | **iter2 — 7 polish items** (A: SSP ghost gap, B: Enter blurs supplier name, C: bidirectional Hide between Quotes & Matrix, D: Bottom Line refinements with tier-based cell coloring + no Trophy + reordered rows + continuous emerald band, E: sticky supplier-name thead, F: dropped green/red Save/Cancel from Matrix cell editing, G: same for PO Checklist value editing). |
| \`5248af9\` (#45) | **Sticky thead fix**: switched to bounded internal scroll on the matrix card so \`sticky top-0\` actually engages. |
| \`f5f68a5\` (#46) | **Pre-vet fallback** for \`/api/extension/markets\` so old Lens-origin submissions with NULL score show real scores in the BloomLens picker (5 affected markets self-heal on read). |

## Database changes already applied to prod

- Migration \`add_sourcing_hub_column_to_sourcing_products\`: \`ALTER TABLE sourcing_products ADD COLUMN sourcing_hub JSONB DEFAULT '{}'\`. Additive, reversible. Applied directly during PR #39 work because the API was silently dropping writes to a column that didn't exist.

## Validation

Dave walked the dev preview through this iter1 + iter2 sequence, greenlighted both. Sticky-thead fix was a single follow-up after the iter2 round.

## Post-merge action items

- BloomLens extension v0.5.9 zip is ready (separate repo). Side-load to test, then upload to Web Store after v0.5.8 review clears.
- The \`__lens_origin\` score derivation fallback on \`/api/analyze\` and \`/api/extension/markets\` can be retired once pre-fix Lens markets have aged out (~7 days from now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)