### PR TITLE
Ship Sourcing referral fee fix to production

### DIFF
--- a/src/components/Sourcing/tabs/PlaceOrderTab.tsx
+++ b/src/components/Sourcing/tabs/PlaceOrderTab.tsx
@@ -571,9 +571,7 @@ export function PlaceOrderTab({
     const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? selectedSupplier.salesPrice ?? null;
     const originalCategory = productData?.category || '';
     const category = hub.categoryOverride || originalCategory || '';
-    const referralFeePct = hub.referralFeePct !== null 
-      ? hub.referralFeePct 
-      : getReferralFeePct(category);
+    const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
 
     // Build checklist items for PDF from schema
     const valueContext: ValueMapperContext = {

--- a/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
+++ b/src/components/Sourcing/tabs/ProfitCalculatorTab.tsx
@@ -634,7 +634,7 @@ export function ProfitCalculatorTab({
   const getReferralFeePercentage = (): number => {
     const hub = hubData || { referralFeePct: null };
     const category = getCategory();
-    return hub.referralFeePct !== null ? hub.referralFeePct : getReferralFeePct(category);
+    return hub.referralFeePct ?? getReferralFeePct(category);
   };
 
   // Extract lead time days from string

--- a/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
+++ b/src/components/Sourcing/tabs/SupplierQuotesTab.tsx
@@ -230,9 +230,7 @@ export const calculateQuoteMetrics = (quote: SupplierQuoteRow, hubData?: Sourcin
   // Get category for referral fee calculation
   const originalCategory = productData?.category || '';
   const category = hub.categoryOverride || originalCategory || '';
-  const referralFeePct = hub.referralFeePct !== null 
-    ? hub.referralFeePct 
-    : getReferralFeePct(category);
+  const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
   const referralFee = targetSalesPrice > 0 && referralFeePct ? targetSalesPrice * referralFeePct : 0;
   const fbaFeePerUnit = quote.fbaFeePerUnit || 0;
   
@@ -1314,10 +1312,8 @@ export function SupplierQuotesTab({ productId, data, onChange, productData, hubD
     const targetSalesPrice = hub.targetSalesPrice ?? hub.offerTargetSalesPrice ?? originalPrice ?? quote.salesPrice;
     const category = hub.categoryOverride || originalCategory || '';
     
-    const referralFeePct = hub.referralFeePct !== null 
-      ? hub.referralFeePct 
-      : getReferralFeePct(category);
-    
+    const referralFeePct = hub.referralFeePct ?? getReferralFeePct(category);
+
     if (!targetSalesPrice || !referralFeePct) return { amount: null, pct: null, category: category || null };
     
     return {


### PR DESCRIPTION
## Summary
- Ships PR #78 (Sourcing referral fee: fall through on undefined `hub.referralFeePct`) to production.
- Verified working on the preview deploy: Pottery Bats product (Arts/Crafts/Sewing) now renders Referral Fee = \$4.49 (15%) instead of a dash, and Profit/Unit / ROI / Margin update correctly across Hub, Supplier Quotes, Profit Matrix, and Place Order surfaces.
- Diff is the same 3-file +5/-11 change already merged to dev.

## Test plan
- [ ] After deploy, re-vet the same Pottery Bats supplier on bloomengine.ai — Referral Fee field shows \$4.49, Profit/Unit shows \$8.46, ROI 70.5%, Margin 28.2%.
- [ ] Spot-check one other affected product to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)