### PR TITLE
Promote: r9 Big Five calibration recal

### DIFF
--- a/scripts/probes/h10-band-aware-probe.ts
+++ b/scripts/probes/h10-band-aware-probe.ts
@@ -1,0 +1,134 @@
+/**
+ * Band-aware calibration probe.
+ * For each priority category, computes the observed median ratio (predicted/actual)
+ * per BSR band, and prints the suggested band multiplier adjustment.
+ *
+ * Run: npx tsx scripts/probes/h10-band-aware-probe.ts <h10.csv>
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { bsrToMonthlyUnitsByCategory } from '../../src/lib/extension/bsrSalesCurve';
+import { CATEGORY_MULTIPLIERS } from '../../src/lib/extension/bsrCategoryMultipliers';
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = []; let cur = ''; let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuote) {
+      if (c === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (c === '"') inQuote = false;
+      else cur += c;
+    } else {
+      if (c === '"') inQuote = true;
+      else if (c === ',') { out.push(cur); cur = ''; }
+      else cur += c;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function num(s: any): number | null {
+  if (s == null) return null;
+  const cleaned = String(s).replace(/[",]/g, '').trim();
+  if (!cleaned || cleaned === 'N/A') return null;
+  const v = Number(cleaned);
+  return Number.isFinite(v) ? v : null;
+}
+
+const BANDS = [
+  { label: '0-4k', min: 0, max: 4_000 },
+  { label: '4k-15k', min: 4_000, max: 15_000 },
+  { label: '15k-60k', min: 15_000, max: 60_000 },
+  { label: '60k-200k', min: 60_000, max: 200_000 },
+  { label: '200k+', min: 200_000, max: Infinity },
+];
+
+function bandLabelFor(bsr: number): string {
+  for (const b of BANDS) if (bsr >= b.min && bsr < b.max) return b.label;
+  return '?';
+}
+
+function median(xs: number[]): number {
+  if (!xs.length) return NaN;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+const PRIORITY_CATS = [
+  'Patio, Lawn & Garden',
+  'Pet Supplies',
+  'Industrial & Scientific',
+  'Kitchen & Dining',
+  'Arts, Crafts & Sewing',
+  'Office Products',
+  'Sports & Outdoors',
+  'Tools & Home Improvement',
+  'Toys & Games',
+  'Musical Instruments',
+  'Automotive',
+  'Baby',
+  'Electronics',
+  'Home & Kitchen',
+  'Health & Household',
+];
+
+function main() {
+  const csvPath = path.resolve(process.argv[2] ?? '/tmp/combined-h10-full.csv');
+  const text = fs.readFileSync(csvPath, 'utf8');
+  const lines = text.split('\n').filter(Boolean);
+  const header = parseCsvLine(lines[0].replace(/^﻿/, ''));
+  const iAsin = header.indexOf('ASIN');
+  const iCat = header.indexOf('Category');
+  const iBsr = header.indexOf('BSR');
+  const iSales = header.indexOf('Parent Level Sales');
+
+  // (category, band) -> ratios[]
+  const byCatBand = new Map<string, Map<string, number[]>>();
+  let total = 0;
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvLine(lines[i]);
+    const cat = cols[iCat]?.trim();
+    const bsr = num(cols[iBsr]);
+    const sales = num(cols[iSales]);
+    if (!cat || bsr == null || sales == null || sales <= 0 || !PRIORITY_CATS.includes(cat)) continue;
+    const pred = bsrToMonthlyUnitsByCategory(bsr, [cat]);
+    if (pred == null || pred <= 0) continue;
+    const band = bandLabelFor(bsr);
+    if (!byCatBand.has(cat)) byCatBand.set(cat, new Map());
+    const bandMap = byCatBand.get(cat)!;
+    if (!bandMap.has(band)) bandMap.set(band, []);
+    bandMap.get(band)!.push(pred / sales);
+    total++;
+  }
+  console.log(`Loaded ${total} priority-category rows from ${csvPath}\n`);
+
+  // Print per-category band table
+  for (const cat of PRIORITY_CATS) {
+    const bandMap = byCatBand.get(cat);
+    if (!bandMap) continue;
+    const cal = (CATEGORY_MULTIPLIERS as any)[cat];
+    const currentBands: any[] = cal?.bands ?? [];
+    const currentDefault = cal?.default;
+    console.log(`\n=== ${cat} (current default mult: ${currentDefault?.toFixed(3) ?? '—'}, total fit n: ${cal?.n ?? '—'}) ===`);
+    console.log('BAND       | corpus n | obs median | current mult | suggested new mult | change');
+    console.log('-'.repeat(95));
+    for (const b of BANDS) {
+      const ratios = bandMap.get(b.label) ?? [];
+      if (ratios.length === 0) continue;
+      const med = median(ratios);
+      const currentBand = currentBands.find((cb) => cb.bsrMin === b.min && cb.bsrMax === b.max);
+      const currentMult = currentBand?.mult ?? currentDefault;
+      const suggested = currentMult / med;
+      const change = suggested / currentMult;
+      const changeStr = change >= 1 ? `× ${change.toFixed(2)}` : `÷ ${(1 / change).toFixed(2)}`;
+      const nStr = currentBand ? `${ratios.length} (fit n=${currentBand.n})` : `${ratios.length} (fit n=default)`;
+      console.log(
+        `${b.label.padEnd(10)} | ${nStr.padEnd(15)} | ${med.toFixed(2).padStart(10)} | ${currentMult?.toFixed(3).padStart(12) ?? '—'.padStart(12)} | ${suggested.toFixed(3).padStart(18)} | ${changeStr.padStart(6)}`,
+      );
+    }
+  }
+}
+
+main();

--- a/scripts/probes/median-vs-sum-test.ts
+++ b/scripts/probes/median-vs-sum-test.ts
@@ -1,0 +1,188 @@
+/**
+ * Test: does sum-of-daily-sales-rates predict H10's reading better than median-BSR?
+ *
+ * For each ASIN that has BOTH a Keepa BSR history in Supabase AND an H10 reading
+ * in the CSV corpus:
+ *   - Method A (current): median of 30-day BSR -> curve -> predicted monthly units
+ *   - Method B (proposed): for each BSR(t) point, daily_rate = curve / 30; sum
+ *                          daily_rate × (hours_in_span / 24) over the 30 days
+ *   - Compare both to H10's Parent Level Sales
+ *
+ * Reports per-category which method is closer.
+ */
+import * as fs from 'fs';
+import { bsrToMonthlyUnitsByCategory } from '../../src/lib/extension/bsrSalesCurve';
+
+type BsrPoint = { value: number; timestamp: number };
+type History = { created_at: string; bsr: BsrPoint[] };
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = []; let cur = ''; let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuote) {
+      if (c === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (c === '"') inQuote = false;
+      else cur += c;
+    } else {
+      if (c === '"') inQuote = true;
+      else if (c === ',') { out.push(cur); cur = ''; }
+      else cur += c;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function num(s: any): number | null {
+  if (s == null) return null;
+  const cleaned = String(s).replace(/[",]/g, '').trim();
+  if (!cleaned || cleaned === 'N/A') return null;
+  const v = Number(cleaned);
+  return Number.isFinite(v) ? v : null;
+}
+
+// Load H10 readings keyed by asin (keep most recent reading per ASIN by file mtime is hard;
+// just keep the LAST one we see — usually fine for relative comparison).
+function loadH10(): Map<string, { cat: string; sales: number; bsr: number }> {
+  const files = fs.readFileSync('/tmp/h10-csv-list.txt', 'utf8').split('\n').filter(Boolean);
+  const map = new Map<string, { cat: string; sales: number; bsr: number }>();
+  for (const f of files) {
+    let text: string;
+    try { text = fs.readFileSync(f, 'utf8'); } catch { continue; }
+    const lines = text.split('\n').filter(Boolean);
+    const header = parseCsvLine(lines[0].replace(/^﻿/, ''));
+    const iAsin = header.indexOf('ASIN');
+    const iCat = header.indexOf('Category');
+    const iBsr = header.indexOf('BSR');
+    const iSales = header.indexOf('Parent Level Sales');
+    if (iAsin < 0 || iCat < 0 || iSales < 0) continue;
+    for (let i = 1; i < lines.length; i++) {
+      const cols = parseCsvLine(lines[i]);
+      const asin = cols[iAsin]?.trim();
+      const cat = cols[iCat]?.trim();
+      const bsr = num(cols[iBsr]);
+      const sales = num(cols[iSales]);
+      if (!asin || !cat || sales == null || sales <= 0 || bsr == null) continue;
+      map.set(asin, { cat, sales, bsr });
+    }
+  }
+  return map;
+}
+
+function median(xs: number[]): number {
+  if (!xs.length) return NaN;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function predictMedian(bsr30d: BsrPoint[], cat: string): number | null {
+  if (!bsr30d.length) return null;
+  const med = median(bsr30d.map((p) => p.value));
+  return bsrToMonthlyUnitsByCategory(med, [cat]);
+}
+
+function predictDailyRateSum(bsr30d: BsrPoint[], cat: string): number | null {
+  if (bsr30d.length < 2) return null;
+  // Sort by timestamp ascending
+  const pts = [...bsr30d].sort((a, b) => a.timestamp - b.timestamp);
+  let total = 0;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const dtMs = pts[i + 1].timestamp - pts[i].timestamp;
+    if (dtMs <= 0) continue;
+    const monthlyAtBsr = bsrToMonthlyUnitsByCategory(pts[i].value, [cat]);
+    if (monthlyAtBsr == null) continue;
+    const dailyRate = monthlyAtBsr / 30; // units/day at this BSR
+    const days = dtMs / 86400000;
+    total += dailyRate * days;
+  }
+  return total;
+}
+
+function main() {
+  const h10 = loadH10();
+  console.log(`H10 readings loaded: ${h10.size} unique ASINs\n`);
+
+  // Glob the bsr-histories-*.json files
+  const fs_ = require('fs') as typeof fs;
+  const histFiles = fs_.readdirSync('/tmp').filter((f: string) => f.startsWith('bsr-histories-') && f.endsWith('.json'));
+  const histories: Record<string, History> = {};
+  for (const f of histFiles) {
+    const data = JSON.parse(fs_.readFileSync('/tmp/' + f, 'utf8'));
+    Object.assign(histories, data);
+  }
+  console.log(`Keepa histories loaded: ${Object.keys(histories).length} ASINs from ${histFiles.length} batch files\n`);
+
+  type Result = {
+    asin: string;
+    cat: string;
+    h10Sales: number;
+    h10Bsr: number;
+    nPoints30d: number;
+    medianBsr: number;
+    medianPred: number;
+    sumPred: number;
+    medianRatio: number;
+    sumRatio: number;
+  };
+  const results: Result[] = [];
+
+  for (const [asin, hist] of Object.entries(histories)) {
+    const h = h10.get(asin);
+    if (!h) continue;
+    const cutoff = new Date(hist.created_at).getTime() - 30 * 86400000;
+    const bsr30d = hist.bsr.filter((p) => p.timestamp >= cutoff && p.value > 0);
+    if (bsr30d.length < 10) continue;
+    const medPred = predictMedian(bsr30d, h.cat);
+    const sumPred = predictDailyRateSum(bsr30d, h.cat);
+    if (medPred == null || sumPred == null || medPred <= 0 || sumPred <= 0) continue;
+    const medBsr = median(bsr30d.map((p) => p.value));
+    results.push({
+      asin, cat: h.cat, h10Sales: h.sales, h10Bsr: h.bsr,
+      nPoints30d: bsr30d.length, medianBsr: medBsr,
+      medianPred: medPred, sumPred, medianRatio: medPred / h.sales, sumRatio: sumPred / h.sales,
+    });
+  }
+
+  console.log(`Paired ASINs evaluated: ${results.length}\n`);
+
+  // Per-category summary
+  const byCat = new Map<string, Result[]>();
+  for (const r of results) {
+    const arr = byCat.get(r.cat) ?? [];
+    arr.push(r); byCat.set(r.cat, arr);
+  }
+  console.log('Per-category: Method A (median-BSR) vs Method B (daily-rate-sum) — closer to 1.0 = better\n');
+  console.log('CATEGORY                       | n  | A med ratio | B med ratio | A better? | B better?');
+  console.log('-'.repeat(100));
+  const cats = [...byCat.entries()].sort((a, b) => b[1].length - a[1].length);
+  for (const [cat, arr] of cats) {
+    if (arr.length < 2) continue;
+    const aMed = median(arr.map((r) => r.medianRatio));
+    const bMed = median(arr.map((r) => r.sumRatio));
+    const aBetter = arr.filter((r) => Math.abs(Math.log(r.medianRatio)) < Math.abs(Math.log(r.sumRatio))).length;
+    const bBetter = arr.length - aBetter;
+    console.log(
+      `${cat.padEnd(30)} | ${String(arr.length).padStart(2)} | ${aMed.toFixed(2).padStart(11)} | ${bMed.toFixed(2).padStart(11)} | ${String(aBetter).padStart(9)} | ${String(bBetter).padStart(9)}`,
+    );
+  }
+
+  // Overall
+  const allA = median(results.map((r) => r.medianRatio));
+  const allB = median(results.map((r) => r.sumRatio));
+  console.log('-'.repeat(100));
+  console.log(`OVERALL (n=${results.length})${' '.repeat(30 - String(results.length).length - 14)} | ${allA.toFixed(2).padStart(11)} | ${allB.toFixed(2).padStart(11)}`);
+
+  // Top examples where B differs most from A
+  console.log('\nTop 10 ASINs where Method B (sum) differs MOST from Method A (median):');
+  console.log('ASIN        | cat              | H10 sales | A pred  | B pred  | A ratio | B ratio');
+  const byDiff = [...results].sort((a, b) => Math.abs(b.sumPred - b.medianPred) - Math.abs(a.sumPred - a.medianPred));
+  for (const r of byDiff.slice(0, 10)) {
+    console.log(
+      `${r.asin} | ${r.cat.padEnd(16)} | ${String(r.h10Sales).padStart(9)} | ${String(Math.round(r.medianPred)).padStart(7)} | ${String(Math.round(r.sumPred)).padStart(7)} | ${r.medianRatio.toFixed(2).padStart(7)} | ${r.sumRatio.toFixed(2).padStart(7)}`,
+    );
+  }
+}
+
+main();

--- a/scripts/probes/plg-split-analysis.ts
+++ b/scripts/probes/plg-split-analysis.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+import { bsrToMonthlyUnitsByCategory } from '../../src/lib/extension/bsrSalesCurve';
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = []; let cur = ''; let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuote) {
+      if (c === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (c === '"') inQuote = false;
+      else cur += c;
+    } else {
+      if (c === '"') inQuote = true;
+      else if (c === ',') { out.push(cur); cur = ''; }
+      else cur += c;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function num(s: any): number | null {
+  if (s == null) return null;
+  const cleaned = String(s).replace(/[",]/g, '').trim();
+  if (!cleaned || cleaned === 'N/A') return null;
+  const v = Number(cleaned);
+  return Number.isFinite(v) ? v : null;
+}
+
+type Row = { asin: string; cat: string; bsr: number; sales: number; src: string };
+
+function loadRows(file: string): Row[] {
+  let text: string;
+  try { text = fs.readFileSync(file, 'utf8'); } catch { return []; }
+  const lines = text.split('\n').filter(Boolean);
+  const header = parseCsvLine(lines[0].replace(/^﻿/, ''));
+  const iAsin = header.indexOf('ASIN');
+  const iCat = header.indexOf('Category');
+  const iBsr = header.indexOf('BSR');
+  const iSales = header.indexOf('Parent Level Sales');
+  if (iAsin < 0 || iCat < 0 || iBsr < 0 || iSales < 0) return [];
+  const rows: Row[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvLine(lines[i]);
+    const asin = cols[iAsin]?.trim();
+    const cat = cols[iCat]?.trim();
+    const bsr = num(cols[iBsr]);
+    const sales = num(cols[iSales]);
+    if (!asin || !cat || bsr == null || sales == null || sales <= 0) continue;
+    if (cat !== 'Patio, Lawn & Garden') continue;
+    rows.push({ asin, cat, bsr, sales, src: file });
+  }
+  return rows;
+}
+
+const oldFiles = fs.readFileSync('/tmp/old-plg.txt', 'utf8').split('\n').filter(Boolean);
+const newFiles = fs.readFileSync('/tmp/new-plg.txt', 'utf8').split('\n').filter(Boolean);
+
+const oldRows = oldFiles.flatMap(loadRows);
+const newRows = newFiles.flatMap(loadRows);
+
+console.log(`OLD P/L/G rows: ${oldRows.length}`);
+console.log(`NEW P/L/G rows: ${newRows.length}\n`);
+
+function bandOf(bsr: number): string {
+  if (bsr < 1000) return '0-1k';
+  if (bsr < 4000) return '1k-4k';
+  if (bsr < 15000) return '4k-15k';
+  if (bsr < 60000) return '15k-60k';
+  if (bsr < 200000) return '60k-200k';
+  return '200k+';
+}
+
+const bands = ['0-1k', '1k-4k', '4k-15k', '15k-60k', '60k-200k', '200k+'];
+
+function tally(rows: Row[]) {
+  const c: Record<string, number> = {}; for (const b of bands) c[b] = 0;
+  for (const r of rows) c[bandOf(r.bsr)]++;
+  return c;
+}
+
+function median(xs: number[]): number {
+  if (!xs.length) return NaN;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function ratiosByBand(rows: Row[]) {
+  const r: Record<string, number[]> = {}; for (const b of bands) r[b] = [];
+  for (const x of rows) {
+    const pred = bsrToMonthlyUnitsByCategory(x.bsr, [x.cat]);
+    if (pred == null || pred <= 0) continue;
+    r[bandOf(x.bsr)].push(pred / x.sales);
+  }
+  return r;
+}
+
+console.log('BSR-band distribution');
+console.log('BAND       | OLD | NEW');
+const oldCounts = tally(oldRows);
+const newCounts = tally(newRows);
+for (const b of bands) console.log(`${b.padEnd(10)} | ${String(oldCounts[b]).padStart(3)} | ${String(newCounts[b]).padStart(3)}`);
+
+console.log('\nMedian ratio per band (predicted ÷ H10 actual)');
+console.log('BAND       | OLD med (n)       | NEW med (n)');
+const oldR = ratiosByBand(oldRows);
+const newR = ratiosByBand(newRows);
+for (const b of bands) {
+  const om = median(oldR[b]); const nm = median(newR[b]);
+  console.log(`${b.padEnd(10)} | ${(isNaN(om) ? '-' : om.toFixed(2)).padStart(7)} (${String(oldR[b].length).padStart(3)})  |  ${(isNaN(nm) ? '-' : nm.toFixed(2)).padStart(7)} (${String(newR[b].length).padStart(3)})`);
+}
+
+// Sample examples
+function sample(rows: Row[]) {
+  const s = [...rows].sort((a, b) => a.bsr - b.bsr);
+  return [
+    s[Math.floor(s.length * 0.1)],
+    s[Math.floor(s.length * 0.5)],
+    s[Math.floor(s.length * 0.9)],
+  ];
+}
+console.log('\n--- 3 OLD P/L/G ASINs (low / mid / high BSR) ---');
+for (const r of sample(oldRows)) {
+  if (!r) continue;
+  const p = bsrToMonthlyUnitsByCategory(r.bsr, [r.cat]);
+  console.log(`  ${r.asin}  BSR ${String(r.bsr).padStart(7)}  band ${bandOf(r.bsr).padEnd(8)}  H10 sales ${String(r.sales).padStart(6)}  predicted ${String(p).padStart(6)}  ratio ${p != null ? (p / r.sales).toFixed(2) + 'x' : '-'}`);
+}
+console.log('\n--- 3 NEW P/L/G ASINs (low / mid / high BSR) ---');
+for (const r of sample(newRows)) {
+  if (!r) continue;
+  const p = bsrToMonthlyUnitsByCategory(r.bsr, [r.cat]);
+  console.log(`  ${r.asin}  BSR ${String(r.bsr).padStart(7)}  band ${bandOf(r.bsr).padEnd(8)}  H10 sales ${String(r.sales).padStart(6)}  predicted ${String(p).padStart(6)}  ratio ${p != null ? (p / r.sales).toFixed(2) + 'x' : '-'}`);
+}

--- a/src/lib/extension/bsrCategoryMultipliers.ts
+++ b/src/lib/extension/bsrCategoryMultipliers.ts
@@ -41,7 +41,7 @@
 // Categories not in this table fall back to 1.0x (the universal curve).
 // That's safer than guessing.
 
-export const CATEGORY_CALIBRATION_VERSION = 'v7-2026-05-08-band-aware-r8';
+export const CATEGORY_CALIBRATION_VERSION = 'v8-2026-05-13-big-five-r9';
 
 export type CategoryBand = {
   /** Inclusive lower bound. */
@@ -71,19 +71,23 @@ export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
   // multiplier "v3" block. Same merged corpus as v6 (Supabase + JSONL),
   // refit against the v1.2.0 base curve. Defaults within ±13% of v6.
 
-  // Kitchen & Dining — n=480. All 5 bands fit. Top movers (1.14x) and
-  // hunt-low (1.39x) higher than default; long tail (0.41x) much lower.
-  // The single 0.853x default was splitting a 3.4x range across bands.
+  // Kitchen & Dining — r9 refit 2026-05-13 against 765-CSV combined H10
+  // corpus (n=1,242 K&D rows, all 5 bands fit at n>=60). r8 was wrong-
+  // shaped: under-predicted in 15k-60k and 60k-200k (the hunt-mid/tail
+  // bands students actually research) while over-predicting in 4k-15k.
+  // Net effect for typical hunt-zone vetting: predictions roughly double
+  // their accuracy at 15k+ BSR. 200k+ tail still under-predicts (0.69x
+  // ratio); a × 1.44 mult bump corrects it.
   "Kitchen & Dining": {
-    default: 0.935,
-    n: 480,
-    fitDate: "2026-05-08",
+    default: 1.225,
+    n: 1242,
+    fitDate: "2026-05-13",
     bands: [
-      { bsrMin: 0,        bsrMax: 4_000,    mult: 1.141, n: 103 },
-      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 1.393, n: 63 },
-      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 0.836, n: 125 },
-      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 0.731, n: 129 },
-      { bsrMin: 200_000,  bsrMax: Infinity, mult: 0.406, n: 60 },
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 1.225, n: 184 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 1.013, n: 164 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 1.796, n: 383 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 1.240, n: 384 },
+      { bsrMin: 200_000,  bsrMax: Infinity, mult: 0.586, n: 127 },
     ],
   },
 
@@ -107,14 +111,24 @@ export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
 
   // Pet Supplies — n=231. 3 hunt-zone bands (4k-200k). Top + deep-tail
   // bands have <30 samples, fall back to default 0.59x.
+  // Pet Supplies — r9 refit 2026-05-13 against 765-CSV combined H10
+  // corpus (n=1,779 Pet Supplies rows). Massive coverage improvement
+  // over r8's n=231. All 5 bands now have n>=30. Strong band structure:
+  // top movers + hunt zones under-predicted heavily (suggested × 1.7-3.4),
+  // 60k-200k tail is approximately calibrated, and the 200k+ tail OVER-
+  // predicts by 3× — Pet Supplies behaves opposite at the tail vs every
+  // other under-calibrated category. Each band is independently fit;
+  // do not apply a global multiplier.
   "Pet Supplies": {
-    default: 0.592,
-    n: 231,
-    fitDate: "2026-05-08",
+    default: 1.107,
+    n: 1779,
+    fitDate: "2026-05-13",
     bands: [
-      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 0.743, n: 47 },
-      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.651, n: 104 },
-      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.450, n: 62 },
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 2.000, n: 263 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 1.627, n: 524 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 1.107, n: 730 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 0.505, n: 230 },
+      { bsrMin: 200_000,  bsrMax: Infinity, mult: 0.197, n: 32 },
     ],
   },
 
@@ -148,17 +162,22 @@ export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
     ],
   },
 
