### PR TITLE
Market Climate: read-only view on public share links

### DIFF
--- a/src/app/api/analyze/[id]/route.ts
+++ b/src/app/api/analyze/[id]/route.ts
@@ -110,6 +110,7 @@ export async function GET(
           originalCsvData: submission.original_csv_data || null,
           isPublic: Boolean(submission.is_public),
           publicSharedAt: submission.public_shared_at || null,
+          researchProductsId: linkedResearchProductId || null,
           aiSummary: submission.ai_summary || null,
           adjustment: submission.submission_data?.adjustment || null,
           originalSnapshot: submission.submission_data?.originalSnapshot || null,

--- a/src/app/api/keepa/analysis/public/route.ts
+++ b/src/app/api/keepa/analysis/public/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export const dynamic = 'force-dynamic';
+
+const getServiceClient = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env vars missing.');
+  return createSupabaseClient(url, key, { auth: { persistSession: false } });
+};
+
+const resolveComputed = (
+  analysisJson: Record<string, any> | null,
+  fallbackWindowMonths: number | null,
+  legacyComputed: Record<string, any> | null
+) => {
+  if (analysisJson && typeof analysisJson === 'object') {
+    const meta = analysisJson.meta && typeof analysisJson.meta === 'object' ? analysisJson.meta : null;
+    const { meta: _meta, ...rest } = analysisJson;
+    const windowMonths = Number(meta?.windowMonths ?? fallbackWindowMonths ?? rest.windowMonths ?? 24);
+    return { windowMonths, ...rest };
+  }
+  if (legacyComputed && typeof legacyComputed === 'object') {
+    const windowMonths = Number(legacyComputed.windowMonths ?? fallbackWindowMonths ?? 24);
+    return { windowMonths, ...legacyComputed };
+  }
+  return null;
+};
+
+const emptyOk = () =>
+  NextResponse.json(
+    { analysis: null, stale: true },
+    { status: 200, headers: { 'Cache-Control': 'no-store' } }
+  );
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const submissionId = url.searchParams.get('submissionId');
+    if (!submissionId) {
+      return NextResponse.json(
+        { error: { code: 'KEEPA_PUBLIC_BAD_REQUEST', message: 'Missing submissionId.' } },
+        { status: 400, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    const supabase = getServiceClient();
+
+    const { data: submission, error: submissionError } = await supabase
+      .from('submissions')
+      .select('id, user_id, research_products_id, is_public')
+      .eq('id', submissionId)
+      .maybeSingle();
+
+    if (submissionError) {
+      console.error('Public Keepa analysis: submission lookup error', submissionError);
+      return NextResponse.json(
+        { error: { code: 'KEEPA_PUBLIC_LOOKUP_FAILED', message: 'Failed to load submission.' } },
+        { status: 500, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+    if (!submission || !submission.is_public) {
+      // Don't leak whether the submission exists — treat private/missing
+      // identically. KeepaSignalsHub will render the "not yet generated"
+      // empty state for either case.
+      return emptyOk();
+    }
+
+    // product_id in keepa_analysis is text. It was written as either the
+    // research_products_id (preferred — VettingDetailContent path) or the
+    // submission_id (legacy fallback). Try both, ordered most-recent first.
+    const candidateIds = Array.from(
+      new Set(
+        [submission.research_products_id, submission.id]
+          .filter((v): v is string => typeof v === 'string' && v.length > 0)
+      )
+    );
+    if (candidateIds.length === 0) return emptyOk();
+
+    const { data, error } = await supabase
+      .from('keepa_analysis')
+      .select(
+        'product_id, updated_at, stale_after, window_months, competitors_asins, analysis_json, normalized_series_json, computed_metrics_json'
+      )
+      .eq('user_id', submission.user_id)
+      .in('product_id', candidateIds)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      console.error('Public Keepa analysis: query error', error);
+      return NextResponse.json(
+        { error: { code: 'KEEPA_PUBLIC_LOAD_FAILED', message: 'Failed to load Market Climate.' } },
+        { status: 500, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+    if (!data) return emptyOk();
+
+    const computed = resolveComputed(
+      (data as any).analysis_json ?? null,
+      data.window_months ?? null,
+      (data as any).computed_metrics_json ?? null
+    );
+    if (!computed) return emptyOk();
+
+    const staleAfter = data.stale_after ? new Date(data.stale_after).getTime() : 0;
+    const isStale = staleAfter > 0 ? staleAfter < Date.now() : true;
+    const windowMonths = Number(computed.windowMonths ?? data.window_months ?? 24);
+
+    return NextResponse.json(
+      {
+        analysis: {
+          productId: data.product_id,
+          updatedAt: data.updated_at,
+          staleAfter: data.stale_after,
+          windowMonths,
+          competitorsAsins: data.competitors_asins ?? [],
+          normalized: data.normalized_series_json ?? null,
+          computed
+        },
+        stale: isStale
+      },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Public Keepa analysis GET error:', error);
+    return NextResponse.json(
+      { error: { code: 'KEEPA_PUBLIC_LOAD_FAILED', message: 'Failed to load Market Climate.' } },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}

--- a/src/app/submission/[id]/page.tsx
+++ b/src/app/submission/[id]/page.tsx
@@ -24,7 +24,14 @@ export default function SubmissionPage() {
   const [recalculationFeedback, setRecalculationFeedback] = useState<string>('');
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [user, setUser] = useState<any>(null);
-  const [onlyReadMode, setOnlyReadMode] = useState(false);
+  // Pessimistic default: assume read-only until fetchSubmission confirms
+  // the viewer is the submission owner. Stops the Refresh button (and
+  // other owner-only controls) from flashing on screen for non-owners
+  // during the gap between checkAuth resolving and fetchSubmission
+  // resolving — a logged-in non-owner would otherwise hit `false` here
+  // for the brief window where checkAuth had run but ownership was not
+  // yet known.
+  const [onlyReadMode, setOnlyReadMode] = useState(true);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
   // Typeform submission tracking
@@ -93,7 +100,11 @@ export default function SubmissionPage() {
         }
         if (user) {
           setUser(user);
-          setOnlyReadMode(false);
+          // Do NOT setOnlyReadMode(false) here — we don't yet know if
+          // this user is the submission owner. fetchSubmission (below)
+          // will flip it to false only after confirming the userId
+          // match. Setting it false here causes a flash of owner-mode
+          // UI (Refresh button, etc.) on non-owners.
         }
         setIsAuthenticating(false);
         
@@ -648,10 +659,12 @@ export default function SubmissionPage() {
           throw new Error('Failed to retrieve submission data');
         }
 
-        // If the submission is not owned by the current user, set only read mode
-        if (data.submission.userId !== session?.user?.id) {
-          setOnlyReadMode(true);
-        }
+        // Set onlyReadMode based on ownership match. Explicit on both
+        // sides so the pessimistic initial state (true) flips correctly
+        // for owners once we've confirmed identity.
+        const viewerId = session?.user?.id;
+        const isOwner = Boolean(viewerId && data.submission.userId === viewerId);
+        setOnlyReadMode(!isOwner);
         
         console.log(`Successfully fetched submission from API: ${data.submission.id}`);
         

--- a/src/app/submission/[id]/page.tsx
+++ b/src/app/submission/[id]/page.tsx
@@ -1055,6 +1055,7 @@ export default function SubmissionPage() {
         
         {/* Use ProductVettingResults component for full functionality */}
         <ProductVettingResults
+          productId={submission.researchProductsId || submission.id}
           competitors={submission.productData?.competitors || []}
           distributions={submission.productData?.distributions}
           keepaResults={submission.keepaResults || []}
@@ -1070,6 +1071,8 @@ export default function SubmissionPage() {
           adjustment={submission.adjustment || null}
           originalSnapshot={submission.originalSnapshot || null}
           onResetToOriginal={handleResetToOriginal}
+          viewerMode={onlyReadMode ? 'public' : 'owner'}
+          submissionId={submission.id}
         />
       </div>
 

--- a/src/components/Keepa/KeepaSignalsHub.tsx
+++ b/src/components/Keepa/KeepaSignalsHub.tsx
@@ -61,6 +61,12 @@ interface KeepaSignalsHubProps {
   title?: string;
   subtitle?: React.ReactNode;
   removedAsins?: Set<string> | string[];
+  // Public-share viewers can't trigger Keepa generates (would burn the
+  // owner's daily refresh cap and they're not authed anyway). In 'public'
+  // mode we read the cached analysis via the no-auth public endpoint and
+  // hide all controls. submissionId is required in 'public' mode.
+  viewerMode?: 'owner' | 'public';
+  submissionId?: string;
 }
 
 const normalizeAsin = (asin: string | null) =>
@@ -79,8 +85,11 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
       <span className="text-slate-100 font-semibold">past 12 months</span>.
     </>
   ),
-  removedAsins
+  removedAsins,
+  viewerMode = 'owner',
+  submissionId
 }) => {
+  const isPublicViewer = viewerMode === 'public';
   const [analysis, setAnalysis] = useState<KeepaAnalysisSnapshot | null>(null);
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'stale' | 'missing' | 'error' | 'quota'>(
     'idle'
@@ -120,12 +129,16 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
   }, []);
 
   const loadAnalysis = useCallback(async () => {
-    if (!productId) return;
+    if (isPublicViewer && !submissionId) return;
+    if (!isPublicViewer && !productId) return;
     setStatus('loading');
     setErrorMessage(null);
     try {
-      const headers = await getAuthHeaders();
-      const response = await fetch(`/api/keepa/analysis?productId=${encodeURIComponent(productId)}`, {
+      const headers = isPublicViewer ? {} : await getAuthHeaders();
+      const endpoint = isPublicViewer
+        ? `/api/keepa/analysis/public?submissionId=${encodeURIComponent(submissionId!)}`
+        : `/api/keepa/analysis?productId=${encodeURIComponent(productId)}`;
+      const response = await fetch(endpoint, {
         method: 'GET',
         headers,
         cache: 'no-store'
@@ -149,7 +162,7 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
         sanitizeUiMessage(error instanceof Error ? error.message : 'Market Climate failed to load.')
       );
     }
-  }, [getAuthHeaders, productId]);
+  }, [getAuthHeaders, productId, isPublicViewer, submissionId]);
 
   useEffect(() => {
     void loadAnalysis();
@@ -177,6 +190,8 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
     if (autoRegenFiredRef.current) return;
     if (isGenerating) return;
     if (topCompetitors.length === 0) return;
+    // Public viewers can't trigger generates — read-only by design.
+    if (isPublicViewer) return;
 
     // Path 1: missing cache — fire first-time generate.
     if (status === 'missing') {
@@ -210,7 +225,7 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
     // via React render; intentionally omitted from deps to keep the
     // effect tied to the analysis-vs-matrix comparison only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [analysis, topCompetitors, isGenerating, status]);
+  }, [analysis, topCompetitors, isGenerating, status, isPublicViewer]);
 
   const handleGenerate = async () => {
     if (!productId || isGenerating) return;
@@ -252,7 +267,11 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
   };
 
   const showWarning =
-    status === 'loading' || status === 'stale' || status === 'missing' || status === 'quota' || status === 'error';
+    status === 'loading' ||
+    (status === 'stale' && !isPublicViewer) ||
+    status === 'missing' ||
+    status === 'quota' ||
+    status === 'error';
 
   return (
     <div className="bg-slate-800/50 backdrop-blur-xl rounded-2xl shadow-xl border border-slate-700/50">
@@ -263,25 +282,27 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
               <h2 className="text-2xl font-bold text-white">{title}</h2>
               <p className="text-slate-400">{subtitle}</p>
             </div>
-            <button
-              type="button"
-              onClick={handleGenerate}
-              disabled={isGenerating || !topCompetitors.length}
-              className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed ${
-                isGenerating
-                  ? 'border-blue-400/70 bg-blue-500/15 text-blue-100 animate-pulse'
-                  : 'border-blue-500/60 bg-blue-500/10 text-blue-100 hover:border-blue-400/70 disabled:border-slate-700/60 disabled:bg-slate-900/40 disabled:text-slate-500'
-              }`}
-            >
-              {isGenerating && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-              {analysis
-                ? isGenerating
-                  ? 'Refreshing…'
-                  : 'Refresh Market Climate'
-                : isGenerating
-                ? 'Generating…'
-                : 'Generate Market Climate'}
-            </button>
+            {!isPublicViewer && (
+              <button
+                type="button"
+                onClick={handleGenerate}
+                disabled={isGenerating || !topCompetitors.length}
+                className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed ${
+                  isGenerating
+                    ? 'border-blue-400/70 bg-blue-500/15 text-blue-100 animate-pulse'
+                    : 'border-blue-500/60 bg-blue-500/10 text-blue-100 hover:border-blue-400/70 disabled:border-slate-700/60 disabled:bg-slate-900/40 disabled:text-slate-500'
+                }`}
+              >
+                {isGenerating && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                {analysis
+                  ? isGenerating
+                    ? 'Refreshing…'
+                    : 'Refresh Market Climate'
+                  : isGenerating
+                  ? 'Generating…'
+                  : 'Generate Market Climate'}
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -305,10 +326,12 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
           )}
           {status === 'missing' && (
             <div className="rounded-lg border border-slate-700/60 bg-slate-900/40 px-4 py-3 text-sm text-slate-300">
-              Market Climate data hasn't been generated yet. Click Generate to load the 12–24 month view.
+              {isPublicViewer
+                ? "Market Climate hasn't been generated for this market yet."
+                : "Market Climate data hasn't been generated yet. Click Generate to load the 12–24 month view."}
             </div>
           )}
-          {status === 'stale' && (
+          {status === 'stale' && !isPublicViewer && (
             <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
               Market Climate is out of date. Refresh to pull the latest 12–24 month view.
             </div>
@@ -355,7 +378,9 @@ const KeepaSignalsHub: React.FC<KeepaSignalsHubProps> = ({
       {!analysis && !isGenerating && !showWarning && (
         <div className="p-6">
           <div className="rounded-xl border border-slate-700/60 bg-slate-900/40 px-4 py-6 text-sm text-slate-300">
-            Market Climate data hasn't been generated yet. Click Generate to load the 12–24 month view.
+            {isPublicViewer
+              ? "Market Climate hasn't been generated for this market yet."
+              : "Market Climate data hasn't been generated yet. Click Generate to load the 12–24 month view."}
           </div>
         </div>
       )}

--- a/src/components/Results/MarketVisuals.tsx
+++ b/src/components/Results/MarketVisuals.tsx
@@ -46,6 +46,8 @@ interface MarketVisualsProps {
   removalCandidateAsins?: string[];
   removedAsins?: Set<string> | string[];
   imageUrlByAsin?: Map<string, string | null>;
+  viewerMode?: 'owner' | 'public';
+  submissionId?: string;
 }
 
 const getPerformanceColor = (score: number): string => {
@@ -1391,7 +1393,9 @@ const MarketVisuals: React.FC<MarketVisualsProps> = ({
   showGraph = true,
   showHistorical = true,
   removalCandidateAsins = [],
-  removedAsins
+  removedAsins,
+  viewerMode = 'owner',
+  submissionId
 }) => {
   const mergedCompetitorData = useMergedCompetitorData(competitors, rawData);
 
@@ -1424,6 +1428,8 @@ const MarketVisuals: React.FC<MarketVisualsProps> = ({
           productId={productId || 'unknown'}
           competitors={getHistoricalCompetitors as any}
           removedAsins={removedAsins}
+          viewerMode={viewerMode}
+          submissionId={submissionId}
         />
       )}
     </div>

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -658,6 +658,11 @@ export const ProductVettingResults: React.FC<{
   /** True when the persisted ai_summary no longer matches the current
    *  competitor set (parent toggled stale on adjust, false on refresh/reset). */
   summaryStale?: boolean;
+  /** Public-share viewer mode for Market Climate. When 'public', the Climate
+   *  panel reads the cached analysis via the no-auth public endpoint and
+   *  hides all controls. Requires submissionId. */
+  viewerMode?: 'owner' | 'public';
+  submissionId?: string;
 }> = ({
   productId,
   onlyReadMode = false,
@@ -677,7 +682,9 @@ export const ProductVettingResults: React.FC<{
   originalSnapshot = null,
   onResetToOriginal,
   onRefreshSummary,
-  summaryStale = false
+  summaryStale = false,
+  viewerMode = 'owner',
+  submissionId
 }) => {
   // Phase 2.3: the AI briefing body starts collapsed — only the verdict,
   // score bar, and headline show on first load. Keeps the side cards from
@@ -3193,6 +3200,8 @@ export const ProductVettingResults: React.FC<{
               competitors={activeCompetitors as any}
               rawData={effectiveKeepaResults}
               showGraph={false}
+              viewerMode={viewerMode}
+              submissionId={submissionId}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- Public share view (`/submission/[id]`) never had a working Market Climate panel for non-owners. Two reasons stacked:
  1. `ProductVettingResults` wasn't being passed a `productId`, so `KeepaSignalsHub` fell through to a synthetic `asin-group:...` key that never matched the cached row
  2. `/api/keepa/analysis` is auth-gated + scoped to `user_id`, so anonymous / other-user viewers got 401 even with the right key
- New public read-only path: GET `/api/keepa/analysis/public?submissionId=...` returns the cached analysis only when `submissions.is_public = true`. Service-role client, never triggers a regen, mirrors `/api/keepa/analysis` response shape
- `KeepaSignalsHub` gains a `viewerMode` prop. In `'public'` mode it hits the new endpoint, skips auto-regen, hides Generate/Refresh, and swaps empty-state copy. Plumbed through `MarketVisuals` → `ProductVettingResults` → `/submission/[id]`
- Owner viewing their own share link keeps full controls (auth-gated path); the existing `onlyReadMode` signal drives the mode switch

## Test plan
- [ ] Open a public share link as **owner** → Market Climate loads with Refresh button, behaves like `/vetting/[asin]`
- [ ] Open the same share link **logged out / different account** → Market Climate loads read-only from cache, no Refresh button, no Generate prompt
- [ ] Open a public share link for a market where owner **hasn't generated** Climate yet → shows "Market Climate hasn't been generated for this market yet." (no Click-Generate prompt)
- [ ] Set submission `is_public = false`, then hit `/api/keepa/analysis/public?submissionId=...` directly → returns `{ analysis: null, stale: true }` (doesn't leak whether the submission exists)
- [ ] `/vetting/[asin]` flow unchanged — owner still sees full Climate controls; auto-regen on missing/stale still fires
- [ ] No 401s in browser console on public share view

🤖 Generated with [Claude Code](https://claude.com/claude-code)