### PR TITLE
Market Climate: auto-generate on fresh markets too

### DIFF
--- a/src/components/Keepa/KeepaSignalsHub.tsx
+++ b/src/components/Keepa/KeepaSignalsHub.tsx
@@ -161,18 +161,33 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
     autoRegenFiredRef.current = false;
   }, [productId]);
 
-  // Auto-regenerate Market Climate when the cached competitor set
-  // doesn't match the matrix's current top-5. Without this, sequences
-  // like "preview-generate → analyze-market create → open vetting page"
-  // can leave the page showing competitors that no longer exist in the
-  // saved set — silent staleness because the cache is keyed on
-  // research_products_id, not the competitor list itself.
+  // Auto-generate Market Climate in two scenarios:
+  //   1. status === 'missing' — no keepa_analysis row exists yet for this
+  //      product (typical for freshly-created markets via Lens Analyze
+  //      Market). Fire once so the user lands on a populated Climate panel
+  //      instead of an empty "Click Generate" state.
+  //   2. status === 'ready' | 'stale' AND the cached competitor set
+  //      doesn't match the matrix's current top-5. Without this, sequences
+  //      like "preview-generate → analyze-market create → open vetting"
+  //      can leave stale competitors visible because the cache is keyed on
+  //      research_products_id, not the competitor list itself.
+  // Both paths share the daily 5/user refresh cap on the server, the same
+  // guard ref (no loops on error), and reset when productId changes.
   useEffect(() => {
     if (autoRegenFiredRef.current) return;
     if (isGenerating) return;
+    if (topCompetitors.length === 0) return;
+
+    // Path 1: missing cache — fire first-time generate.
+    if (status === 'missing') {
+      autoRegenFiredRef.current = true;
+      void handleGenerate();
+      return;
+    }
+
+    // Path 2: cached but possibly stale-vs-matrix.
     if (status !== 'ready' && status !== 'stale') return;
     if (!analysis) return;
-    if (topCompetitors.length === 0) return;
 
     const cachedAsins = Array.isArray(analysis.competitorsAsins)
       ? analysis.competitorsAsins.map(normalizeAsin).filter(Boolean)


### PR DESCRIPTION
## Summary

Extends `KeepaSignalsHub.tsx`'s autoRegen `useEffect` to fire when `status === 'missing'` (no keepa_analysis row yet), in addition to the existing stale-vs-matrix divergence case. Users no longer need to click "Generate Market Climate" on freshly-created markets — it loads alongside the score automatically.

## Why

Real example from Dave's 2026-05-12 testing — created a Wheel Chocks market with 1 competitor via BloomLens Analyze Market. Vetting page rendered the score + market structure + Market Health, but Market Climate panel showed the empty state "Market Climate data hasn't been generated yet. Click Generate…" That extra click was always going to happen, and it's a Keepa-quota-capped call either way — better to do it eagerly so the user sees a complete page on first load.

## How

```ts
// Path 1: missing cache — fire first-time generate.
if (status === 'missing') {
  autoRegenFiredRef.current = true;
  void handleGenerate();
  return;
}

// Path 2: cached but possibly stale-vs-matrix.  (unchanged)
if (status !== 'ready' && status !== 'stale') return;
// … divergence check …
```

## Cost

One extra Keepa call per market creation. Same daily 5/user cap on the server; if the user's over quota the generate transitions status to 'quota' and the ref stays true (no retry loop). Net effect: users who would have clicked Generate anyway now don't have to, users who didn't want Climate "pay" one call they wouldn't have paid before — but it's bounded by the cap.

## Test plan

- [ ] Create a brand-new market via BloomLens Analyze Market → vetting page loads → Market Climate panel populates without a manual click
- [ ] Open a market whose Climate cache matches the matrix → no auto-fire, no extra Keepa call
- [ ] Open a market whose Climate cache is divergent → auto-regen fires (existing behavior — regression check)
- [ ] User over the 5/day cap → status flips to 'quota', no retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)