### PR TITLE
/vetting/[asin]: redirect unauth visitors to /login

### DIFF
--- a/src/components/Vetting/VettingDetailContent.tsx
+++ b/src/components/Vetting/VettingDetailContent.tsx
@@ -152,7 +152,23 @@ export function VettingDetailContent({ asin }: { asin: string }) {
   }, [submission]);
 
   const fetchData = async () => {
-    if (!user) return;
+    if (!user) {
+      // Distinguish "auth state still loading" from "definitely not logged in".
+      // The Redux user is null during the brief window before AuthProvider
+      // hydrates from Supabase, AND it's null for actually-logged-out users.
+      // Without this check, unauth visitors saw an endless "Loading vetting
+      // analysis…" spinner because fetchData silently returned and never
+      // flipped `loading` to false.
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        const path = pathname + (searchString ? `?${searchString}` : '');
+        router.replace(`/login?redirect=${encodeURIComponent(path)}`);
+        return;
+      }
+      // Session exists but Redux hasn't caught up yet — useEffect re-runs
+      // when user.id populates, so just wait.
+      return;
+    }
     try {
       setLoading(true);
       setError(null);


### PR DESCRIPTION
## Summary
- `VettingDetailContent.fetchData` early-returned when Redux `user` was `null` without flipping `loading=false`, so unauth visitors saw an endless "Loading vetting analysis…" spinner
- Now: if no Supabase session, redirect to `/login?redirect=<current path>` (matches the pattern used in `/profile`, `/subscription`, etc.). If session exists but Redux user hasn't hydrated yet, return — the existing useEffect re-runs when `user.id` populates
- Uses `router.replace` so the dead vetting URL doesn't sit in back-button history

## Test plan
- [ ] Open `/vetting/<some-asin>` in an incognito window → redirects to `/login?redirect=%2Fvetting%2F...` instantly (no spinner)
- [ ] Sign in via that login flow → bounces back to the original vetting URL and loads normally
- [ ] Open `/vetting/<some-asin>` while logged in → no regression, loads as today
- [ ] Hard-refresh `/vetting/<some-asin>` while logged in (brief Redux-hydration window) → loads as today, no redirect-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)