### PR TITLE
Inflated-review detection: composite signal replacing PR #55 velocity check

### DIFF
--- a/scripts/probes/keepa-rating-param.ts
+++ b/scripts/probes/keepa-rating-param.ts
@@ -1,0 +1,110 @@
+/**
+ * Probe — does Keepa need `&rating=1` to return csv[16]/csv[17] (rating +
+ * rating count)?
+ *
+ * Our /api/extension/enrich currently sends `&stats=180&history=1` and
+ * reads `stats.current[17]` for the per-ASIN review count. The cached
+ * keepa_lens_metrics for two known products (one valid top-seller, one
+ * suspect outlier) both stored reviews: null, so something's off in the
+ * request shape.
+ *
+ * Goal: determine the minimum URL parameters needed to get a populated
+ * csv[16] (rating × 10) and csv[17] (rating/review count) for a known
+ * top product. Then update enrich/route.ts.
+ *
+ * Run with: `npx tsx scripts/probes/keepa-rating-param.ts`
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+try {
+  const envText = fs.readFileSync(path.join(process.cwd(), '.env.local'), 'utf8');
+  for (const line of envText.split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)=(.*)$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+  }
+} catch {}
+
+const KEEPA_BASE_URL = 'https://api.keepa.com';
+const KEY = process.env.KEEPA_API_KEY;
+if (!KEY) {
+  console.error('KEEPA_API_KEY missing from env. Exit.');
+  process.exit(1);
+}
+
+// TheraICE variation family. SERP DOM shows IDENTICAL 43,519 reviews on
+// each of the 4 children's cards (verified via production data corpus
+// query). If Keepa returns identical csv[17] for each, the per-child
+// reviews are aggregated upstream (variation-tree share-reviews) — and
+// "divert to Keepa per child" doesn't fully solve the variation case. If
+// Keepa returns DIFFERENT per-child counts, then SERP is aggregating
+// and Keepa is the per-child truth we want.
+const ASINS = ['B0CBSQVMHM', 'B0D9BWY9MP', 'B0CNKPLFK5', 'B0CBCVS3XX'];
+
+type Variant = {
+  label: string;
+  params: string;
+};
+
+const VARIANTS: Variant[] = [
+  // Confirmed working variant from prior run.
+  { label: 'stats=180&history=1&rating=1', params: '&stats=180&history=1&rating=1' },
+];
+
+function summarize(product: any) {
+  const stats = product?.stats ?? {};
+  const cur: number[] = Array.isArray(stats.current) ? stats.current : [];
+  const csv: any[] = Array.isArray(product?.csv) ? product.csv : [];
+  const csv16: number[] = Array.isArray(csv[16]) ? csv[16] : [];
+  const csv17: number[] = Array.isArray(csv[17]) ? csv[17] : [];
+
+  return {
+    asin: product?.asin,
+    title: (product?.title || '').slice(0, 60),
+    'stats.current[16] (rating ×10)': cur[16] ?? '∅',
+    'stats.current[17] (review count)': cur[17] ?? '∅',
+    'csv[16].length (rating history pts)': csv16.length,
+    'csv[17].length (review count history pts)': csv17.length,
+    'csv[16] last value (rating ×10)':
+      csv16.length >= 2 ? csv16[csv16.length - 1] : '∅',
+    'csv[17] last value (review count)':
+      csv17.length >= 2 ? csv17[csv17.length - 1] : '∅',
+  };
+}
+
+async function fetchVariant(asin: string, variant: Variant) {
+  const url =
+    `${KEEPA_BASE_URL}/product` +
+    `?key=${KEY}` +
+    `&domain=1` + // US
+    `&asin=${asin}` +
+    variant.params;
+  const t0 = Date.now();
+  const res = await fetch(url);
+  const elapsed = Date.now() - t0;
+  if (!res.ok) {
+    return { error: `HTTP ${res.status} (${elapsed}ms)`, elapsed };
+  }
+  const body = (await res.json()) as any;
+  const product = Array.isArray(body?.products) ? body.products[0] : null;
+  return {
+    elapsed,
+    tokensConsumed: body?.tokensConsumed ?? null,
+    tokensLeft: body?.tokensLeft ?? null,
+    refillRate: body?.refillRate ?? null,
+    summary: product ? summarize(product) : { error: 'No product in response' },
+  };
+}
+
+(async () => {
+  for (const asin of ASINS) {
+    console.log(`\n=== ${asin} ===`);
+    for (const variant of VARIANTS) {
+      console.log(`\n--- variant: ${variant.label} ---`);
+      const result = await fetchVariant(asin, variant);
+      console.log(JSON.stringify(result, null, 2));
+      // Be polite to Keepa.
+      await new Promise((r) => setTimeout(r, 400));
+    }
+  }
+})();

--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -54,6 +54,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/utils/supabaseAdmin';
 import { checkCap } from '@/lib/subscription';
 import { calculateMarketScore } from '@/utils/scoring';
+import { isReviewCountInflated } from '@/lib/competitorDataQuality';
 import {
   corsPreflight,
   deriveEffectiveLensTier,
@@ -104,7 +105,12 @@ type ScrapedRow = {
 // rendered `—` even though we had the data, which surfaced as Dave's
 // "missing matrix columns" testing feedback.
 function scrapedRowToCompetitor(row: ScrapedRow, opts: { isNew: boolean; addedAt: string }) {
-  return {
+  // Detect rows whose displayed review count is inconsistent with the
+  // rest of the listing data (variation-family aggregation on SERP,
+  // catalog-content edits, etc.). Tag `dataQuality: 'limited'` so the
+  // vetting page can dash the affected cells and skip them from share-%
+  // denominators. See src/lib/competitorDataQuality.ts for the gate.
+  const baseCompetitor = {
     asin: row.asin,
     title: row.title ?? row.asin,
     brand: row.brand ?? null,
@@ -129,6 +135,8 @@ function scrapedRowToCompetitor(row: ScrapedRow, opts: { isNew: boolean; addedAt
     __lens_origin: true,
     ...(opts.isNew ? { __lens_new: true, __lens_added_at: opts.addedAt } : {}),
   };
+  const dataQuality = isReviewCountInflated(baseCompetitor) ? 'limited' : undefined;
+  return dataQuality ? { ...baseCompetitor, dataQuality } : baseCompetitor;
 }
 
 function indexScrapedByAsin(rows: ScrapedRow[]): Map<string, ScrapedRow> {

--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -54,6 +54,7 @@ import {
   CURVE_VERSION,
 } from '@/lib/extension/bsrSalesCurve';
 import { resolveCategoryMultiplier } from '@/lib/extension/bsrCategoryMultipliers';
+import { isReviewCountInflated } from '@/lib/competitorDataQuality';
 
 export const dynamic = 'force-dynamic';
 
@@ -501,27 +502,29 @@ function buildEnrichedRow(product: any): EnrichedRow {
   // Static fields. listedSince is in Keepa minutes.
   const listingCreatedAt = keepaMinutesToIso(product.listedSince);
 
-  // Relisted-ASIN guardrail. Sellers periodically drop a brand-new
-  // product onto an ASIN that previously held a different (mature)
-  // listing. Amazon's PDP shows the new product, but Keepa retains the
-  // PREVIOUS product's review/BSR/rank history attached to the ASIN —
-  // so we'd report 18k+ reviews and a healthy BSR for a 70-day-old
-  // ping-pong table (real example: B0GQSRRRXK on 2026-05-11). When
-  // implausible review velocity tips us off, treat the entire metrics
-  // block as untrustworthy: surface a "limited" row instead of fake
-  // monthly-revenue numbers that mislead the user. 50 reviews/day is
-  // a deliberately generous cap — even viral organic launches rarely
-  // sustain that pace.
-  const REVIEWS_PER_DAY_CAP = 50;
-  const listingAgeDays =
-    typeof product.listedSince === 'number' && product.listedSince > 0
-      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
-      : null;
-  const isLikelyRelistedAsin =
-    reviews != null &&
-    reviews > 0 &&
-    listingAgeDays != null &&
-    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
+  // Inflated-review guardrail. Several mechanisms can leave Keepa or
+  // Amazon's SERP DOM reporting a review count that's inconsistent with
+  // the rest of the listing's data: variation-family review aggregation
+  // (Amazon shows the parent's count on child cards), catalog-content
+  // edits on long-lived ASINs (reviews persist when the listing's
+  // identity changes), and SERP-DOM sponsored-card scraping picking up
+  // brand-aggregate counts. The original framing ("relisted ASIN" /
+  // "previous owner of ASIN") was inaccurate — ASINs aren't transferred
+  // between owners. We just need to recognize the data-quality problem
+  // and mark the row 'limited'.
+  //
+  // The first version of this gate used reviews-per-day > 50 alone, which
+  // false-positived legitimate viral products (e.g. Loocio B09DF9NWC7 at
+  // BSR 22 sustains 90 reviews/day organically). The shared helper raises
+  // the velocity threshold to 100/day AND adds a sales/BSR sanity signal,
+  // so legitimate top-sellers pass through while inflated outliers (e.g.
+  // bangminda B0GBX8QY64: 15,343 reviews at BSR 1M, 3/mo sales) flag.
+  const isLikelyRelistedAsin = isReviewCountInflated({
+    reviews,
+    dateFirstAvailable: listingCreatedAt,
+    bsr: currentBsr,
+    monthlySales: monthlyUnits,
+  });
   const weightLb =
     typeof product.packageWeight === 'number' && product.packageWeight > 0
       ? round2(product.packageWeight / 453.592) // grams → pounds

--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -197,13 +197,24 @@ export async function POST(request: NextRequest) {
 
     // Single batched call to Keepa for all misses. Empty toFetch → skip.
     if (toFetch.length > 0) {
+      // `rating=1` opts into Keepa's rating + rating-count history
+      // (csv[16] and csv[17]). Without it, stats.current[16/17] come back
+      // as -1 and the csv arrays are empty length, leaving us blind to
+      // per-ASIN review counts and forcing reliance on SERP DOM (which
+      // aggregates variation families and can be inflated by catalog
+      // edits). Probe results confirm: for a known top-seller (Loocio
+      // BSR 22), adding rating=1 returns the real 24k review count where
+      // baseline returned -1. Cost: 2 tokens/request instead of 1, well
+      // within our 62/min refill budget. See
+      // scripts/probes/keepa-rating-param.ts for the validation run.
       const url =
         `${KEEPA_BASE_URL}/product` +
         `?key=${apiKey}` +
         `&domain=${KEEPA_DOMAIN_US}` +
         `&asin=${toFetch.join(',')}` +
         `&stats=180` +
-        `&history=1`;
+        `&history=1` +
+        `&rating=1`;
 
       const t0 = Date.now();
       const res = await fetch(url);

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -21,6 +21,7 @@ import MarketVisuals, { CompetitorGraphTab } from './MarketVisuals';
 import { Tooltip as InfoTooltip } from '../Offer/components/Tooltip';
 import PriceMap from './Charts/PriceMap';
 import { getVettingInsights, type CompetitorRowInsight } from '@/lib/vetting/insights';
+import { isReviewCountInflated } from '@/lib/competitorDataQuality';
 import { getPercentileThresholds } from '../../utils/metricBands';
 import { KeepaAnalysisResult } from '../Keepa/KeepaTypes';
 import {
@@ -1137,12 +1138,40 @@ export const ProductVettingResults: React.FC<{
       .filter(Boolean);
   }, [fullVettingInsights]);
 
+  // Detect competitors whose displayed review count is inconsistent with
+  // the rest of their listing data (variation-family review aggregation
+  // on Amazon SERP, catalog-content edits, sponsored-brand card scraping,
+  // etc. — the cause varies, the data quality problem is the same).
+  // Calling these "relisted ASINs" was inaccurate. The src/lib helper
+  // gates on a two-signal check that doesn't false-positive legitimate
+  // viral products. See src/lib/competitorDataQuality.ts.
+  const inflatedReviewAsins = useMemo(() => {
+    const set = new Set<string>();
+    for (const comp of activeCompetitors) {
+      if (isReviewCountInflated(comp as any)) {
+        const a = normalizeAsin(comp.asin);
+        if (a) set.add(a);
+      }
+    }
+    return set;
+  }, [activeCompetitors]);
+
+  const isInflatedReviewRow = (competitor: Competitor) =>
+    inflatedReviewAsins.has(normalizeAsin(competitor.asin));
+
   const reviewShareStats = useMemo(() => {
-    const totalReviews = activeCompetitors.reduce((sum, comp) => {
+    // Skip inflated-review rows from the denominator AND from the
+    // share-% spread used to compute band thresholds — a row that gets
+    // dashed in the table shouldn't be steering the percentile cutoffs
+    // that color the OTHER rows' badges.
+    const reliable = activeCompetitors.filter(
+      (comp) => !inflatedReviewAsins.has(normalizeAsin(comp.asin))
+    );
+    const totalReviews = reliable.reduce((sum, comp) => {
       const reviewValue = typeof comp.reviews === 'string' ? parseFloat(comp.reviews) : (comp.reviews || 0);
       return sum + (Number.isFinite(reviewValue) ? reviewValue : 0);
     }, 0);
-    const reviewShares = activeCompetitors
+    const reviewShares = reliable
       .map((comp) => {
         const reviewValue = typeof comp.reviews === 'string' ? parseFloat(comp.reviews) : (comp.reviews || 0);
         if (!totalReviews || !Number.isFinite(reviewValue)) return undefined;
@@ -1154,7 +1183,7 @@ export const ProductVettingResults: React.FC<{
       thresholds: getPercentileThresholds(reviewShares),
       extremes: getPercentileThresholds(reviewShares, { low: 0.1, high: 0.9 })
     };
-  }, [activeCompetitors]);
+  }, [activeCompetitors, inflatedReviewAsins]);
 
   const strengthRank: Record<string, number> = {
     STRONG: 3,
@@ -1163,6 +1192,10 @@ export const ProductVettingResults: React.FC<{
   };
 
   const getReviewShareValue = (competitor: Competitor) => {
+    // Inflated-review rows render as "—" in the Review Share column.
+    // Their reviews are also excluded from reviewShareStats.totalReviews
+    // (the denominator) so the OTHER rows' shares aren't squashed.
+    if (isInflatedReviewRow(competitor)) return undefined;
     const reviewValue = typeof competitor.reviews === 'string'
       ? parseFloat(competitor.reviews)
       : (competitor.reviews || 0);
@@ -1535,6 +1568,16 @@ export const ProductVettingResults: React.FC<{
     isHighlighted: boolean
   ) => {
     if (columnKey === 'reviews') {
+      // Inflated-review rows (e.g. variation-aggregated SERP counts) render
+      // as "—" so the user isn't told a 5-stock, 3/mo-sales listing has
+      // 15,000 reviews.
+      if (isInflatedReviewRow(competitor)) {
+        return (
+          <span className="inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold border border-slate-700/60 bg-slate-900/40 text-slate-400">
+            —
+          </span>
+        );
+      }
       const reviewsValue = typeof competitor.reviews === 'string'
         ? parseFloat(competitor.reviews)
         : competitor.reviews;
@@ -2061,9 +2104,14 @@ export const ProductVettingResults: React.FC<{
         })()
       : 'No data';
 
-    // Market Size — same weighting logic as the legacy card, collapsed into a label+color
+    // Market Size — same weighting logic as the legacy card, collapsed into a label+color.
+    // Exclude inflated-review rows so a variation-aggregated 15k-review entry
+    // doesn't push a tiny niche market into the "established" bucket.
+    const sizeCompetitors = activeCompetitors.filter(
+      (c) => !inflatedReviewAsins.has(normalizeAsin(c.asin))
+    );
     const { sizeLabel: marketSizeLabel, sizeIcon: marketSizeIcon, sizeColor: marketSizeColor } =
-      computeMarketSize(activeCompetitors);
+      computeMarketSize(sizeCompetitors.length > 0 ? sizeCompetitors : activeCompetitors);
 
     const bsrStability = computeStabilityLabel(effectiveKeepaResults, 'bsr');
     const priceStability = computeStabilityLabel(effectiveKeepaResults, 'price', /* priceMode */ true);

