### PR TITLE
Strip data-quality band-aids + compute marketShare server-side

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -308,15 +308,34 @@ async function handleCreate(
 
   // Build the competitor list from the Keepa hydration map. None are
   // flagged __lens_new on create — they're the founding set.
-  const competitors: CanonicalCompetitor[] = requestedAsins
+  const competitorsRaw: CanonicalCompetitor[] = requestedAsins
     .map((asin) => hydrated.get(asin))
     .filter((c): c is CanonicalCompetitor => Boolean(c))
     .map((c) => ({ ...c, __lens_origin: true }));
 
-  const totalRevenue = competitors.reduce(
+  const totalRevenue = competitorsRaw.reduce(
     (sum, c) => sum + (typeof c.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
     0
   );
+  const totalReviews = competitorsRaw.reduce(
+    (sum, c) => sum + (typeof c.reviews === 'number' ? c.reviews : 0),
+    0
+  );
+
+  // Attach marketShare + reviewShare per competitor at write time so the
+  // matrix renders them immediately (without needing a refresh / removal
+  // recompute to backfill).
+  const competitors = competitorsRaw.map((c) => ({
+    ...c,
+    marketShare:
+      totalRevenue > 0 && typeof c.monthlyRevenue === 'number'
+        ? (c.monthlyRevenue / totalRevenue) * 100
+        : 0,
+    reviewShare:
+      totalReviews > 0 && typeof c.reviews === 'number'
+        ? (c.reviews / totalReviews) * 100
+        : 0,
+  }));
 
   const initialMarketScore = competitors.length > 0
     ? calculateMarketScore(competitors as any[], [])

--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -52,9 +52,6 @@ import { CURVE_VERSION } from '@/lib/extension/bsrSalesCurve';
 import {
   buildEnrichedRow,
   buildEmptyEnrichedRow,
-  km2ms,
-  nonNegOrNull,
-  KEEPA_CSV,
   type EnrichedRow,
 } from '@/lib/keepa/enrichedRow';
 
@@ -65,47 +62,6 @@ const KEEPA_DOMAIN_US = 1;
 const MAX_ASINS_PER_REQUEST = 100;
 const ASIN_REGEX = /^[A-Z0-9]{10}$/;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
-
-/**
- * Implausible-review-velocity guardrail. When stored review count divided
- * by listing age exceeds ~50/day, Keepa's review/BSR/rank history likely
- * reflects a prior product on this ASIN rather than the current PDP —
- * surfacing those numbers would mislead. Drop the history-sourced fields
- * to "limited" while keeping identity + static fields intact.
- *
- * Stays in this route (not the shared module) because it's a drawer-side
- * display safety; write paths use the unfiltered shared output so refresh
- * + recompute can recover if data becomes self-consistent again.
- */
-const REVIEWS_PER_DAY_CAP = 50;
-function applyImplausibleReviewVelocityGuardrail(product: any, row: EnrichedRow): EnrichedRow {
-  const cur: number[] = product?.stats?.current ?? [];
-  const reviews = nonNegOrNull(cur[KEEPA_CSV.REVIEW_COUNT]);
-  const listingAgeDays =
-    typeof product?.listedSince === 'number' && product.listedSince > 0
-      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
-      : null;
-  const trip =
-    reviews != null &&
-    reviews > 0 &&
-    listingAgeDays != null &&
-    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
-  if (!trip) return row;
-  return {
-    ...row,
-    bsr: null,
-    bsr30dMedian: null,
-    bsrVolatility: null,
-    bsrTrendPct: null,
-    monthlyUnits: null,
-    monthlyRevenue: null,
-    parentMonthlyUnits: null,
-    parentMonthlyRevenue: null,
-    unitsSource: null,
-    reviews: null,
-    dataQuality: 'limited',
-  };
-}
 
 export async function OPTIONS(request: NextRequest) {
   return corsPreflight(request) ?? new NextResponse(null, { status: 405 });
@@ -236,10 +192,7 @@ export async function POST(request: NextRequest) {
 
       for (const asin of toFetch) {
         const product = byAsin.get(asin);
-        const baseRow = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
-        const row = product
-          ? applyImplausibleReviewVelocityGuardrail(product, baseRow)
-          : baseRow;
+        const row = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
         enriched[asin] = row;
         upsertRows.push({
           asin,

--- a/src/app/api/submissions/[id]/refresh-market-data/route.ts
+++ b/src/app/api/submissions/[id]/refresh-market-data/route.ts
@@ -169,7 +169,7 @@ export async function POST(
     }
 
     // --- Build refreshed competitor list ---
-    const refreshedCompetitors = asins.map((asin) => {
+    const refreshedRaw = asins.map((asin) => {
       const fresh = hydrated.get(asin);
       const existing = existingByAsin.get(asin);
       const lensMeta = lensMetadataByAsin.get(asin) ?? {};
@@ -188,11 +188,30 @@ export async function POST(
       };
     });
 
-    // --- Recompute metrics ---
-    const totalRevenue = refreshedCompetitors.reduce(
+    // --- Recompute metrics + per-competitor shares ---
+    const totalRevenue = refreshedRaw.reduce(
       (sum: number, c: any) => sum + (typeof c?.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
       0,
     );
+    const totalReviews = refreshedRaw.reduce(
+      (sum: number, c: any) => sum + (typeof c?.reviews === 'number' ? c.reviews : 0),
+      0,
+    );
+
+    // Re-attach marketShare + reviewShare so the matrix renders the new
+    // values without waiting for a removal-recompute to backfill them.
+    const refreshedCompetitors = refreshedRaw.map((c: any) => ({
+      ...c,
+      marketShare:
+        totalRevenue > 0 && typeof c?.monthlyRevenue === 'number'
+          ? (c.monthlyRevenue / totalRevenue) * 100
+          : 0,
+      reviewShare:
+        totalReviews > 0 && typeof c?.reviews === 'number'
+          ? (c.reviews / totalReviews) * 100
+          : 0,
+    }));
+
     const newMetrics = {
       totalCompetitors: refreshedCompetitors.length,
       totalMarketCap: totalRevenue,

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -1037,9 +1037,33 @@ export const ProductVettingResults: React.FC<{
     return new Set(Array.from(removedCompetitors).map((asin) => normalizeAsin(asin)));
   }, [removedAsinsKey]);
 
-  // Filter out removed competitors first - this is the main competitors array to use
+  // Filter out removed competitors first - this is the main competitors array to use.
+  // Also recompute marketShare + reviewShare against the active set at render
+  // time. The server-side writers (analyze-market, refresh-market-data) attach
+  // these per-competitor, but render-time recompute keeps the displayed
+  // percentages consistent when the user removes competitors and self-heals
+  // older markets that were saved before the server-side writers existed.
   const activeCompetitors = useMemo(() => {
-    return localCompetitors.filter((competitor) => !removedSet.has(normalizeAsin(competitor.asin)));
+    const filtered = localCompetitors.filter((competitor) => !removedSet.has(normalizeAsin(competitor.asin)));
+    const totalRevenue = filtered.reduce(
+      (sum, c: any) => sum + (typeof c?.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
+      0
+    );
+    const totalReviews = filtered.reduce(
+      (sum, c: any) => sum + (typeof c?.reviews === 'number' ? c.reviews : 0),
+      0
+    );
+    return filtered.map((c: any) => ({
+      ...c,
+      marketShare:
+        totalRevenue > 0 && typeof c?.monthlyRevenue === 'number'
+          ? (c.monthlyRevenue / totalRevenue) * 100
+          : 0,
+      reviewShare:
+        totalReviews > 0 && typeof c?.reviews === 'number'
+          ? (c.reviews / totalReviews) * 100
+          : 0,
+    }));
   }, [localCompetitors, removedSet]);
 
   const variationLowerRevenueAsins = useMemo(() => {

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -290,7 +290,15 @@ export function buildEnrichedRow(
     reviews,
     imageUrl,
     brand,
-    dataQuality: bsr30dMedian != null ? 'full' : 'limited',
+    // 'limited' only when Keepa returned no usable signal at all. The prior
+    // gate (bsr30dMedian != null) was a synthetic threshold that dashed
+    // legitimate top-rank products (stable BSR = few rank-change points)
+    // and confused the matrix vs drawer parity. If Keepa gave us BSR
+    // snapshot, monthlySold, reviews, or rating, the row is 'full'.
+    dataQuality:
+      currentBsr != null || monthlySoldRaw != null || reviews != null || ratingTenths != null
+        ? 'full'
+        : 'limited',
     curveVersion: CURVE_VERSION,
   };
 }


### PR DESCRIPTION
## Summary

Two confirmed bugs from today's production CSV comparison, plus the underlying root cause for both: synthetic data-quality gates that nullify valid Keepa data, and missing server-side `marketShare` computation.

### Bug 1 — Drawer dashed rows with full Keepa data

**B0C1HCCK2T** (drift wood freshener): Keepa returned BSR=1, monthlySold=10,000, 19,542 reviews, rating 3.8. But `csv[3]` had only 4 rank-change points in the last 30 days (rank #1 is so stable Keepa rarely records updates). The `points30.length >= 5` gate stamped `dataQuality: 'limited'`. The BloomLens drawer's `LIMITED_DASH_KEYS` rendered em-dashes for every history-derived column.

**B0GX2PRW13** (Grow Fragrance variation): Keepa returned BSR=50,337, rating 4.1, 1,580 reviews. But because it's a 29-day-old child of a mature variation family, reviews/listing-age = 54.5/day tripped the implausible-review-velocity guardrail (cap 50/day). Same result — drawer em-dashes.

Both products are real, both have full Keepa data, both rendered correctly in the matrix. The drawer was the only surface dashing them — because of synthetic gates, not because the data was missing.

The variation-family review-pooling explanation makes the `reviews/listingAge` signal meaningless. Dave called this out today as the rule going forward.

### Bug 2 — Market Share was 0% on every fresh market

`/api/extension/analyze-market/route.ts` stores `competitors[]` from Keepa hydration but never computes per-row `marketShare` before insert. `/api/submissions/[id]/refresh-market-data/route.ts` re-hydrates but also never writes it. The matrix UI reads `Number(competitor.marketShare || 0)` → 0% for every row.

The computation exists in three other code paths (`applyAdjustment`, `lens-recalc`, `handleCompetitorsUpdated`), which is why removing a competitor "fixes" it. But the two entry-point write paths never had it.

## Changes

| File | What changed |
| --- | --- |
| `src/lib/keepa/enrichedRow.ts` | `dataQuality: 'limited'` only when Keepa returned no usable signal at all (no BSR snapshot AND no monthlySold AND no reviews AND no rating). The previous gate (`bsr30dMedian != null`) is dropped. |
| `src/app/api/extension/enrich/route.ts` | Removes the implausible-review-velocity guardrail (~50 lines). |
| `src/app/api/extension/analyze-market/route.ts` | Computes `marketShare` + `reviewShare` per competitor before insert. |
| `src/app/api/submissions/[id]/refresh-market-data/route.ts` | Same, after re-hydration. |
| `src/components/Results/ProductVettingResults.tsx` | Render-time recompute of `marketShare` + `reviewShare` against the active-set totals. Self-heals older markets stored before the write-path fix. |
| `src/lib/extension/bsrSalesCurve.ts` | Bumps `CURVE_VERSION` to invalidate `keepa_lens_metrics` cache rows that were stamped `limited` by the prior gates. |

## Out of scope (per your instruction)

- No BloomLens extension changes. The drawer's `LIMITED_DASH_KEYS` gate stays as-is. After this lands, the cache rows it reads will be `'full'` for products that have any Keepa data, so the drawer will display them. No Web Store zip submission.
- Variation-cap math (`min(N, 5)`), BSR-curve anchors, category multipliers — all untouched. This PR only removes synthetic gates and adds missing share computation.

## What the matrix should look like after this lands

For your 6-ASIN test market:

| ASIN | Brand | Revenue | Market Share | Strength |
|---|---|---:|---:|---|
| B0C1HCCK2T | drift | $106,319.50 | ~92% | STRONG |
| B0GX2PRW13 | Grow Fragrance | $9,762.83 | ~8% | STRONG |
| B0G38S5XZY | Generic | $0.00 | 0% | WEAK |
| B0G5HGPD53 | nopicsn | $0.00 | 0% | WEAK |
| B0G4WCVXKR | LQXNXHC | $0.00 | 0% | WEAK |
| B0G5HPFV3H | nopicsn | $0.00 | 0% | WEAK |

The 4 zero-revenue rows are Keepa returning no rank data — your "no data → 0 for revenue, N/A for rating/BSR" rule applies. They're not filtered out, just genuinely empty.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Open existing market on the preview → matrix shows real Market Share percentages (the render-time recompute backfills)
- [ ] Create a new market via Analyze Market from the extension (production extension hits production, so this is testable only after dev → main promotion)
- [ ] Click Refresh Market Data on an existing market → percentages recompute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)