-  // Patio, Lawn & Garden — n=208. 3 bands fit (4k-200k). Hunt-low band
-  // (4k-15k) is dramatically lower than mid (0.32x vs 0.74x) — likely
-  // seasonal/niche-product noise. IQR for that band is wide.
+  // Patio, Lawn & Garden — r9 refit 2026-05-13 against 765-CSV combined
+  // H10 corpus (n=1,491 P/L/G rows; was n=208 in r8). Every band needed a
+  // significant bump. The 4k-15k band moves from 0.317 → 1.587 (× 5.01);
+  // r8's 0.317 was the lowest multiplier in the entire file and an
+  // obvious fitting artifact from a 30-row sample. All bands now have
+  // n>=89, sample sizes 5-15x larger than r8.
   "Patio, Lawn & Garden": {
-    default: 0.676,
-    n: 208,
-    fitDate: "2026-05-08",
+    default: 1.185,
+    n: 1491,
+    fitDate: "2026-05-13",
     bands: [
-      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 0.317, n: 30 },
-      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.738, n: 93 },
-      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.683, n: 48 },
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 1.174, n: 265 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 1.587, n: 463 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 1.454, n: 393 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 1.185, n: 281 },
+      { bsrMin: 200_000,  bsrMax: Infinity, mult: 1.062, n: 89 },
     ],
   },
 
