### PR TITLE
Bloom Lens enrich: guardrail for relisted ASINs

### DIFF
--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -500,6 +500,28 @@ function buildEnrichedRow(product: any): EnrichedRow {
 
   // Static fields. listedSince is in Keepa minutes.
   const listingCreatedAt = keepaMinutesToIso(product.listedSince);
+
+  // Relisted-ASIN guardrail. Sellers periodically drop a brand-new
+  // product onto an ASIN that previously held a different (mature)
+  // listing. Amazon's PDP shows the new product, but Keepa retains the
+  // PREVIOUS product's review/BSR/rank history attached to the ASIN —
+  // so we'd report 18k+ reviews and a healthy BSR for a 70-day-old
+  // ping-pong table (real example: B0GQSRRRXK on 2026-05-11). When
+  // implausible review velocity tips us off, treat the entire metrics
+  // block as untrustworthy: surface a "limited" row instead of fake
+  // monthly-revenue numbers that mislead the user. 50 reviews/day is
+  // a deliberately generous cap — even viral organic launches rarely
+  // sustain that pace.
+  const REVIEWS_PER_DAY_CAP = 50;
+  const listingAgeDays =
+    typeof product.listedSince === 'number' && product.listedSince > 0
+      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
+      : null;
+  const isLikelyRelistedAsin =
+    reviews != null &&
+    reviews > 0 &&
+    listingAgeDays != null &&
+    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
   const weightLb =
     typeof product.packageWeight === 'number' && product.packageWeight > 0
       ? round2(product.packageWeight / 453.592) // grams → pounds
@@ -519,6 +541,39 @@ function buildEnrichedRow(product: any): EnrichedRow {
       : null;
   const imageUrl = pickImageUrl(product);
   const brand = pickBrand(product);
+
+  if (isLikelyRelistedAsin) {
+    // Keep identity + static fields (listing age, dimensions, price,
+    // category, rating, image, brand, variation count) since those are
+    // still about the CURRENT product. Drop everything sourced from
+    // accumulated history — reviews, BSR series, derived units +
+    // revenue — because those belong to the prior listing on this ASIN.
+    return {
+      rootCategory: rootCategoryName,
+      matchedCategory,
+      matchedBand,
+      bsr: null,
+      bsr30dMedian: null,
+      bsrVolatility: null,
+      bsrTrendPct: null,
+      monthlyUnits: null,
+      monthlyRevenue: null,
+      parentMonthlyUnits: null,
+      parentMonthlyRevenue: null,
+      unitsSource: null,
+      price: currentPriceCents,
+      weightLb,
+      dimensions,
+      listingCreatedAt,
+      variationCount: variationCount > 0 ? variationCount : null,
+      rating: ratingTenths != null ? ratingTenths / 10 : null,
+      reviews: null,
+      imageUrl,
+      brand,
+      dataQuality: 'limited',
+      curveVersion: CURVE_VERSION,
+    };
+  }
 
   return {
     rootCategory: rootCategoryName,


### PR DESCRIPTION
## Summary

Detects ASIN reuse (a brand-new product dropped onto an ASIN that previously held a different mature listing) by checking review velocity. When `reviews / listingAgeDays > 50`, we treat the row as `dataQuality: 'limited'` and null the history-derived fields so the drawer doesn't surface inherited reviews / BSR / monthly-revenue as if they belonged to the current product.

## Why

Real example from Dave's 2026-05-11 testing — ASIN **B0GQSRRRXK**:

| Field | BloomLens drawer | Amazon PDP |
|---|---|---|
| Listing age | 70 days | "New on Amazon in past month" |
| Reviews | 18,602 | — |
| BSR | 69,602 | "BSR is undefined" |
| Monthly Sales / Revenue | 2,652 / $151,137 | — |

18,602 reviews ÷ 70 days = **266 reviews/day** — physically impossible for any organic listing. Keepa is returning the prior listing's accumulated data because the ASIN was reused. The drawer trusted Keepa and rendered fake metrics.

## Detection logic

```ts
const REVIEWS_PER_DAY_CAP = 50;  // even viral launches rarely sustain >50/day
const isLikelyRelistedAsin =
  reviews > 0 &&
  listingAgeDays != null &&
  reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
```

When tripped:
- **Nulled** (history-sourced — belongs to prior listing): `reviews`, `bsr`, `bsr30dMedian`, `bsrVolatility`, `bsrTrendPct`, `monthlyUnits`, `monthlyRevenue`, `parentMonthlyUnits`, `parentMonthlyRevenue`, `unitsSource`.
- **Kept** (current-listing facts): `price`, `weightLb`, `dimensions`, `listingCreatedAt`, `variationCount`, `rating`, `imageUrl`, `brand`, `rootCategory`, `matchedCategory`, `matchedBand`.
- `dataQuality` forced to `'limited'`.

## Cache behavior

`CURVE_VERSION` is intentionally **not** bumped — bumping invalidates every cached row across the user base, which would force a full Keepa refetch and burn API quota for a guardrail this targeted. Existing rows in `keepa_lens_metrics` keep showing the old (bad) metrics until natural 24h TTL expiry.

## Does NOT address

- Bug #3 (phantom competitor in Market Climate) — separate investigation, waiting on the volleyball market's submission ID.
- Bug #1 (Sports & Outdoors calibration) — separate backlog item.
- Bug #5 (toggle save-to-funnel) — separate feature work.

## Test plan

- [ ] After merging + waiting 24h for cache to expire (or manually clearing the row), re-fetch B0GQSRRRXK in BloomLens — row should render with `dataQuality: 'limited'` and empty review/BSR/revenue cells.
- [ ] Confirm legitimate aged listings (rows 3–10 in the same CSV) still render full enrichment.
- [ ] Confirm legitimate brand-new low-review listings (row 19: B0FSQFMYJ2, 1 review on a 30-day listing → 0.03/day) still render full enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)