### PR TITLE
Sentry: skip preview source-map uploads (build perf)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,4 +33,10 @@ module.exports = withSentryConfig(module.exports, {
       removeDebugLogging: true,
     },
   },
+  // Skip source-map upload on preview/dev builds — production-only
+  // symbolication is the value, and preview uploads were adding 3-5
+  // minutes to every Vercel build (Sentry API ingest latency).
+  sourcemaps: {
+    disable: process.env.VERCEL_ENV !== 'production',
+  },
 });


### PR DESCRIPTION
Cuts Vercel preview build time from 3-6 min back to ~1m10s by skipping Sentry's source-map upload on preview/dev builds. Production builds still upload so real user errors stay symbolicated.

Single change: adds `sourcemaps: { disable: process.env.VERCEL_ENV !== 'production' }` to `withSentryConfig` in `next.config.js`.

Branched off main directly because the prior dev→main attempt (#52) couldn't cleanly merge due to squash-merge history divergence. Dev branch is already at the same file content via PR #51 — this just gets it onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)