### PR TITLE
Logo: drop imageRendering: crisp-edges (raster logo, not pixel art)

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -50,7 +50,6 @@ export function Logo({
       src={logoPath}
       alt={alt}
       className={`w-auto object-contain ${className}`}
-      style={{ imageRendering: 'crisp-edges' }}
     />
   );
 


### PR DESCRIPTION
## Summary

Removes the `style={{ imageRendering: 'crisp-edges' }}` inline style from `src/components/Logo.tsx`. That CSS hint forces nearest-neighbor scaling — correct for pixel art, wrong for a 1000×200 raster wordmark, which ended up looking chunky/jagged after the browser downscaled it.

## Reported

Dave noticed the navbar logo looked "lo-res all of a sudden" during 2026-05-12 prod testing. The render bug had actually been present since the Logo component landed (commit `b2d2747`); it just became more visible at certain DPI / zoom combinations.

## Test plan

- [ ] Visual smoke check: wordmark / horizontal / stacked variants render smoothly on `/`, `/research`, `/vetting`, `/offering`, `/sourcing` on both light + dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)