### PR TITLE
Fix Sourcing referral fee: handle undefined hub.referralFeePct

### DIFF
--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -571,9 +571,7 @@ export function PlaceOrderTab({
     const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
     const originalCategory = productData?.category || '';
     const category = hub.categoryOverride || originalCategory || '';
-    const referralFeePct = hub.referralFeePct !== null 
-      ? hub.referralFeePct 
-      : getReferralFeePct(category);
+    const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
 
     // Build checklist items for PDF from schema
     const valueContext: ValueMapperContext = {

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -634,7 +634,7 @@ export function ProfitCalculatorTab({
   const getReferralFeePercentage = (): number => {
     const hub = hubData || { referralFeePct: null };
     const category = getCategory();
-    return hub.referralFeePct !== null ? hub.referralFeePct : getReferralFeePct(category);
+    return hub.referralFeePct ?? getReferralFeePct(category);
   };
 
   // Extract lead time days from string

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -230,9 +230,7 @@ export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: Sourcin
   // Get category for referral fee calculation
   const originalCategory = productData?.category || '';
   const category = hub.categoryOverride || originalCategory || '';
-  const referralFeePct = hub.referralFeePct !== null 
-    ? hub.referralFeePct 
-    : getReferralFeePct(category);
+  const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
   const referralFee = targetSalesPrice > 0 && referralFeePct ? targetSalesPrice * referralFeePct : 0;
   const fbaFeePerUnit = quote.fbaFeePerUnit || 0;
   
@@ -1314,10 +1312,8 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
     const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice;
     const category = hub.categoryOverride || originalCategory || '';
     
-    const referralFeePct = hub.referralFeePct !== null 
-      ? hub.referralFeePct 
-      : getReferralFeePct(category);
-    
+    const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
+
     if (!targetSalesPrice || !referralFeePct) return { amount: null, pct: null, category: category || null };
     
     return {


### PR DESCRIPTION
## Summary
- Sourcing pages were showing the Referral Fee cell as a dash AND silently zeroing the fee inside profit math, inflating Profit/Unit, ROI, and Margin everywhere downstream.
- Root cause: saved `sourcing_hub` JSON for many records is `{}`, leaving `hub.referralFeePct` as `undefined` rather than `null`. The existing strict-null check (`hub.referralFeePct !== null ? ... : getReferralFeePct(category)`) treated `undefined` as a real override and never reached the category fallback.
- Fix: switch to `??` so both `null` and `undefined` fall through to the category lookup. Applied in `calculateQuoteMetrics`, `getReferralFeeForQuote`, `ProfitCalculatorTab.getReferralFeePercentage`, and `PlaceOrderTab.handleDownloadPDF` — every consumer of `hub.referralFeePct`.

## Test plan
- [ ] On `/sourcing/<asin>` for the Pottery Bats product (B0FFDM7RJK, category Arts/Crafts/Sewing): the Referral Fee field on the Supplier Quotes tab now shows a dollar amount (~$4.49 for $29.95 × 15% default) instead of a dash.
- [ ] Profit/Unit on the same supplier drops correspondingly (~$8.46 instead of $12.95).
- [ ] Same supplier on the Profit Matrix tab and Place Order tab show the same updated profit/ROI/margin.
- [ ] Spot-check a category that uses a non-default rate (e.g., Patio/Lawn/Garden = 8%) — fee renders correctly there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)