### PR TITLE
Remove implausible-review-velocity guardrail from /enrich

### DIFF
--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -52,9 +52,6 @@ import { CURVE_VERSION } from '@/lib/extension/bsrSalesCurve';
 import {
   buildEnrichedRow,
   buildEmptyEnrichedRow,
-  km2ms,
-  nonNegOrNull,
-  KEEPA_CSV,
   type EnrichedRow,
 } from '@/lib/keepa/enrichedRow';
 
@@ -65,47 +62,6 @@ const KEEPA_DOMAIN_US = 1;
 const MAX_ASINS_PER_REQUEST = 100;
 const ASIN_REGEX = /^[A-Z0-9]{10}$/;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
-
-/**
- * Implausible-review-velocity guardrail. When stored review count divided
- * by listing age exceeds ~50/day, Keepa's review/BSR/rank history likely
- * reflects a prior product on this ASIN rather than the current PDP —
- * surfacing those numbers would mislead. Drop the history-sourced fields
- * to "limited" while keeping identity + static fields intact.
- *
- * Stays in this route (not the shared module) because it's a drawer-side
- * display safety; write paths use the unfiltered shared output so refresh
- * + recompute can recover if data becomes self-consistent again.
- */
-const REVIEWS_PER_DAY_CAP = 50;
-function applyImplausibleReviewVelocityGuardrail(product: any, row: EnrichedRow): EnrichedRow {
-  const cur: number[] = product?.stats?.current ?? [];
-  const reviews = nonNegOrNull(cur[KEEPA_CSV.REVIEW_COUNT]);
-  const listingAgeDays =
-    typeof product?.listedSince === 'number' && product.listedSince > 0
-      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
-      : null;
-  const trip =
-    reviews != null &&
-    reviews > 0 &&
-    listingAgeDays != null &&
-    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
-  if (!trip) return row;
-  return {
-    ...row,
-    bsr: null,
-    bsr30dMedian: null,
-    bsrVolatility: null,
-    bsrTrendPct: null,
-    monthlyUnits: null,
-    monthlyRevenue: null,
-    parentMonthlyUnits: null,
-    parentMonthlyRevenue: null,
-    unitsSource: null,
-    reviews: null,
-    dataQuality: 'limited',
-  };
-}
 
 export async function OPTIONS(request: NextRequest) {
   return corsPreflight(request) ?? new NextResponse(null, { status: 405 });
@@ -236,10 +192,7 @@ export async function POST(request: NextRequest) {
 
       for (const asin of toFetch) {
         const product = byAsin.get(asin);
-        const baseRow = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
-        const row = product
-          ? applyImplausibleReviewVelocityGuardrail(product, baseRow)
-          : baseRow;
+        const row = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
         enriched[asin] = row;
         upsertRows.push({
           asin,

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+drop-velocity-guardrail-2026-05-13';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**


### PR DESCRIPTION
## Summary

Drops the >50-reviews-per-day cap from the BloomLens drawer's enrich endpoint. The guardrail was added in PR #55 (pre-Keepa-everywhere sweep) to mitigate SERP-DOM-sourced inflated review counts. With the sweep now in production trusting Keepa exclusively, that defense no longer applies — and it is actively eating valid data.

## Symptom

**B0GX2PRW13** (Grow Fragrance Certified Non Toxic, Plant-Based Air Freshener Spray):
- Listing age: 29 days
- Keepa-returned reviews: **1,580** → 54.5/day, just over the 50/day cap
- Guardrail trips → reviews, BSR, BSR30dMedian, all monthly metrics, dataQuality all nulled / `'limited'`
- Keepa actually has the full picture: BSR 50,337, 23 BSR points in last 30d, rating 4.1, buybox $44.99
- H10 surfaces the same product with full data (BSR 50k, 133 ASIN sales, 1,580 reviews)
- We were the only tool dropping it

Confirmed by `scripts/probes/keepa-probe-missing-data-asins.ts` against the same H10 CSV Dave exported on 2026-05-13.

## What this changes

- Deletes ~50 lines from `src/app/api/extension/enrich/route.ts` (the guardrail function and its call site)
- Removes now-unused imports from `@/lib/keepa/enrichedRow` (`km2ms`, `nonNegOrNull`, `KEEPA_CSV`)
- Bumps `CURVE_VERSION` so existing cached `keepa_lens_metrics` rows that were stamped `limited` by the prior guardrail get refetched on next drawer load

## Out of scope (deferred)

- Relaxing the `>= 5 BSR points in last 30 days` threshold for products with stable rank (B0C1HCCK2T at BSR #1 has only 4 recent points because the rank doesn't move) — separate decision.
- Pre-sweep matrix data that was hydrated under the old SERP-DOM path is still in the DB. To recover that, click Refresh Market Data on affected markets after this lands.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Open BloomLens drawer on an Amazon search containing B0GX2PRW13 (or another fresh-but-popular listing) — confirm Reviews / Monthly Sales / Revenue all populate
- [ ] Sample 3-4 older mature ASINs (1+ year old, normal review velocity) — confirm no regression in their data

🤖 Generated with [Claude Code](https://claude.com/claude-code)