@@ -197,16 +216,20 @@ export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
     ],
   },
 
-  // Arts, Crafts & Sewing — n=126. 2 bands fit (15k-200k). Hunt-mid at
-  // 0.74x, long-tail collapses to 0.35x — typical pattern for craft
-  // products where deep-tail BSRs have very low velocity.
+  // Arts, Crafts & Sewing — r9 refit 2026-05-13 against 765-CSV combined
+  // H10 corpus (n=931 A/C/S rows; was 126 in r8). New 4k-15k band added
+  // (n=106). 60k-200k band doubled to 0.690 from r8's 0.345; r8 was
+  // over-fit to a thin 30-row sample. 200k+ comes in at 1.00x — already
+  // calibrated, no band needed (default catches it). 0-4k still thin
+  // (n=15) — falls back to default.
   "Arts, Crafts & Sewing": {
-    default: 0.582,
-    n: 126,
-    fitDate: "2026-05-08",
+    default: 0.841,
+    n: 931,
+    fitDate: "2026-05-13",
     bands: [
-      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.742, n: 56 },
-      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.345, n: 30 },
+      { bsrMin: 4_000,   bsrMax: 15_000,  mult: 0.841, n: 106 },
+      { bsrMin: 15_000,  bsrMax: 60_000,  mult: 0.904, n: 323 },
+      { bsrMin: 60_000,  bsrMax: 200_000, mult: 0.690, n: 365 },
     ],
   },
 
