### PR TITLE
Vetting load perf: narrow /api/analyze + /api/research by asin

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -194,6 +194,13 @@ export async function GET(request: NextRequest) {
   try {
     const url = new URL(request.url)
     const userId = url.searchParams.get('userId')
+    // Optional narrowing params. /vetting/[asin] passes one of these so the
+    // server returns a single submission instead of the user's entire
+    // history — payload + scoring-fallback work scales O(N) without them,
+    // which is the main reason the vetting page load grew from ~20s to
+    // ~2min as accounts accumulated submissions.
+    const filterAsin = url.searchParams.get('asin')?.trim().toUpperCase() || null
+    const filterSubmissionId = url.searchParams.get('submissionId')?.trim() || null
 
     if (!userId) {
       return NextResponse.json(
@@ -201,13 +208,13 @@ export async function GET(request: NextRequest) {
         { status: 400 }
       )
     }
-    
+
     console.log('API GET: Fetching submissions for user:', userId);
-    
+
     // Get the authorization token from headers
     const authHeader = request.headers.get('authorization');
     const token = authHeader?.replace('Bearer ', '');
-    
+
     // Create authenticated Supabase client if token exists
     let serverSupabase;
     if (token) {
@@ -227,14 +234,38 @@ export async function GET(request: NextRequest) {
       console.log('GET: No token found, using server client with cookies');
       serverSupabase = createClient();
     }
-    
+
     // Try to get submissions from Supabase
     try {
-      const { data: submissions, error } = await serverSupabase
+      let query = serverSupabase
         .from('submissions')
         .select('*')
         .eq('user_id', userId)
-        .order('created_at', { ascending: false })
+        .order('created_at', { ascending: false });
+
+      if (filterSubmissionId) {
+        query = query.eq('id', filterSubmissionId);
+      } else if (filterAsin) {
+        // Resolve the research_product first so we can filter by the FK on
+        // the submissions table — that's the path BloomLens-origin
+        // submissions take. If no research_product exists for this ASIN
+        // (legacy CSV-upload case), fall back to a JSONB match on the
+        // primary ASIN stored inside submission_data.productData.
+        const { data: rp } = await serverSupabase
+          .from('research_products')
+          .select('id')
+          .eq('user_id', userId)
+          .eq('asin', filterAsin)
+          .maybeSingle();
+
+        if (rp?.id) {
+          query = query.eq('research_products_id', rp.id);
+        } else {
+          query = query.eq('submission_data->productData->>asin', filterAsin);
+        }
+      }
+
+      const { data: submissions, error } = await query;
 
       if (error) {
         console.error('Supabase error fetching submissions:', error);

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -50,9 +50,14 @@ export async function GET(request: NextRequest) {
     const limit = url.searchParams.get('limit');
     const offset = url.searchParams.get('offset');
     const status = url.searchParams.get('status');
+    // /vetting/[asin] passes asin so the server returns a single row
+    // instead of the user's full research_products library. Without it
+    // the payload grows linearly with funnel size and the vetting page
+    // load hangs on the parallel /api/analyze + /api/research fetch.
+    const asin = url.searchParams.get('asin')?.trim().toUpperCase() || null;
 
     console.log('GET research: User ID:', user.id);
-    
+
     // Build the query — include the user's tags for each product via
     // the product_tags join table. RLS on product_tags + tags keeps this
     // scoped to the owner automatically.
@@ -61,19 +66,23 @@ export async function GET(request: NextRequest) {
       .select('*, product_tags(tag_id, tags(id, name, color))')
       .eq('user_id', user.id)
       .order('created_at', { ascending: false });
-    
+
     // Apply optional filters
     if (status) {
       query = query.eq('status', status);
     }
-    
+
+    if (asin) {
+      query = query.eq('asin', asin);
+    }
+
     if (limit) {
       const limitNum = parseInt(limit, 10);
       if (!isNaN(limitNum) && limitNum > 0) {
         query = query.limit(limitNum);
       }
     }
-    
+
     if (offset) {
       const offsetNum = parseInt(offset, 10);
       if (!isNaN(offsetNum) && offsetNum >= 0) {

--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -178,8 +178,23 @@ export function VettingDetailContent({ asin }: { asin: string }) {
 
       const { data: { session } } = await supabase.auth.getSession();
 
-      const submissionsUrl = `/api/analyze?userId=${user.id}`;
-      const researchUrl = '/api/research';
+      // Narrow both calls server-side so we fetch one submission +
+      // one research_product instead of the user's full library.
+      // /api/analyze without a narrowing param returns every submission
+      // with its full submission_data blob, which is the root of the
+      // 20s → 2min vetting load regression once accounts accumulate
+      // BloomLens markets.
+      const narrowAsin = !isInvalidAsin ? asin : '';
+      const analyzeQs = new URLSearchParams({ userId: user.id });
+      if (submissionId) {
+        analyzeQs.set('submissionId', submissionId);
+      } else if (narrowAsin) {
+        analyzeQs.set('asin', narrowAsin);
+      }
+      const submissionsUrl = `/api/analyze?${analyzeQs.toString()}`;
+      const researchUrl = narrowAsin
+        ? `/api/research?asin=${encodeURIComponent(narrowAsin)}`
+        : '/api/research';
       if (isDev) {
         console.debug('[VettingDetail] Fetching data', { submissionsUrl, researchUrl, userId: user.id, asin });
       }


### PR DESCRIPTION
## Summary

- `/api/analyze` GET now accepts `?asin=` and `?submissionId=` to return a single submission instead of the user's full history.
- `/api/research` GET now accepts `?asin=` to return a single research_product instead of the user's full library.
- `VettingDetailContent` passes the route's ASIN (or `?submissionId=` query param) to both endpoints. The client-side `.find()` lookups still work — they just operate over 0–1 rows instead of N.

## Why

Vetting page load grew from ~20s to ~2min and the "Loading Vetting Results" screen hung after a fresh BloomLens "Analyze Market" handoff. Root cause: `/api/analyze?userId=X` returned **every** submission the user owns, each with the full `submission_data` blob (30+ competitors + Keepa snapshots), just so the client could `.find()` one by ASIN. As BloomLens markets accumulated, payload + the `__lens_origin` score-fallback recompute scaled linearly with submission count.

After this PR the vetting page does O(1) work regardless of funnel size.

## Behavior preserved

- Dashboard + every other caller still hits the unfiltered paths (additive params, no breaking changes).
- Legacy CSV-upload submissions without a `research_products_id` are still findable via a JSONB fallback on `submission_data->productData->>asin`.
- Auth + RLS unchanged — both filters scope to `user_id` the same way the existing query does.

## Does NOT address

- Bug #3 (phantom competitor in Market Climate) — separate investigation, awaiting submission ID to query Supabase.
- Bug #2 (BSR data quality on brand-new ASINs) — separate.
- Bug #5 (toggle save-to-funnel) — separate feature work.

## Test plan

- [ ] Open `/vetting/<asin>` for an existing market — page loads in seconds, not minutes.
- [ ] Open `/vetting/<asin>` immediately after a BloomLens Analyze Market handoff — page loads (no endless spinner).
- [ ] Dashboard still loads the full submissions list correctly.
- [ ] DevTools Network: `/api/analyze` response is small (~one row) and `/api/research` returns one row when navigating to `/vetting/[asin]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)