### PR TITLE
Release: D3 — no false-positive recalc banner on fresh markets

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -415,7 +415,13 @@ async function handleCreate(
       createdAt: nowIso,
       __lens_origin: true,
       __lens_primary_asin: primaryAsinRaw,
-      __lens_pending_recalc: true, // signals to /vetting/[asin] that Keepa enrichment is still pending
+      // Intentionally NOT setting __lens_pending_recalc here. The vetting
+      // page surfaces that flag via the "New competitors detected —
+      // competitors were added from BloomLens since this market was last
+      // vetted" banner, which is wrong copy for a brand-new market (there
+      // is no "last vetted" baseline). The expansion path below still
+      // appends to lensExpansions[] when competitors are added to an
+      // existing market — that's the case the banner is designed for.
     },
     metrics: {
       totalCompetitors: competitors.length,


### PR DESCRIPTION
## Summary

Single-commit release: removes the `__lens_pending_recalc: true` flag from new-submission inserts in `/api/extension/analyze-market` so freshly-created markets don't render the misleading "New competitors detected" banner.

## Shipping

- #61 — analyze-market: don't flag fresh markets as pending-recalc

## Test plan

- [ ] Confirm Vercel prod deploy goes green (~9 min — Sentry source-map upload)
- [ ] Create a brand-new market via BloomLens "Analyze Market" → vetting page should NOT show the recalc banner
- [ ] Existing markets created before this fix → still show the banner (legacy fallback intentional)
- [ ] Expansion path (Lens "Add to existing" on an already-vetted market) → still fires banner correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)