### PR TITLE
Release: Market Climate autogen on fresh markets + logo fix

### DIFF
--- a/src/components/Keepa/KeepaSignalsHub.tsx
+++ b/src/components/Keepa/KeepaSignalsHub.tsx
@@ -161,18 +161,33 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
     autoRegenFiredRef.current = false;
   }, [productId]);
 
-  // Auto-regenerate Market Climate when the cached competitor set
-  // doesn't match the matrix's current top-5. Without this, sequences
-  // like "preview-generate → analyze-market create → open vetting page"
-  // can leave the page showing competitors that no longer exist in the
-  // saved set — silent staleness because the cache is keyed on
-  // research_products_id, not the competitor list itself.
+  // Auto-generate Market Climate in two scenarios:
+  //   1. status === 'missing' — no keepa_analysis row exists yet for this
+  //      product (typical for freshly-created markets via Lens Analyze
+  //      Market). Fire once so the user lands on a populated Climate panel
+  //      instead of an empty "Click Generate" state.
+  //   2. status === 'ready' | 'stale' AND the cached competitor set
+  //      doesn't match the matrix's current top-5. Without this, sequences
+  //      like "preview-generate → analyze-market create → open vetting"
+  //      can leave stale competitors visible because the cache is keyed on
+  //      research_products_id, not the competitor list itself.
+  // Both paths share the daily 5/user refresh cap on the server, the same
+  // guard ref (no loops on error), and reset when productId changes.
   useEffect(() => {
     if (autoRegenFiredRef.current) return;
     if (isGenerating) return;
+    if (topCompetitors.length === 0) return;
+
+    // Path 1: missing cache — fire first-time generate.
+    if (status === 'missing') {
+      autoRegenFiredRef.current = true;
+      void handleGenerate();
+      return;
+    }
+
+    // Path 2: cached but possibly stale-vs-matrix.
     if (status !== 'ready' && status !== 'stale') return;
     if (!analysis) return;
-    if (topCompetitors.length === 0) return;
 
     const cachedAsins = Array.isArray(analysis.competitorsAsins)
       ? analysis.competitorsAsins.map(normalizeAsin).filter(Boolean)

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -50,7 +50,6 @@ export function Logo({
       src={logoPath}
       alt={alt}
       className={`w-auto object-contain ${className}`}
-      style={{ imageRendering: 'crisp-edges' }}
     />
   );
 


### PR DESCRIPTION
## Summary

Two commits from dev to prod:
- #63 — Market Climate auto-generates on freshly-created markets (no more manual Generate click)
- #64 — Logo: drop imageRendering: crisp-edges (smooth raster scaling)

## Test plan

- [ ] Wait for Vercel prod deploy
- [ ] Create a brand-new market via BloomLens Analyze Market → Market Climate panel auto-populates
- [ ] Existing markets with matching cache → no extra Keepa call
- [ ] Navbar logo renders smoothly across pages + themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)