### PR TITLE
Sentry: skip source-map upload on preview builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,4 +33,10 @@ module.exports = withSentryConfig(module.exports, {
       removeDebugLogging: true,
     },
   },
+  // Skip source-map upload on preview/dev builds — production-only
+  // symbolication is the value, and preview uploads were adding 3-5
+  // minutes to every Vercel build (Sentry API ingest latency).
+  sourcemaps: {
+    disable: process.env.VERCEL_ENV !== 'production',
+  },
 });


### PR DESCRIPTION
## Summary

Cuts Vercel preview build time from 3-6 min back to the ~1m10s baseline by skipping Sentry's source-map upload on preview/dev builds. Production builds still upload so stack traces stay symbolicated for real user errors.

## Diff

One-line addition to `next.config.js` inside the existing `withSentryConfig(...)`:

```js
sourcemaps: {
  disable: process.env.VERCEL_ENV !== 'production',
},
```

## Tradeoff

Errors captured on Vercel preview builds will show file/line at bundled-output coordinates instead of original TS source. Acceptable because previews are pre-merge smoke tests — the source file is at your fingertips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)