### PR TITLE
analyze-market: don't flag fresh markets as pending-recalc (D3)

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -415,7 +415,13 @@ async function handleCreate(
       createdAt: nowIso,
       __lens_origin: true,
       __lens_primary_asin: primaryAsinRaw,
-      __lens_pending_recalc: true, // signals to /vetting/[asin] that Keepa enrichment is still pending
+      // Intentionally NOT setting __lens_pending_recalc here. The vetting
+      // page surfaces that flag via the "New competitors detected —
+      // competitors were added from BloomLens since this market was last
+      // vetted" banner, which is wrong copy for a brand-new market (there
+      // is no "last vetted" baseline). The expansion path below still
+      // appends to lensExpansions[] when competitors are added to an
+      // existing market — that's the case the banner is designed for.
     },
     metrics: {
       totalCompetitors: competitors.length,


### PR DESCRIPTION
## Summary

Removes `__lens_pending_recalc: true` from the new-submission insert in `/api/extension/analyze-market`. Fresh markets created via BloomLens "Analyze Market" no longer show the misleading "New competitors detected — competitors were added since this market was last vetted" banner immediately after creation.

## Why

For a freshly-created market there is no "last vetted" baseline. The banner copy is wrong, and worse, the call-to-action ("Recalculate") implies the displayed score is stale — but the user just clicked the button to get that score.

## Real example (Dave 2026-05-12)

Created an airpods-case market from BloomLens with 1 competitor → page rendered:
- PASS 93.3% / 1 LOW competitor / full market metrics
- AND the "New competitors detected" banner with Recalculate CTA

That's contradictory UX.

## What's unchanged

- **Expansion path** (line 562+): existing market + new competitors added via Lens "Add to existing" still appends to `lensExpansions[]` with `scoreAfter: null`. The banner still fires correctly when there's a real "since last vetted" delta.
- **Legacy markets** that already have the flag stored keep showing the banner until their next recalc. `VettingDetailContent.tsx`'s `hasLegacyPendingRecalc` fallback handles this transitional case (per the existing comment, drop after a deploy cycle).

## Test plan

- [ ] Create a brand-new market via BloomLens Analyze Market → vetting page should NOT show the recalc banner
- [ ] Add competitors to an existing vetted market via Lens "Add to existing" → vetting page SHOULD show the banner (regression check on the expansion path)
- [ ] Open a market created before this fix → still shows the banner until manually recalc'd (legacy fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)