--- a/src/lib/competitorDataQuality.ts
+++ b/src/lib/competitorDataQuality.ts
@@ -1,0 +1,95 @@
+/**
+ * Detect competitors whose displayed review count is inconsistent with the
+ * rest of their listing data. The mechanism on Amazon's side can be one of
+ * several things — variation-family review aggregation on the SERP DOM,
+ * catalog-content editing on a long-lived ASIN, sponsored-brand card
+ * scraping that picks up brand-aggregate counts — but from BloomEngine's
+ * vantage point we only need to recognize the data-quality problem, not
+ * its cause. Calling these "relisted ASINs" was inaccurate; ASINs aren't
+ * transferred between owners on Amazon. Use `dataQuality: 'limited'`.
+ *
+ * Detection is intentionally a two-signal gate. A pure reviews-per-day
+ * velocity check (the v1 heuristic that shipped in PR #55) false-positives
+ * on legitimate viral products — e.g. a product with BSR 22 selling 3,000+
+ * units/month can sustain 90 reviews/day organically. Two real corpus
+ * checks both pass the new gate:
+ *   - Loocio B09DF9NWC7: 24,340 reviews, BSR 22, 3,634/mo sales → NOT flagged
+ *   - TheraICE B0CBSQVMHM: 43,519 reviews, BSR 645, 22,458/mo sales → NOT flagged
+ * Two real corpus cases both flag correctly:
+ *   - B0GBX8QY64 (Dave's screenshot): 15,343 reviews, BSR 1,006,500, 3/mo → FLAG
+ *   - B0GQSRRRXK (the 2026-05-11 case): 18,602 reviews, age 70 days → FLAG (velocity)
+ */
+
+const REVIEWS_FLOOR = 1000;
+const REVIEWS_PER_DAY_CAP = 100;
+const BSR_POOR_FLOOR = 500_000;
+const MONTHLY_SALES_FLOOR = 50;
+
+type MaybeNumeric = number | string | null | undefined;
+
+const asNumber = (v: MaybeNumeric): number | null => {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const dateFirstAvailableToDays = (raw: MaybeNumeric, now: number = Date.now()): number | null => {
+  if (raw == null) return null;
+  // Accept ISO strings, Date-parseable strings, or numeric epoch.
+  const ms = typeof raw === 'number' ? raw : Date.parse(String(raw));
+  if (!Number.isFinite(ms)) return null;
+  const days = Math.floor((now - ms) / 86_400_000);
+  return days >= 0 ? Math.max(1, days) : null;
+};
+
+export interface CompetitorLike {
+  reviews?: MaybeNumeric;
+  monthlySales?: MaybeNumeric;
+  bsr?: MaybeNumeric;
+  dateFirstAvailable?: MaybeNumeric;
+  age?: MaybeNumeric;
+}
+
+/**
+ * Returns true when the competitor's review count is internally
+ * inconsistent with the rest of its listing data and should NOT be
+ * trusted for share-% denominators, market-size classification, or
+ * direct display.
+ */
+export function isReviewCountInflated(comp: CompetitorLike, now: number = Date.now()): boolean {
+  const reviews = asNumber(comp.reviews);
+  if (reviews == null || reviews < REVIEWS_FLOOR) return false;
+
+  const ageDays =
+    dateFirstAvailableToDays(comp.dateFirstAvailable, now) ??
+    (asNumber(comp.age) != null ? Math.max(1, Math.round((asNumber(comp.age) as number) * 30)) : null);
+
+  // Signal A: implausible accumulation velocity. 100 reviews/day is well
+  // above any real product's organic rate (peak viral products top out
+  // around 50/day per Amazon community benchmarks). Catches cases where
+  // Keepa-derived sales/BSR are ALSO polluted from the same source as the
+  // review count, leaving velocity as the only clean signal.
+  if (ageDays != null && reviews / ageDays > REVIEWS_PER_DAY_CAP) return true;
+
+  // Signal B: sales/rank can't support the displayed review count. A real
+  // listing accumulating 1,000+ reviews has to be selling; if BSR is way
+  // down AND monthly-sales velocity is near zero, the reviews are coming
+  // from somewhere other than this product's own sales history.
+  const bsr = asNumber(comp.bsr);
+  const monthlySales = asNumber(comp.monthlySales);
+  const bsrPoor = bsr != null && bsr > BSR_POOR_FLOOR;
+  const salesLow = monthlySales != null && monthlySales < MONTHLY_SALES_FLOOR;
+  if (bsrPoor && salesLow) return true;
+
+  return false;
+}
+
+/**
+ * Returns a shallow-copied competitor with `dataQuality: 'limited'` set
+ * when the review count is inflated. Use when WRITING competitor records
+ * (analyze-market route) so downstream consumers see the flag.
+ */
+export function tagCompetitorDataQuality<T extends CompetitorLike>(comp: T, now: number = Date.now()): T & { dataQuality?: 'limited' } {
+  if (!isReviewCountInflated(comp, now)) return comp;
+  return { ...comp, dataQuality: 'limited' };
+}


### PR DESCRIPTION
## What this fixes

Dave caught **B0GBX8QY64** showing **15,343 reviews** on the vetting page despite:
- BSR 1,006,500
- 3 monthly sales
- $74.97 monthly revenue
- 5 in stock
- Helium 10 widget showing Current Rating: N/A

A real product with 15k reviews cannot rank ~1M and sell 3/month. The number is inconsistent with the rest of the listing's data.

## Mechanism (corrected)

My earlier "previous owner of ASIN" framing was wrong. ASINs aren't transferred between owners on Amazon. The actual mechanisms are some combination of:
- **Variation-family review aggregation** — Amazon's SERP DOM shows the parent variation's aggregate review count on each child ASIN's card (corpus confirmed: TheraICE has 4 ASINs all showing identical 43,519 reviews + BSR 645)
- **Catalog-content editing** — sellers edit the listing identity on a long-lived ASIN; reviews persist with the new content
- **Sponsored/brand-spotlight card DOM** — scraper grabs a brand-aggregate count from a nested element

The detection signal matters. The cause doesn't.

## What changed

### `src/lib/competitorDataQuality.ts` (new)

Shared `isReviewCountInflated()` helper. A competitor is "limited" when `reviews >= 1000` AND either:
- `reviewsPerDay > 100` (physically implausible — peak viral tops out around 50/day)
- OR `BSR > 500,000 AND monthlySales < 50` (listing isn't selling enough to support the displayed review count)

### Validation against production corpus

| ASIN | Reviews | BSR | Sales/mo | v1 gate (50/day) | New gate |
|---|---|---|---|---|---|
| B0GBX8QY64 (Dave's screenshot) | 15,343 | 1,006,500 | 3 | flagged | **flagged** |
| B0GQSRRRXK (2026-05-11 case) | 18,602 | 69,602 | ~6,040 est | flagged | **flagged** |
| B09DF9NWC7 (Loocio, legit viral) | 24,340 | 22 | 3,634 | flagged ❌ | clean ✓ |
| B0CBSQVMHM (TheraICE, top-seller) | 43,519 | 645 | 22,458 | flagged ❌ | clean ✓ |

The v1 gate had false positives on legitimate viral products. New gate doesn't.

### Three application points

1. **`/api/extension/enrich`** — replaces the inline PR #55 velocity check with the shared helper. Eliminates Loocio/TheraICE false positives in the BloomLens drawer.

2. **`/api/extension/analyze-market`** — **NEW** write-time guardrail. When BloomLens "Analyze Market" fires on a SERP with an inflated-review row, the saved competitor now carries `dataQuality: 'limited'`. This was the leak that produced Dave's screenshot — the enrich guardrail ran in the drawer, but `scrapedRowToCompetitor` (which builds the SAVED competitor list) did not.

3. **`ProductVettingResults`** — **NEW** read-time gate. Catches submissions saved before the write-time guardrail existed (including the student's deviled-egg market). Dashes Reviews + Review Share cells for flagged rows, excludes them from the share-% denominator (so the other rows aren't squashed by a 96.36%-of-reviews outlier), and removes them from the `computeMarketSize` totalReviews input.

## Test plan

- [ ] Open the student's submission `35d60b46-2187-414e-8d7f-7e8d87830d86` (Renmxj Deviled Egg market) on the dev preview → B0GBX8QY64's Reviews cell shows "—", Review Share shows "—", other competitors' Review Share % values now sum to roughly 100% without the 96.36% outlier
- [ ] Sanity-check a market with a legitimate top-seller (BSR < 1000, reviews 10k+) → that row is NOT dashed
- [ ] Run BloomLens "Analyze Market" on a SERP that includes a known inflated-review listing → the new submission's stored competitor for that ASIN has `dataQuality: 'limited'`
- [ ] Open BloomLens drawer on a Loocio-style legitimate viral listing → no longer flagged "limited" in the drawer (was false-positive under v1 gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)