### PR TITLE
Ship Amazon-bucket attribution fix to production

### DIFF
--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13+amazon-bucket-attribution-2026-05-14';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -49,7 +49,7 @@ export type EnrichedRow = {
   monthlyRevenue: number | null;
   parentMonthlyUnits: number | null;
   parentMonthlyRevenue: number | null;
-  unitsSource: 'bsr-curve' | 'bucket-fallback' | null;
+  unitsSource: 'amazon-bucket' | 'bsr-curve' | 'bucket-fallback' | null;
   /** price is in cents. */
   price: number | null;
   weightLb: number | null;
@@ -96,11 +96,11 @@ export function buildEmptyEnrichedRow(): EnrichedRow {
  * Build the enriched row for one Keepa product. Pure function over the
  * product blob — call site is responsible for fetching from Keepa.
  *
- * Math unchanged from prior in-route implementation. Source of monthly
- * units is the BSR-curve (parent-level), attributed across the variation
- * family with a cap of min(N, 5). Single-variation listings collapse to
- * parent === child. Amazon's monthlySold "X+ bought" bucket is used only
- * as a last-resort fallback when BSR is unavailable.
+ * Source of child-level monthly units is Amazon's "X+ bought in past month"
+ * badge (delivered via Keepa's monthlySold field), translated to bucket
+ * midpoint. Falls back to BSR-curve / variation-cap split when the badge
+ * is absent (low-volume or new listings). Parent-level units always use
+ * the BSR-curve × category multiplier.
  *
  * Price preference order: cur[18] BUY_BOX_SHIPPING → cur[0] AMAZON →
  * cur[1] NEW. Buy box is the price the customer actually pays so it's
@@ -201,17 +201,23 @@ export function buildEnrichedRow(
         ? cur[30]
         : null;
 
+  // Prefer Amazon's "X+ bought in past month" badge (via Keepa monthlySold)
+  // over BSR-derived attribution. The badge is source-of-truth — Amazon's
+  // own published number, not an estimate. Validated against 149 child
+  // variations: bucket-midpoint cuts residual error 4.5× vs the prior
+  // parent/N equal-split. Falls back to BSR curve when Amazon doesn't
+  // display the badge (low-volume or new listings).
   let monthlyUnits: number | null = null;
   let unitsSource: EnrichedRow['unitsSource'] = null;
-  if (parentMonthlyUnits != null) {
+  if (monthlySoldRaw != null && monthlySoldRaw > 0) {
+    monthlyUnits = bucketMidpoint(monthlySoldRaw);
+    unitsSource = 'amazon-bucket';
+  } else if (parentMonthlyUnits != null) {
     monthlyUnits =
       variationCount <= 1
         ? parentMonthlyUnits
         : Math.max(0, Math.round(parentMonthlyUnits / Math.min(variationCount, 5)));
     unitsSource = 'bsr-curve';
-  } else if (monthlySoldRaw != null) {
-    monthlyUnits = Math.round(monthlySoldRaw * 1.5);
-    unitsSource = 'bucket-fallback';
   }
 
   // 30-day avg price for revenue (so a deal-day spike doesn't skew).
@@ -320,6 +326,24 @@ export function posOrNull(v: unknown): number | null {
 
 export function nonNegOrNull(v: unknown): number | null {
   return typeof v === 'number' && v >= 0 ? v : null;
+}
+
+/**
+ * Translate Amazon's "X+ bought in past month" bucket into a point estimate.
+ * Buckets are right-open intervals: 100+ means [100, 200), 1000+ means [1000, 2000).
+ * Midpoint of the interval is the best single-value estimator and is what
+ * H10's X-Ray ASIN Sales column lands at empirically (validated 2026-05-14
+ * against 149 child variations, median residual 0.31 vs 1.38 for equal-split).
+ */
+export function bucketMidpoint(bucket: number): number {
+  if (!Number.isFinite(bucket) || bucket <= 0) return 0;
+  let next: number;
+  if (bucket < 100) next = 100;            // 50 → 100, midpoint 75
+  else if (bucket < 1000) next = bucket + 100;  // 100→200, …, 900→1000
+  else if (bucket < 10_000) next = bucket + 1000; // 1k→2k, …, 9k→10k
+  else if (bucket < 100_000) next = bucket + 10_000;
+  else next = bucket + 100_000;
+  return Math.round((bucket + next) / 2);
 }
 
 export function round2(n: number): number {


### PR DESCRIPTION
## Summary
- Ships PR #80 to production: replaces the equal-split (parent ÷ N) attribution with Amazon's "X+ bought in past month" badge via Keepa's monthlySold field.
- Bucket midpoint cuts child-level estimation error 4.5× (validated against 149 child variations from a 45-parent PLG corpus).
- Parent-level units unchanged; only child attribution changes.
- Required to ship straight to main because BloomLens extension is hardcoded to bloomengine.ai and can't be tested via preview.

## Test plan
- [ ] After deploy, open BloomLens drawer on any Amazon search page — Monthly Sales values should align with the "X+ bought in past month" badge on each Amazon product detail page
- [ ] Fresh /vetting/<asin> markets show child Monthly Sales much closer to Helium 10 X-Ray's ASIN Sales column
- [ ] No null/NaN regressions on products without the Amazon badge (graceful fallback to BSR-curve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)