@@ -221,13 +244,22 @@ export const CATEGORY_MULTIPLIERS: Record<string, CategoryCalibration> = {
     ],
   },
 
-  // Industrial & Scientific — n=85. No bands meet the n>=30 threshold;
-  // default-only fit. Niche category — would need fresh per-category
-  // batches to band-fit cleanly.
+  // Industrial & Scientific — r9 refit 2026-05-13 against 765-CSV combined
+  // H10 corpus (n=776 I&S rows; was 85 default-only in r8). Four bands
+  // now fit at n>=76. 200k+ tail still thin (n=24) — falls back to
+  // default. Top + tail bands close to old default (0.59 → 0.61, 0.62)
+  // but hunt zones (4k-15k, 15k-60k) want significantly higher multipliers
+  // (0.88, 0.97).
   "Industrial & Scientific": {
-    default: 0.590,
-    n: 85,
-    fitDate: "2026-05-08",
+    default: 0.751,
+    n: 776,
+    fitDate: "2026-05-13",
+    bands: [
+      { bsrMin: 0,        bsrMax: 4_000,    mult: 0.612, n: 116 },
+      { bsrMin: 4_000,    bsrMax: 15_000,   mult: 0.880, n: 275 },
+      { bsrMin: 15_000,   bsrMax: 60_000,   mult: 0.972, n: 285 },
+      { bsrMin: 60_000,   bsrMax: 200_000,  mult: 0.622, n: 76 },
+    ],
   },
 
   // Phase 5.4-I r7 (2026-05-06) — band-aware fits from fresh per-category

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**


### PR DESCRIPTION
## Summary

Promotes PR #76 from dev → main. Refits Pet Supplies, Patio/Lawn/Garden, Kitchen & Dining, Industrial & Scientific, and Arts/Crafts/Sewing against a 16k-row H10 corpus. All five categories now sit at observed median ratio 1.00× (was 0.43-0.70× before).

See #76 for the full calibration rationale, sample sizes, band-by-band changes, and probe scripts.

## Production impact

This shifts live BloomLens output for the five recalibrated categories. Students who have spreadsheets with previously-vetted Pet Supplies / P/L/G / K&D / I&S / A/C/S numbers will see different numbers going forward. New numbers are calibrated to match Helium 10's algorithm; old numbers were systematically low.

`CURVE_VERSION` is bumped so `keepa_lens_metrics` cached predictions auto-invalidate.

## Test plan

- [x] Calibration probe verified — all 5 Big Five categories land at observed median 1.00× on the 16k-row corpus
- [x] `npx tsc --noEmit` clean
- [x] Vercel saasogv6 deployment passed on the dev preview
- [ ] Spot-check a Pet Supplies or P/L/G market via the BloomEngine app after main promotion — confirm revenue numbers look reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)