### PR TITLE
Promote: category fix + strip data-quality band-aids + marketShare

### DIFF
--- a/src/app/api/extension/analyze-market/route.ts
+++ b/src/app/api/extension/analyze-market/route.ts
@@ -308,15 +308,34 @@ async function handleCreate(
 
   // Build the competitor list from the Keepa hydration map. None are
   // flagged __lens_new on create — they're the founding set.
-  const competitors: CanonicalCompetitor[] = requestedAsins
+  const competitorsRaw: CanonicalCompetitor[] = requestedAsins
     .map((asin) => hydrated.get(asin))
     .filter((c): c is CanonicalCompetitor => Boolean(c))
     .map((c) => ({ ...c, __lens_origin: true }));
 
-  const totalRevenue = competitors.reduce(
+  const totalRevenue = competitorsRaw.reduce(
     (sum, c) => sum + (typeof c.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
     0
   );
+  const totalReviews = competitorsRaw.reduce(
+    (sum, c) => sum + (typeof c.reviews === 'number' ? c.reviews : 0),
+    0
+  );
+
+  // Attach marketShare + reviewShare per competitor at write time so the
+  // matrix renders them immediately (without needing a refresh / removal
+  // recompute to backfill).
+  const competitors = competitorsRaw.map((c) => ({
+    ...c,
+    marketShare:
+      totalRevenue > 0 && typeof c.monthlyRevenue === 'number'
+        ? (c.monthlyRevenue / totalRevenue) * 100
+        : 0,
+    reviewShare:
+      totalReviews > 0 && typeof c.reviews === 'number'
+        ? (c.reviews / totalReviews) * 100
+        : 0,
+  }));
 
   const initialMarketScore = competitors.length > 0
     ? calculateMarketScore(competitors as any[], [])

--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -52,9 +52,6 @@ import { CURVE_VERSION } from '@/lib/extension/bsrSalesCurve';
 import {
   buildEnrichedRow,
   buildEmptyEnrichedRow,
-  km2ms,
-  nonNegOrNull,
-  KEEPA_CSV,
   type EnrichedRow,
 } from '@/lib/keepa/enrichedRow';
 
@@ -65,47 +62,6 @@ const KEEPA_DOMAIN_US = 1;
 const MAX_ASINS_PER_REQUEST = 100;
 const ASIN_REGEX = /^[A-Z0-9]{10}$/;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
-
-/**
- * Implausible-review-velocity guardrail. When stored review count divided
- * by listing age exceeds ~50/day, Keepa's review/BSR/rank history likely
- * reflects a prior product on this ASIN rather than the current PDP —
- * surfacing those numbers would mislead. Drop the history-sourced fields
- * to "limited" while keeping identity + static fields intact.
- *
- * Stays in this route (not the shared module) because it's a drawer-side
- * display safety; write paths use the unfiltered shared output so refresh
- * + recompute can recover if data becomes self-consistent again.
- */
-const REVIEWS_PER_DAY_CAP = 50;
-function applyImplausibleReviewVelocityGuardrail(product: any, row: EnrichedRow): EnrichedRow {
-  const cur: number[] = product?.stats?.current ?? [];
-  const reviews = nonNegOrNull(cur[KEEPA_CSV.REVIEW_COUNT]);
-  const listingAgeDays =
-    typeof product?.listedSince === 'number' && product.listedSince > 0
-      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
-      : null;
-  const trip =
-    reviews != null &&
-    reviews > 0 &&
-    listingAgeDays != null &&
-    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
-  if (!trip) return row;
-  return {
-    ...row,
-    bsr: null,
-    bsr30dMedian: null,
-    bsrVolatility: null,
-    bsrTrendPct: null,
-    monthlyUnits: null,
-    monthlyRevenue: null,
-    parentMonthlyUnits: null,
-    parentMonthlyRevenue: null,
-    unitsSource: null,
-    reviews: null,
-    dataQuality: 'limited',
-  };
-}
 
 export async function OPTIONS(request: NextRequest) {
   return corsPreflight(request) ?? new NextResponse(null, { status: 405 });
@@ -236,10 +192,7 @@ export async function POST(request: NextRequest) {
 
       for (const asin of toFetch) {
         const product = byAsin.get(asin);
-        const baseRow = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
-        const row = product
-          ? applyImplausibleReviewVelocityGuardrail(product, baseRow)
-          : baseRow;
+        const row = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
         enriched[asin] = row;
         upsertRows.push({
           asin,

--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -48,12 +48,15 @@ import {
   resolveExtensionToken,
   withCors,
 } from '@/lib/extensionAuth';
+import { CURVE_VERSION } from '@/lib/extension/bsrSalesCurve';
 import {
-  bsrToMonthlyUnits,
-  bsrToMonthlyUnitsByCategory,
-  CURVE_VERSION,
-} from '@/lib/extension/bsrSalesCurve';
-import { resolveCategoryMultiplier } from '@/lib/extension/bsrCategoryMultipliers';
+  buildEnrichedRow,
+  buildEmptyEnrichedRow,
+  km2ms,
+  nonNegOrNull,
+  KEEPA_CSV,
+  type EnrichedRow,
+} from '@/lib/keepa/enrichedRow';
 
 export const dynamic = 'force-dynamic';
 
@@ -63,61 +66,46 @@ const MAX_ASINS_PER_REQUEST = 100;
 const ASIN_REGEX = /^[A-Z0-9]{10}$/;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 
-// Keepa "minutes" since 2011-01-01.
-const KEEPA_EPOCH_MS = new Date('2011-01-01T00:00:00Z').getTime();
-const km2ms = (km: number) => KEEPA_EPOCH_MS + km * 60_000;
-
-type EnrichedRow = {
-  // Amazon root category name (e.g. "Toys & Games", "Pet Supplies"). Pulled
-  // from Keepa's categoryTree[0].name. Drawer overwrites its placeholder
-  // category with this so the user sees the real category the calibration
-  // multiplier was keyed on.
-  rootCategory: string | null;
-  // Phase 5.4-I: which category-name in the path actually matched the
-  // calibration table. Drawer can show this in a tooltip so it's visible
-  // when "Home & Kitchen" rows resolved on the deeper "Kitchen & Dining"
-  // sub-category multiplier vs. fell back to the no-op root. null means
-  // no calibrated entry matched anywhere in the path.
-  matchedCategory: string | null;
-  // Phase 5.4-I band-aware: which BSR band within `matchedCategory`
-  // resolved this product's multiplier. "default" = fell back to the
-  // category-level multiplier; "0-4000" / "4000-15000" / etc = a band
-  // override. null = no calibrated category at all.
-  matchedBand: string | null;
-  // Snapshot BSR — what Amazon shows on the PDP right now. Matches H10's
-  // BSR column. Used for display only.
-  bsr: number | null;
-  // 30-day smoothed BSR — used internally to derive parent units. Surfaced
-  // on payload so the drawer can show it in the BSR cell tooltip.
-  bsr30dMedian: number | null;
-  bsrVolatility: number | null;
-  bsrTrendPct: number | null;
-  // Per-CHILD monthly units (Phase 5.4-G):
-  //   - When Keepa exposes monthlySold for this child → use directly
-  //   - When monthlySold is null + family is multi-variation → parent / min(N, 5)
-  //   - When single-variation → BSR-derived parent units (= child units)
-  monthlyUnits: number | null;
-  /** monthlyUnits × 30d-avg child price. Cents. */
-  monthlyRevenue: number | null;
-  // Family totals — same value across every child in the family.
-  parentMonthlyUnits: number | null;
-  /** parentMonthlyUnits × 30d-avg price. Cents. */
-  parentMonthlyRevenue: number | null;
-  /** 'amazon' = monthlySold bucket; 'attributed' = derived via BSR + cap; null = no data. */
-  unitsSource: 'bsr-curve' | 'bucket-fallback' | null;
-  /** price is in cents. */
-  price: number | null;
-  weightLb: number | null;
-  dimensions: { l: number; w: number; h: number } | null;
-  listingCreatedAt: string | null;
-  variationCount: number | null;
-  rating: number | null;
-  reviews: number | null;
-  imageUrl: string | null;
-  brand: string | null;
-  dataQuality: 'full' | 'limited';
-  curveVersion: string;
-};
+/**
+ * Implausible-review-velocity guardrail. When stored review count divided
+ * by listing age exceeds ~50/day, Keepa's review/BSR/rank history likely
+ * reflects a prior product on this ASIN rather than the current PDP —
+ * surfacing those numbers would mislead. Drop the history-sourced fields
+ * to "limited" while keeping identity + static fields intact.
+ *
+ * Stays in this route (not the shared module) because it's a drawer-side
+ * display safety; write paths use the unfiltered shared output so refresh
+ * + recompute can recover if data becomes self-consistent again.
+ */
+const REVIEWS_PER_DAY_CAP = 50;
+function applyImplausibleReviewVelocityGuardrail(product: any, row: EnrichedRow): EnrichedRow {
+  const cur: number[] = product?.stats?.current ?? [];
+  const reviews = nonNegOrNull(cur[KEEPA_CSV.REVIEW_COUNT]);
+  const listingAgeDays =
+    typeof product?.listedSince === 'number' && product.listedSince > 0
+      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
+      : null;
+  const trip =
+    reviews != null &&
+    reviews > 0 &&
+    listingAgeDays != null &&
+    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
+  if (!trip) return row;
+  return {
+    ...row,
+    bsr: null,
+    bsr30dMedian: null,
+    bsrVolatility: null,
+    bsrTrendPct: null,
+    monthlyUnits: null,
+    monthlyRevenue: null,
+    parentMonthlyUnits: null,
+    parentMonthlyRevenue: null,
+    unitsSource: null,
+    reviews: null,
+    dataQuality: 'limited',
+  };
+}
 
 export async function OPTIONS(request: NextRequest) {
   return corsPreflight(request) ?? new NextResponse(null, { status: 405 });
@@ -248,7 +236,10 @@ export async function POST(request: NextRequest) {
 
       for (const asin of toFetch) {
         const product = byAsin.get(asin);
-        const row = product ? buildEnrichedRow(product) : buildEmptyRow();
+        const baseRow = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
+        const row = product
+          ? applyImplausibleReviewVelocityGuardrail(product, baseRow)
+          : baseRow;
         enriched[asin] = row;
         upsertRows.push({
           asin,
@@ -282,431 +273,4 @@ export async function POST(request: NextRequest) {
       NextResponse.json({ ok: false, error: 'Internal error' }, { status: 500 })
     );
   }
-}
-
-// -----------------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------------
-
-function buildEmptyRow(): EnrichedRow {
-  return {
-    rootCategory: null,
-    matchedCategory: null,
-    matchedBand: null,
-    bsr: null,
-    bsr30dMedian: null,
-    bsrVolatility: null,
-    bsrTrendPct: null,
-    monthlyUnits: null,
-    monthlyRevenue: null,
-    parentMonthlyUnits: null,
-    parentMonthlyRevenue: null,
-    unitsSource: null,
-    price: null,
-    weightLb: null,
-    dimensions: null,
-    listingCreatedAt: null,
-    variationCount: null,
-    rating: null,
-    reviews: null,
-    imageUrl: null,
-    brand: null,
-    dataQuality: 'limited',
-    curveVersion: CURVE_VERSION,
-  };
-}
-
-/**
- * Build the enriched row for one Keepa product. Handles both the full-history
- * happy path AND the empty-csv fallback (deactivated listings).
- */
-function buildEnrichedRow(product: any): EnrichedRow {
-  const cur: number[] = product.stats?.current ?? [];
-  const currentBsr = posOrNull(cur[3]);
-  // Price preference: Buy Box (cur[18], requires &buybox=1) → Amazon (cur[0])
-  // → New (cur[1]). Buy Box is what the customer actually pays so it's the
-  // most relevant value for the revenue calculation downstream.
-  const currentPriceCents =
-    posOrNull(cur[18]) ?? posOrNull(cur[0]) ?? posOrNull(cur[1]);
-  const reviews = nonNegOrNull(cur[17]);
-  const ratingTenths = posOrNull(cur[16]);
-
-  // BSR history (csv[3]) — alternating [keepaMinute, rank, ...]. -1 sentinel
-  // means out-of-stock or no rank; skip those points.
-  const csv3: number[] = Array.isArray(product.csv?.[3]) ? product.csv[3] : [];
-  const points: Array<{ ts: number; rank: number }> = [];
-  for (let i = 0; i + 1 < csv3.length; i += 2) {
-    const km = csv3[i];
-    const rank = csv3[i + 1];
-    if (typeof km !== 'number' || typeof rank !== 'number' || rank <= 0) continue;
-    points.push({ ts: km2ms(km), rank });
-  }
-
-  const cutoff30 = Date.now() - 30 * 86_400_000;
-  const points30 = points.filter((p) => p.ts >= cutoff30);
-
-  // Median-of-daily-medians smoothing. Group rank samples by day, take
-  // each day's median, then take the median across the 30 days.
-  let bsr30dMedian: number | null = null;
-  let bsrVolatility: number | null = null;
-  let bsrTrendPct: number | null = null;
-
-  if (points30.length >= 5) {
-    const byDay = new Map<string, number[]>();
-    for (const pt of points30) {
-      const day = new Date(pt.ts).toISOString().slice(0, 10);
-      const arr = byDay.get(day) ?? [];
-      arr.push(pt.rank);
-      byDay.set(day, arr);
-    }
-    const dailyMedians = Array.from(byDay.values()).map(median);
-    bsr30dMedian = median(dailyMedians);
-    // Volatility = coefficient of variation (stddev / mean) of daily
-    // medians. Surfaces "is this product spiky?" — high CV means the
-    // smoothed value matters more than the snapshot.
-    if (dailyMedians.length >= 2) {
-      const m = dailyMedians.reduce((a, b) => a + b, 0) / dailyMedians.length;
-      const variance =
-        dailyMedians.reduce((a, b) => a + (b - m) ** 2, 0) / dailyMedians.length;
-      bsrVolatility = m > 0 ? Math.sqrt(variance) / m : null;
-    }
-    // Trend = (current snapshot − 30d-ago median) / 30d-ago median.
-    // Find the day closest to 30 days ago in our sample.
-    if (currentBsr != null && bsr30dMedian != null) {
-      bsrTrendPct = ((currentBsr - bsr30dMedian) / bsr30dMedian) * 100;
-    }
-  }
-
-  // Family / parent units (Phase 5.4-G): the BSR-curve gives us
-  // PARENT-level units because Keepa returns parent BSR for every
-  // child of a variation family (verified by sibling probe — all 4
-  // siblings of B07F1BK675 returned BSR within 0.1% of each other).
-  // We always compute this; the per-child monthlyUnits below uses it
-  // as the basis for attribution.
-  //
-  // Phase 5.4-H: pass the category through so the curve applies a
-  // per-category multiplier (trained against the H10 corpus). Phase 5.4-I:
-  // pass the FULL category path so leaf-first resolution can find calibrated
-  // sub-categories (e.g. "Kitchen & Dining" 0.853x sitting under the no-op
-  // "Home & Kitchen" root). Phase 5.4-I band-aware: pass BSR so the lookup
-  // can pick the right BSR-band override within the matched category.
-  // Falls back to the universal curve (1.0x) when no category in the path
-  // is calibrated.
-  const rootCategoryName = pickRootCategoryName(product);
-  const categoryPath = pickCategoryPath(product);
-  const bsrForUnits = bsr30dMedian ?? currentBsr;
-  const { matched: matchedCategory, band: matchedBand } = resolveCategoryMultiplier(
-    categoryPath,
-    bsrForUnits,
-  );
-  const parentMonthlyUnits =
-    bsrForUnits != null
-      ? bsrToMonthlyUnitsByCategory(bsrForUnits, categoryPath)
-      : null;
-
-  // Variation count drives the per-child attribution math below. Some
-  // products carry a single-variation listing (variations array empty
-  // or absent) — those default to 1 so the family/child math degenerates
-  // cleanly.
-  const variationCount = Array.isArray(product.variations)
-    ? product.variations.length || 1
-    : 1;
-
-  // Per-child monthly units (Phase 5.4-H3 r3 — BSR-curve-only):
-  //   Primary: BSR-derived parent_units / min(variationCount, 5),
-  //            i.e. the calibrated curve + V3 category multipliers
-  //            attributed across the variation family. Cap of 5 matches
-  //            the typical 20–30% share observed for a family's bestseller.
-  //   Last-resort fallback: monthlySold × 1.5 ONLY when BSR is unavailable
-  //            entirely (rank-less / brand-new / out-of-stock products).
-  //
-  // Pre-r3 we used Amazon's monthlySold bucket as a "floor" lifting child
-  // values up to the published "X+ bought" number when BSR-derived was
-  // smaller. Removed in r3 — Amazon's bucket is itself rounded (100-unit
-  // chunks), so any path that displays it directly produced visibly-
-  // rounded numbers (10000, 5000, 2000, etc) which Dave called out as
-  // looking inaccurate. The competitive target is H10 X-ray's "ASIN Sales"
-  // column, which is smooth (e.g. 3944, 15295, 5848) — driven by their
-  // own BSR model, not by Amazon's bucket. Match that pattern.
-  //
-  // The bucket is still used for QA / validation against the H10 corpus
-  // (see scripts/probes/keepa-attribution-validate.ts) but never for
-  // display. See feedback_no_round_displayed_numbers.md (rule from
-  // 2026-05-05).
-  const monthlySoldRaw =
-    typeof product.monthlySold === 'number' && product.monthlySold > 0
-      ? product.monthlySold
-      : typeof cur[30] === 'number' && cur[30] > 0
-        ? cur[30]
-        : null;
-
-  let monthlyUnits: number | null = null;
-  let unitsSource: EnrichedRow['unitsSource'] = null;
-  if (parentMonthlyUnits != null) {
-    monthlyUnits =
-      variationCount <= 1
-        ? parentMonthlyUnits
-        : Math.max(0, Math.round(parentMonthlyUnits / Math.min(variationCount, 5)));
-    unitsSource = 'bsr-curve';
-  } else if (monthlySoldRaw != null) {
-    monthlyUnits = Math.round(monthlySoldRaw * 1.5);
-    unitsSource = 'bucket-fallback';
-  }
-
-  // Average price across the trailing 30 days. Falls back to current
-  // price if no history. Used for revenue so a deal-day current price
-  // doesn't distort the revenue column.
-  const csv0: number[] = Array.isArray(product.csv?.[0]) ? product.csv[0] : [];
-  const csv1: number[] = Array.isArray(product.csv?.[1]) ? product.csv[1] : [];
-  const priceHistory = csv0.length >= csv1.length ? csv0 : csv1;
-  const pricePoints30: number[] = [];
-  for (let i = 0; i + 1 < priceHistory.length; i += 2) {
-    const km = priceHistory[i];
-    const cents = priceHistory[i + 1];
-    if (typeof km !== 'number' || typeof cents !== 'number' || cents <= 0) continue;
-    if (km2ms(km) >= cutoff30) pricePoints30.push(cents);
-  }
-  const avgPriceCents =
-    pricePoints30.length > 0
-      ? pricePoints30.reduce((a, b) => a + b, 0) / pricePoints30.length
-      : currentPriceCents;
-
-  const monthlyRevenue =
-    monthlyUnits != null && avgPriceCents != null
-      ? Math.round(monthlyUnits * avgPriceCents)
-      : null;
-
-  // Parent (family-total) units invariant: parent >= child × cap, where
-  // cap = min(variationCount, 5) — the same cap used for child attribution.
-  //
-  // Phase 5.4-H3: when the bucket-floor lifts child above the BSR-derived
-  // parent (e.g. Amazon publishes "5000+ bought" for one variation but
-  // the family-level BSR curve estimate is only 3,680), the family total
-  // must be at LEAST `child × cap`. Floor parent at that. Single-variation
-  // listings (cap=1) collapse to parent === child, which is correct.
-  //
-  // Pre-H3 the rule was `parent >= child` (lift parent to child when
-  // smaller) — fine when child was authoritative per-child, but it
-  // produced parent === child for variation families whenever the
-  // bucket path fired, hiding family-total information from the user.
-  const parentCap = Math.min(Math.max(variationCount, 1), 5);
-  const minParentFromChild =
-    monthlyUnits != null ? monthlyUnits * parentCap : null;
-  let parentUnitsResolved = parentMonthlyUnits;
-  if (minParentFromChild != null) {
-    if (parentUnitsResolved == null || parentUnitsResolved < minParentFromChild) {
-      parentUnitsResolved = minParentFromChild;
-    }
-  }
-
-  // Parent revenue = parent_units × this child's avg price (rough
-  // approximation; siblings have similar prices for most variation
-  // families). When we floor parent_units at child_units, parent_revenue
-  // should track — recompute rather than fall back to the BSR-derived
-  // value (which would still be too low).
-  const parentMonthlyRevenue =
-    parentUnitsResolved != null && avgPriceCents != null
-      ? Math.round(parentUnitsResolved * avgPriceCents)
-      : null;
-
-  // Static fields. listedSince is in Keepa minutes.
-  const listingCreatedAt = keepaMinutesToIso(product.listedSince);
-
-  // Relisted-ASIN guardrail. Sellers periodically drop a brand-new
-  // product onto an ASIN that previously held a different (mature)
-  // listing. Amazon's PDP shows the new product, but Keepa retains the
-  // PREVIOUS product's review/BSR/rank history attached to the ASIN —
-  // so we'd report 18k+ reviews and a healthy BSR for a 70-day-old
-  // ping-pong table (real example: B0GQSRRRXK on 2026-05-11). When
-  // implausible review velocity tips us off, treat the entire metrics
-  // block as untrustworthy: surface a "limited" row instead of fake
-  // monthly-revenue numbers that mislead the user. 50 reviews/day is
-  // a deliberately generous cap — even viral organic launches rarely
-  // sustain that pace.
-  const REVIEWS_PER_DAY_CAP = 50;
-  const listingAgeDays =
-    typeof product.listedSince === 'number' && product.listedSince > 0
-      ? Math.max(1, Math.floor((Date.now() - km2ms(product.listedSince)) / 86_400_000))
-      : null;
-  const isLikelyRelistedAsin =
-    reviews != null &&
-    reviews > 0 &&
-    listingAgeDays != null &&
-    reviews / listingAgeDays > REVIEWS_PER_DAY_CAP;
-  const weightLb =
-    typeof product.packageWeight === 'number' && product.packageWeight > 0
-      ? round2(product.packageWeight / 453.592) // grams → pounds
-      : null;
-  const dimensions =
-    typeof product.packageLength === 'number' &&
-    typeof product.packageWidth === 'number' &&
-    typeof product.packageHeight === 'number' &&
-    product.packageLength > 0 &&
-    product.packageWidth > 0 &&
-    product.packageHeight > 0
-      ? {
-          l: product.packageLength,
-          w: product.packageWidth,
-          h: product.packageHeight,
-        }
-      : null;
-  const imageUrl = pickImageUrl(product);
-  const brand = pickBrand(product);
-
-  if (isLikelyRelistedAsin) {
-    // Keep identity + static fields (listing age, dimensions, price,
-    // category, rating, image, brand, variation count) since those are
-    // still about the CURRENT product. Drop everything sourced from
-    // accumulated history — reviews, BSR series, derived units +
-    // revenue — because those belong to the prior listing on this ASIN.
-    return {
-      rootCategory: rootCategoryName,
-      matchedCategory,
-      matchedBand,
-      bsr: null,
-      bsr30dMedian: null,
-      bsrVolatility: null,
-      bsrTrendPct: null,
-      monthlyUnits: null,
-      monthlyRevenue: null,
-      parentMonthlyUnits: null,
-      parentMonthlyRevenue: null,
-      unitsSource: null,
-      price: currentPriceCents,
-      weightLb,
-      dimensions,
-      listingCreatedAt,
-      variationCount: variationCount > 0 ? variationCount : null,
-      rating: ratingTenths != null ? ratingTenths / 10 : null,
-      reviews: null,
-      imageUrl,
-      brand,
-      dataQuality: 'limited',
-      curveVersion: CURVE_VERSION,
-    };
-  }
-
-  return {
-    rootCategory: rootCategoryName,
-    matchedCategory,
-    matchedBand,
-    bsr: currentBsr,
-    bsr30dMedian: bsr30dMedian != null ? Math.round(bsr30dMedian) : null,
-    bsrVolatility: bsrVolatility != null ? round2(bsrVolatility) : null,
-    bsrTrendPct: bsrTrendPct != null ? round2(bsrTrendPct) : null,
-    monthlyUnits,
-    monthlyRevenue,
-    parentMonthlyUnits: parentUnitsResolved,
-    parentMonthlyRevenue,
-    unitsSource,
-    price: currentPriceCents,
-    weightLb,
-    dimensions,
-    listingCreatedAt,
-    variationCount: variationCount > 0 ? variationCount : null,
-    rating: ratingTenths != null ? ratingTenths / 10 : null,
-    reviews,
-    imageUrl,
-    brand,
-    // 'limited' when we couldn't even build a smoothed BSR — the row is
-    // running on snapshot fields only.
-    dataQuality: bsr30dMedian != null ? 'full' : 'limited',
-    curveVersion: CURVE_VERSION,
-  };
-}
-
-function median(nums: number[]): number {
-  if (nums.length === 0) return 0;
-  const s = [...nums].sort((a, b) => a - b);
-  const mid = Math.floor(s.length / 2);
-  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
-}
-
-function posOrNull(v: unknown): number | null {
-  return typeof v === 'number' && v > 0 ? v : null;
-}
-
-function nonNegOrNull(v: unknown): number | null {
-  return typeof v === 'number' && v >= 0 ? v : null;
-}
-
-function round2(n: number): number {
-  return Math.round(n * 100) / 100;
-}
-
-function keepaMinutesToIso(km: any): string | null {
-  if (typeof km !== 'number' || km <= 0) return null;
-  return new Date(km2ms(km)).toISOString().slice(0, 10);
-}
-
-function pickImageUrl(product: any): string | null {
-  if (Array.isArray(product?.images) && product.images.length > 0) {
-    const first = product.images[0];
-    const filename =
-      typeof first?.m === 'string' && first.m
-        ? first.m
-        : typeof first?.l === 'string' && first.l
-          ? first.l
-          : null;
-    if (filename) return `https://m.media-amazon.com/images/I/${filename}`;
-  }
-  if (typeof product?.imagesCSV === 'string' && product.imagesCSV.length > 0) {
-    const filename = product.imagesCSV.split(',')[0]?.trim();
-    if (filename) return `https://m.media-amazon.com/images/I/${filename}`;
-  }
-  return null;
-}
-
-/**
- * Pull the Amazon root category NAME from a Keepa product response.
- * Keepa returns a few different shapes depending on the product; we
- * try the cheapest path first and fall back gracefully.
- *
- * Most Keepa /product responses include `categoryTree` (array of
- * `{catId, name}` entries from root → leaf) and `rootCategory` (the
- * numeric ID of the top-level). We want the NAME, since that's what
- * the calibration multipliers map keys on. Keepa's categoryTree[0]
- * is the root.
- *
- * Returns null when no usable category is present — the curve falls
- * back to the universal v1.1.0 multiplier (1.0).
- */
-function pickRootCategoryName(product: any): string | null {
-  const tree = product?.categoryTree;
-  if (Array.isArray(tree) && tree.length > 0) {
-    const root = tree[0];
-    if (root && typeof root.name === 'string' && root.name.trim()) {
-      return root.name.trim();
-    }
-  }
-  return null;
-}
-
-/**
- * Full Keepa categoryTree as a name array (root → leaf). Drives Phase
- * 5.4-I leaf-first multiplier resolution — feeds the path into
- * `categoryMultiplier` / `bsrToMonthlyUnitsByCategory` so the deepest
- * calibrated sub-category wins (e.g. "Kitchen & Dining" sub of the no-op
- * "Home & Kitchen" root).
- */
-function pickCategoryPath(product: any): string[] | null {
-  const tree = product?.categoryTree;
-  if (!Array.isArray(tree) || tree.length === 0) return null;
-  const names = tree
-    .map((t: any) => (typeof t?.name === 'string' ? t.name.trim() : ''))
-    .filter((n: string) => n.length > 0);
-  return names.length > 0 ? names : null;
-}
-
-function pickBrand(product: any): string | null {
-  const brand =
-    typeof product?.brand === 'string' && product.brand.trim()
-      ? product.brand.trim()
-      : null;
-  if (brand) return brand;
-  const manufacturer =
-    typeof product?.manufacturer === 'string' && product.manufacturer.trim()
-      ? product.manufacturer.trim()
-      : null;
-  return manufacturer;
 }

--- a/src/app/api/submissions/[id]/refresh-market-data/route.ts
+++ b/src/app/api/submissions/[id]/refresh-market-data/route.ts
@@ -169,7 +169,7 @@ export async function POST(
     }
 
     // --- Build refreshed competitor list ---
-    const refreshedCompetitors = asins.map((asin) => {
+    const refreshedRaw = asins.map((asin) => {
       const fresh = hydrated.get(asin);
       const existing = existingByAsin.get(asin);
       const lensMeta = lensMetadataByAsin.get(asin) ?? {};
@@ -188,11 +188,30 @@ export async function POST(
       };
     });
 
-    // --- Recompute metrics ---
-    const totalRevenue = refreshedCompetitors.reduce(
+    // --- Recompute metrics + per-competitor shares ---
+    const totalRevenue = refreshedRaw.reduce(
       (sum: number, c: any) => sum + (typeof c?.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
       0,
     );
+    const totalReviews = refreshedRaw.reduce(
+      (sum: number, c: any) => sum + (typeof c?.reviews === 'number' ? c.reviews : 0),
+      0,
+    );
+
+    // Re-attach marketShare + reviewShare so the matrix renders the new
+    // values without waiting for a removal-recompute to backfill them.
+    const refreshedCompetitors = refreshedRaw.map((c: any) => ({
+      ...c,
+      marketShare:
+        totalRevenue > 0 && typeof c?.monthlyRevenue === 'number'
+          ? (c.monthlyRevenue / totalRevenue) * 100
+          : 0,
+      reviewShare:
+        totalReviews > 0 && typeof c?.reviews === 'number'
+          ? (c.reviews / totalReviews) * 100
+          : 0,
+    }));
+
     const newMetrics = {
       totalCompetitors: refreshedCompetitors.length,
       totalMarketCap: totalRevenue,

--- a/src/components/Results/ProductVettingResults.tsx
+++ b/src/components/Results/ProductVettingResults.tsx
@@ -1037,9 +1037,33 @@ export const ProductVettingResults: React.FC<{
     return new Set(Array.from(removedCompetitors).map((asin) => normalizeAsin(asin)));
   }, [removedAsinsKey]);
 
-  // Filter out removed competitors first - this is the main competitors array to use
+  // Filter out removed competitors first - this is the main competitors array to use.
+  // Also recompute marketShare + reviewShare against the active set at render
+  // time. The server-side writers (analyze-market, refresh-market-data) attach
+  // these per-competitor, but render-time recompute keeps the displayed
+  // percentages consistent when the user removes competitors and self-heals
+  // older markets that were saved before the server-side writers existed.
   const activeCompetitors = useMemo(() => {
-    return localCompetitors.filter((competitor) => !removedSet.has(normalizeAsin(competitor.asin)));
+    const filtered = localCompetitors.filter((competitor) => !removedSet.has(normalizeAsin(competitor.asin)));
+    const totalRevenue = filtered.reduce(
+      (sum, c: any) => sum + (typeof c?.monthlyRevenue === 'number' ? c.monthlyRevenue : 0),
+      0
+    );
+    const totalReviews = filtered.reduce(
+      (sum, c: any) => sum + (typeof c?.reviews === 'number' ? c.reviews : 0),
+      0
+    );
+    return filtered.map((c: any) => ({
+      ...c,
+      marketShare:
+        totalRevenue > 0 && typeof c?.monthlyRevenue === 'number'
+          ? (c.monthlyRevenue / totalRevenue) * 100
+          : 0,
+      reviewShare:
+        totalReviews > 0 && typeof c?.reviews === 'number'
+          ? (c.reviews / totalReviews) * 100
+          : 0,
+    }));
   }, [localCompetitors, removedSet]);
 
   const variationLowerRevenueAsins = useMemo(() => {

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -105,8 +105,18 @@ export function buildEmptyEnrichedRow(): EnrichedRow {
  * Price preference order: cur[18] BUY_BOX_SHIPPING → cur[0] AMAZON →
  * cur[1] NEW. Buy box is the price the customer actually pays so it's
  * the most relevant for revenue calculation.
+ *
+ * `opts.bsrCategoryPath` — when the BSR-tracked category differs from
+ * categoryTree[0] (resolved upstream via Keepa /category), pass the
+ * resolved root → leaf path here. Drives `rootCategory`, category-curve
+ * lookup, and band-aware multiplier resolution so multi-category products
+ * (e.g. Health & Household listing with BSR tracked in Automotive) use
+ * the correct multiplier instead of categoryTree[0].
  */
-export function buildEnrichedRow(product: any): EnrichedRow {
+export function buildEnrichedRow(
+  product: any,
+  opts: { bsrCategoryPath?: string[] | null } = {},
+): EnrichedRow {
   const cur: number[] = product.stats?.current ?? [];
   const currentBsr = posOrNull(cur[KEEPA_CSV.BSR]);
   // Price: prefer Buy Box (idx 18), then Amazon (0), then New (1).
@@ -157,8 +167,19 @@ export function buildEnrichedRow(product: any): EnrichedRow {
     }
   }
 
-  const rootCategoryName = pickRootCategoryName(product);
-  const categoryPath = pickCategoryPath(product);
+  // Prefer the BSR-resolved path (set when categoryTree[0] disagrees with
+  // the category Amazon actually ranks the product in — passed in via
+  // opts.bsrCategoryPath after the caller resolves it via Keepa /category).
+  const treeRootName = pickRootCategoryName(product);
+  const treeCategoryPath = pickCategoryPath(product);
+  const rootCategoryName =
+    opts.bsrCategoryPath && opts.bsrCategoryPath.length > 0
+      ? opts.bsrCategoryPath[0]
+      : treeRootName;
+  const categoryPath =
+    opts.bsrCategoryPath && opts.bsrCategoryPath.length > 0
+      ? opts.bsrCategoryPath
+      : treeCategoryPath;
   const bsrForUnits = bsr30dMedian ?? currentBsr;
   const { matched: matchedCategory, band: matchedBand } = resolveCategoryMultiplier(
     categoryPath,

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -290,7 +290,15 @@ export function buildEnrichedRow(
     reviews,
     imageUrl,
     brand,
-    dataQuality: bsr30dMedian != null ? 'full' : 'limited',
+    // 'limited' only when Keepa returned no usable signal at all. The prior
+    // gate (bsr30dMedian != null) was a synthetic threshold that dashed
+    // legitimate top-rank products (stable BSR = few rank-change points)
+    // and confused the matrix vs drawer parity. If Keepa gave us BSR
+    // snapshot, monthlySold, reviews, or rating, the row is 'full'.
+    dataQuality:
+      currentBsr != null || monthlySoldRaw != null || reviews != null || ratingTenths != null
+        ? 'full'
+        : 'limited',
     curveVersion: CURVE_VERSION,
   };
 }

--- a/src/lib/keepa/hydrateCompetitor.ts
+++ b/src/lib/keepa/hydrateCompetitor.ts
@@ -245,9 +245,82 @@ export async function hydrateCompetitorsFromKeepa(
           if (p?.asin) byAsin.set(String(p.asin).toUpperCase(), p);
         }
 
+        // BSR-tracked-category resolution. Keepa's categoryTree[0] is
+        // sometimes the marketplace-listing category rather than the
+        // category whose BSR is actually returned (example caught
+        // 2026-05-13: B0095UVKRI lists under "Health & Household" but
+        // BSR is ranked under "Automotive"). The wrong category drives
+        // the wrong BSR-curve multiplier, which produces wrong monthly
+        // units / revenue estimates.
+        //
+        // When salesRankReference points to a catId NOT in categoryTree,
+        // resolve the correct path via a single Keepa /category call (cheap
+        // — one token regardless of how many catIds we batch).
+        const catIdsToResolve = new Set<number>();
+        const productBsrCatId = new Map<string, number>();
+        for (const [asin, product] of byAsin) {
+          const treeCatIds: number[] = (Array.isArray(product?.categoryTree) ? product.categoryTree : [])
+            .map((c: any) => c?.catId)
+            .filter((id: any) => typeof id === 'number');
+          const bsrCatId =
+            typeof product?.salesRankReference === 'number' && product.salesRankReference > 0
+              ? product.salesRankReference
+              : null;
+          if (bsrCatId != null && !treeCatIds.includes(bsrCatId)) {
+            catIdsToResolve.add(bsrCatId);
+            productBsrCatId.set(asin, bsrCatId);
+          }
+        }
+
+        const catPathByCatId = new Map<number, string[]>();
+        if (catIdsToResolve.size > 0) {
+          try {
+            const catUrl =
+              `${KEEPA_BASE_URL}/category` +
+              `?key=${apiKey}` +
+              `&domain=${KEEPA_DOMAIN_US}` +
+              `&category=${Array.from(catIdsToResolve).join(',')}` +
+              `&parents=1`;
+            const catRes = await fetch(catUrl);
+            if (catRes.ok) {
+              const catData: any = await catRes.json();
+              const cats = catData?.categories || {};
+              for (const startId of catIdsToResolve) {
+                const path: string[] = [];
+                const visited = new Set<number>();
+                let currentId: number | null = startId;
+                while (currentId != null && !visited.has(currentId)) {
+                  visited.add(currentId);
+                  const node: any = cats[String(currentId)];
+                  if (!node) break;
+                  if (typeof node.name === 'string' && node.name) {
+                    path.unshift(node.name);
+                  }
+                  currentId =
+                    typeof node.parent === 'number' && node.parent !== 0
+                      ? node.parent
+                      : null;
+                }
+                if (path.length > 0) catPathByCatId.set(startId, path);
+              }
+            } else {
+              console.warn(
+                `Keepa /category returned ${catRes.status}; falling back to categoryTree paths`,
+              );
+            }
+          } catch (err) {
+            console.warn('Keepa /category resolution failed; falling back to categoryTree', err);
+          }
+        }
+
         for (const asin of chunk) {
           const product = byAsin.get(asin);
-          const enriched = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
+          const bsrCatId = productBsrCatId.get(asin);
+          const bsrCategoryPath =
+            bsrCatId != null ? (catPathByCatId.get(bsrCatId) ?? null) : null;
+          const enriched = product
+            ? buildEnrichedRow(product, { bsrCategoryPath })
+            : buildEmptyEnrichedRow();
           const sponsored = sponsoredLookup(asin);
           result.set(asin, mapKeepaProductToCompetitor(asin, product, enriched, { sponsored }));
         }


### PR DESCRIPTION
## Summary

Promotes three dev commits to main:

- **PR #72** — Batch-path category resolution (fixes Refresh Market Data on multi-category products like B0095UVKRI) + dedup `buildEnrichedRow` math
- **PR #74** — Strips synthetic data-quality gates (`bsr30dMedian >= 5 points`, implausible-review-velocity) so legitimate top-rank and variation-family products no longer show em-dashes; computes `marketShare` + `reviewShare` server-side at write time and as render-time backfill

## What changes for production users

- BloomLens drawer rows that were showing em-dashes for products like B0C1HCCK2T (drift, BSR #1) and B0GX2PRW13 (Grow Fragrance variation) will now display real numbers after their cache rows refetch on next drawer load (CURVE_VERSION bump triggers refetch).
- Competitor matrix Market Share column will show real percentages on every market, including markets created with Analyze Market from the extension, without needing a removal-click to backfill.
- Multi-category products in Refresh Market Data + analyze-market + save-funnel now resolve their BSR-tracked category via Keepa `/category`, fixing the wrong-multiplier issue (e.g. Health & Household listing with Automotive BSR).

## Diff scope

7 files. ~150 insertions / ~492 deletions (most deletions are dead-code removed during the enrich-route dedup in PR #72).

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Open an existing market on production after merge → matrix shows real Market Share (no longer 0.00%)
- [ ] Click Refresh Market Data → no errors, percentages stay correct
- [ ] In the BloomLens drawer, run Analyze Market on a search that includes a strong-BSR product (drift, etc.) → row shows real BSR / Monthly Revenue / Strength (no em-dashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)