### PR TITLE
Weighted-sibling child attribution (badge as weight, not value)

### DIFF
--- a/src/app/api/extension/enrich/route.ts
+++ b/src/app/api/extension/enrich/route.ts
@@ -53,7 +53,9 @@ import {
   buildEnrichedRow,
   buildEmptyEnrichedRow,
   type EnrichedRow,
+  type SiblingStat,
 } from '@/lib/keepa/enrichedRow';
+import { fetchSiblingStats } from '@/lib/keepa/hydrateCompetitor';
 
 export const dynamic = 'force-dynamic';
 
@@ -179,6 +181,43 @@ export async function POST(request: NextRequest) {
           `(processing=${data.processingTimeInMs}ms, tokensConsumed=${data.tokensConsumed}, tokensLeft=${data.tokensLeft})`
       );
 
+      // Sibling collection — gather variation ASINs from each freshly-
+      // fetched product so we can batch-fetch their stats for weighted
+      // child attribution. Skips siblings already in the primary fetch.
+      const siblingsByParent = new Map<string, string[]>();
+      const newSiblingAsins = new Set<string>();
+      for (const [primaryAsin, product] of byAsin) {
+        if (!Array.isArray(product?.variations)) continue;
+        const sibAsins: string[] = [];
+        for (const v of product.variations) {
+          const sibAsin = String(typeof v === 'string' ? v : v?.asin ?? '')
+            .toUpperCase()
+            .trim();
+          if (!sibAsin || !ASIN_REGEX.test(sibAsin)) continue;
+          if (sibAsin === primaryAsin) continue;
+          sibAsins.push(sibAsin);
+          if (!byAsin.has(sibAsin)) newSiblingAsins.add(sibAsin);
+        }
+        if (sibAsins.length > 0) siblingsByParent.set(primaryAsin, sibAsins);
+      }
+
+      const siblingStatsByAsin = await fetchSiblingStats(
+        Array.from(newSiblingAsins),
+        apiKey,
+        { userId: resolved.userId ?? null },
+      );
+      // Augment with siblings already in the primary batch (free).
+      for (const [asin, product] of byAsin) {
+        if (siblingStatsByAsin.has(asin)) continue;
+        const cur: number[] = product?.stats?.current ?? [];
+        const bsr = typeof cur[3] === 'number' && cur[3] > 0 ? cur[3] : null;
+        const monthlySold =
+          typeof product?.monthlySold === 'number' && product.monthlySold > 0
+            ? product.monthlySold
+            : null;
+        siblingStatsByAsin.set(asin, { asin, monthlySold, bsr });
+      }
+
       // Build payloads + upsert into cache.
       const upsertRows: Array<{
         asin: string;
@@ -192,7 +231,13 @@ export async function POST(request: NextRequest) {
 
       for (const asin of toFetch) {
         const product = byAsin.get(asin);
-        const row = product ? buildEnrichedRow(product) : buildEmptyEnrichedRow();
+        const sibAsins = siblingsByParent.get(asin) ?? [];
+        const siblings: SiblingStat[] = sibAsins
+          .map((a) => siblingStatsByAsin.get(a))
+          .filter((s): s is SiblingStat => s != null);
+        const row = product
+          ? buildEnrichedRow(product, { siblings })
+          : buildEmptyEnrichedRow();
         enriched[asin] = row;
         upsertRows.push({
           asin,

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13+weighted-sibling-attribution-2026-05-14';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**

--- a/src/lib/extension/bsrSalesCurve.ts
+++ b/src/lib/extension/bsrSalesCurve.ts
@@ -24,7 +24,7 @@
 // rows populated before `&rating=1&buybox=1` were added to the Keepa
 // fetch URL. Those rows had reviews/rating null because Keepa returns
 // -1 for cur[16]/cur[17] without rating=1; refetching gives real values.
-export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13+amazon-bucket-attribution-2026-05-14';
+export const CURVE_VERSION = 'v1.2.0-h10-corpus-recal-2026-05-04+h3-r7-cat-v6-band-aware+keepa-everywhere-2026-05-13+strip-quality-gates-2026-05-13+big-five-recal-2026-05-13';
 export const CURVE_CALIBRATED_AT = '2026-05-04';
 
 /**

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -37,6 +37,46 @@ export const KEEPA_CSV = {
 /** Query params for the canonical Keepa /product fetch. Use everywhere. */
 export const KEEPA_FETCH_PARAMS = 'stats=180&history=1&rating=1&buybox=1&offers=20&aplus=1';
 
+/**
+ * Sibling variation stats used for weighted child attribution.
+ * `monthlySold` is Amazon's "X+ bought in past month" bucket via Keepa.
+ * `bsr` is the variation's individual rank (used as fallback weight signal
+ * when no badge is present).
+ */
+export type SiblingStat = {
+  asin: string;
+  monthlySold: number | null;
+  bsr: number | null;
+};
+
+/**
+ * Empirically-derived scale factor for converting per-child BSR-curve
+ * estimates into "implied bucket" weights comparable to actual Amazon
+ * monthlySold buckets. Sibling variations share parent ranking momentum,
+ * so applying the universal curve to a child's individual BSR
+ * over-predicts by ~17×. The 0.06 factor (= 1/17) puts the BSR-derived
+ * weight on the same scale as the Amazon bucket — used ONLY for
+ * relative weighting, never displayed.
+ *
+ * Validated 2026-05-14 across 244 child variations from PLG corpus
+ * (median H10/curve_at_child_BSR = 0.06).
+ */
+const SIBLING_BSR_SCALE = 0.06;
+
+/**
+ * Compute a sibling's relative weight for child-share attribution.
+ * Primary signal: Keepa monthlySold (the bucket value Amazon displays).
+ * Fallback: BSR-curve estimate scaled by SIBLING_BSR_SCALE.
+ */
+function getSiblingWeight(s: SiblingStat): number {
+  if (s.monthlySold && s.monthlySold > 0) return s.monthlySold;
+  if (s.bsr && s.bsr > 0) {
+    const curve = bsrToMonthlyUnitsByCategory(s.bsr, null);
+    return curve != null ? curve * SIBLING_BSR_SCALE : 0;
+  }
+  return 0;
+}
+
 export type EnrichedRow = {
   rootCategory: string | null;
   matchedCategory: string | null;
@@ -49,7 +89,7 @@ export type EnrichedRow = {
   monthlyRevenue: number | null;
   parentMonthlyUnits: number | null;
   parentMonthlyRevenue: number | null;
-  unitsSource: 'bsr-curve' | 'bucket-fallback' | null;
+  unitsSource: 'weighted-sibling' | 'bsr-curve' | 'bucket-fallback' | null;
   /** price is in cents. */
   price: number | null;
   weightLb: number | null;
@@ -96,11 +136,15 @@ export function buildEmptyEnrichedRow(): EnrichedRow {
  * Build the enriched row for one Keepa product. Pure function over the
  * product blob — call site is responsible for fetching from Keepa.
  *
- * Math unchanged from prior in-route implementation. Source of monthly
- * units is the BSR-curve (parent-level), attributed across the variation
- * family with a cap of min(N, 5). Single-variation listings collapse to
- * parent === child. Amazon's monthlySold "X+ bought" bucket is used only
- * as a last-resort fallback when BSR is unavailable.
+ * Parent-level units come from `bsrToMonthlyUnitsByCategory(parentBSR, category)`
+ * — the corpus-calibrated BSR curve × per-category band multiplier.
+ *
+ * Child-level attribution: when `opts.siblings` is provided, distributes
+ * `parentMonthlyUnits` proportional to each sibling's weight. Weight is
+ * derived from Amazon's "X+ bought in past month" bucket (Keepa monthlySold)
+ * with a BSR-implied fallback for unbadged children. The output is smooth
+ * (parent_total × fraction), never bucket-aligned. Falls back to parent ÷
+ * min(variationCount, 5) equal-split when siblings aren't supplied.
  *
  * Price preference order: cur[18] BUY_BOX_SHIPPING → cur[0] AMAZON →
  * cur[1] NEW. Buy box is the price the customer actually pays so it's
@@ -115,7 +159,7 @@ export function buildEmptyEnrichedRow(): EnrichedRow {
  */
 export function buildEnrichedRow(
   product: any,
-  opts: { bsrCategoryPath?: string[] | null } = {},
+  opts: { bsrCategoryPath?: string[] | null; siblings?: SiblingStat[] } = {},
 ): EnrichedRow {
   const cur: number[] = product.stats?.current ?? [];
   const currentBsr = posOrNull(cur[KEEPA_CSV.BSR]);
@@ -203,15 +247,54 @@ export function buildEnrichedRow(
 
   let monthlyUnits: number | null = null;
   let unitsSource: EnrichedRow['unitsSource'] = null;
-  if (parentMonthlyUnits != null) {
-    monthlyUnits =
-      variationCount <= 1
-        ? parentMonthlyUnits
-        : Math.max(0, Math.round(parentMonthlyUnits / Math.min(variationCount, 5)));
-    unitsSource = 'bsr-curve';
-  } else if (monthlySoldRaw != null) {
-    monthlyUnits = Math.round(monthlySoldRaw * 1.5);
-    unitsSource = 'bucket-fallback';
+
+  // Weighted-sibling attribution when caller supplied sibling stats.
+  // Distributes parent_total proportional to each variation's
+  // Amazon-bucket-or-BSR-implied weight, so smooth parent numbers stay
+  // smooth at the child level (never round bucket multiples).
+  if (parentMonthlyUnits != null && opts.siblings && opts.siblings.length > 0) {
+    const selfAsin = String(product?.asin ?? '').toUpperCase();
+    const selfStat: SiblingStat = {
+      asin: selfAsin,
+      monthlySold: monthlySoldRaw,
+      bsr: bsrForUnits,
+    };
+    // Combine self + siblings, deduping on ASIN. Weights computed
+    // identically across the family so the math sums to parent_total.
+    const allMembers = new Map<string, SiblingStat>();
+    allMembers.set(selfAsin, selfStat);
+    for (const s of opts.siblings) {
+      const k = s.asin.toUpperCase();
+      if (k !== selfAsin) allMembers.set(k, s);
+    }
+    let totalWeight = 0;
+    let selfWeight = 0;
+    for (const [asin, stat] of allMembers) {
+      const w = getSiblingWeight(stat);
+      totalWeight += w;
+      if (asin === selfAsin) selfWeight = w;
+    }
+    if (totalWeight > 0 && selfWeight > 0) {
+      monthlyUnits = Math.max(0, Math.round(parentMonthlyUnits * (selfWeight / totalWeight)));
+      unitsSource = 'weighted-sibling';
+    }
+  }
+
+  // Fallback path when no siblings provided OR weighting yielded nothing
+  // (e.g. zero total weight across all members). Preserves current
+  // production behavior so callers that don't yet supply siblings still
+  // get smooth parent/N estimates.
+  if (monthlyUnits == null) {
+    if (parentMonthlyUnits != null) {
+      monthlyUnits =
+        variationCount <= 1
+          ? parentMonthlyUnits
+          : Math.max(0, Math.round(parentMonthlyUnits / Math.min(variationCount, 5)));
+      unitsSource = 'bsr-curve';
+    } else if (monthlySoldRaw != null) {
+      monthlyUnits = Math.round(monthlySoldRaw * 1.5);
+      unitsSource = 'bucket-fallback';
+    }
   }
 
   // 30-day avg price for revenue (so a deal-day spike doesn't skew).

--- a/src/lib/keepa/enrichedRow.ts
+++ b/src/lib/keepa/enrichedRow.ts
@@ -49,7 +49,7 @@ export type EnrichedRow = {
   monthlyRevenue: number | null;
   parentMonthlyUnits: number | null;
   parentMonthlyRevenue: number | null;
-  unitsSource: 'amazon-bucket' | 'bsr-curve' | 'bucket-fallback' | null;
+  unitsSource: 'bsr-curve' | 'bucket-fallback' | null;
   /** price is in cents. */
   price: number | null;
   weightLb: number | null;
@@ -96,11 +96,11 @@ export function buildEmptyEnrichedRow(): EnrichedRow {
  * Build the enriched row for one Keepa product. Pure function over the
  * product blob — call site is responsible for fetching from Keepa.
  *
- * Source of child-level monthly units is Amazon's "X+ bought in past month"
- * badge (delivered via Keepa's monthlySold field), translated to bucket
- * midpoint. Falls back to BSR-curve / variation-cap split when the badge
- * is absent (low-volume or new listings). Parent-level units always use
- * the BSR-curve × category multiplier.
+ * Math unchanged from prior in-route implementation. Source of monthly
+ * units is the BSR-curve (parent-level), attributed across the variation
+ * family with a cap of min(N, 5). Single-variation listings collapse to
+ * parent === child. Amazon's monthlySold "X+ bought" bucket is used only
+ * as a last-resort fallback when BSR is unavailable.
  *
  * Price preference order: cur[18] BUY_BOX_SHIPPING → cur[0] AMAZON →
  * cur[1] NEW. Buy box is the price the customer actually pays so it's
@@ -201,23 +201,17 @@ export function buildEnrichedRow(
         ? cur[30]
         : null;
 
-  // Prefer Amazon's "X+ bought in past month" badge (via Keepa monthlySold)
-  // over BSR-derived attribution. The badge is source-of-truth — Amazon's
-  // own published number, not an estimate. Validated against 149 child
-  // variations: bucket-midpoint cuts residual error 4.5× vs the prior
-  // parent/N equal-split. Falls back to BSR curve when Amazon doesn't
-  // display the badge (low-volume or new listings).
   let monthlyUnits: number | null = null;
   let unitsSource: EnrichedRow['unitsSource'] = null;
-  if (monthlySoldRaw != null && monthlySoldRaw > 0) {
-    monthlyUnits = bucketMidpoint(monthlySoldRaw);
-    unitsSource = 'amazon-bucket';
-  } else if (parentMonthlyUnits != null) {
+  if (parentMonthlyUnits != null) {
     monthlyUnits =
       variationCount <= 1
         ? parentMonthlyUnits
         : Math.max(0, Math.round(parentMonthlyUnits / Math.min(variationCount, 5)));
     unitsSource = 'bsr-curve';
+  } else if (monthlySoldRaw != null) {
+    monthlyUnits = Math.round(monthlySoldRaw * 1.5);
+    unitsSource = 'bucket-fallback';
   }
 
   // 30-day avg price for revenue (so a deal-day spike doesn't skew).
@@ -326,24 +320,6 @@ export function posOrNull(v: unknown): number | null {
 
 export function nonNegOrNull(v: unknown): number | null {
   return typeof v === 'number' && v >= 0 ? v : null;
-}
-
-/**
- * Translate Amazon's "X+ bought in past month" bucket into a point estimate.
- * Buckets are right-open intervals: 100+ means [100, 200), 1000+ means [1000, 2000).
- * Midpoint of the interval is the best single-value estimator and is what
- * H10's X-Ray ASIN Sales column lands at empirically (validated 2026-05-14
- * against 149 child variations, median residual 0.31 vs 1.38 for equal-split).
- */
-export function bucketMidpoint(bucket: number): number {
-  if (!Number.isFinite(bucket) || bucket <= 0) return 0;
-  let next: number;
-  if (bucket < 100) next = 100;            // 50 → 100, midpoint 75
-  else if (bucket < 1000) next = bucket + 100;  // 100→200, …, 900→1000
-  else if (bucket < 10_000) next = bucket + 1000; // 1k→2k, …, 9k→10k
-  else if (bucket < 100_000) next = bucket + 10_000;
-  else next = bucket + 100_000;
-  return Math.round((bucket + next) / 2);
 }
 
 export function round2(n: number): number {

--- a/src/lib/keepa/hydrateCompetitor.ts
+++ b/src/lib/keepa/hydrateCompetitor.ts
@@ -24,6 +24,7 @@ import {
   formatDimensions,
   KEEPA_FETCH_PARAMS,
   type EnrichedRow,
+  type SiblingStat,
 } from './enrichedRow';
 import { computeLqsFromKeepaProduct, type LqsResult } from './listingQualityScore';
 
@@ -313,13 +314,60 @@ export async function hydrateCompetitorsFromKeepa(
           }
         }
 
+        // Sibling collection — gather every variation ASIN referenced by
+        // primary products so we can batch-fetch their stats for weighted
+        // child attribution. Skips siblings already in the primary batch
+        // (we'll reuse their data) and ones already enriched in `result`
+        // from a prior chunk in this same call.
+        const siblingsByParent = new Map<string, string[]>();
+        const newSiblingAsins = new Set<string>();
+        for (const [primaryAsin, product] of byAsin) {
+          if (!Array.isArray(product?.variations)) continue;
+          const sibAsins: string[] = [];
+          for (const v of product.variations) {
+            // Keepa variations entries can be either { asin, attributes } objects
+            // or bare ASIN strings depending on API version — handle both.
+            const sibAsin = String(typeof v === 'string' ? v : v?.asin ?? '')
+              .toUpperCase()
+              .trim();
+            if (!sibAsin || !/^[A-Z0-9]{10}$/.test(sibAsin)) continue;
+            if (sibAsin === primaryAsin) continue;
+            sibAsins.push(sibAsin);
+            if (!byAsin.has(sibAsin)) newSiblingAsins.add(sibAsin);
+          }
+          if (sibAsins.length > 0) siblingsByParent.set(primaryAsin, sibAsins);
+        }
+
+        const siblingStatsByAsin = await fetchSiblingStats(
+          Array.from(newSiblingAsins),
+          apiKey,
+          { userId: opts.userId ?? null },
+        );
+
+        // Augment with siblings that happen to be in the same primary batch
+        // (free — we already have their stats from the primary fetch).
+        for (const [asin, product] of byAsin) {
+          if (siblingStatsByAsin.has(asin)) continue;
+          const cur: number[] = product?.stats?.current ?? [];
+          const bsr = typeof cur[3] === 'number' && cur[3] > 0 ? cur[3] : null;
+          const monthlySold =
+            typeof product?.monthlySold === 'number' && product.monthlySold > 0
+              ? product.monthlySold
+              : null;
+          siblingStatsByAsin.set(asin, { asin, monthlySold, bsr });
+        }
+
         for (const asin of chunk) {
           const product = byAsin.get(asin);
           const bsrCatId = productBsrCatId.get(asin);
           const bsrCategoryPath =
             bsrCatId != null ? (catPathByCatId.get(bsrCatId) ?? null) : null;
+          const sibAsins = siblingsByParent.get(asin) ?? [];
+          const siblings: SiblingStat[] = sibAsins
+            .map((a) => siblingStatsByAsin.get(a))
+            .filter((s): s is SiblingStat => s != null);
           const enriched = product
-            ? buildEnrichedRow(product, { bsrCategoryPath })
+            ? buildEnrichedRow(product, { bsrCategoryPath, siblings })
             : buildEmptyEnrichedRow();
           const sponsored = sponsoredLookup(asin);
           result.set(asin, mapKeepaProductToCompetitor(asin, product, enriched, { sponsored }));
@@ -328,6 +376,72 @@ export async function hydrateCompetitorsFromKeepa(
     );
   }
 
+  return result;
+}
+
+/**
+ * Lightweight batch fetch for sibling variation stats — only need
+ * monthlySold (Amazon's "X+ bought" bucket via Keepa) and current BSR
+ * for relative attribution weighting. Uses `stats=180` only, skipping
+ * history / offers / aplus to minimize Keepa token cost (~1 token per
+ * ASIN vs ~5-7 for a full fetch).
+ */
+export async function fetchSiblingStats(
+  asins: string[],
+  apiKey: string,
+  opts: { userId: string | null },
+): Promise<Map<string, SiblingStat>> {
+  const result = new Map<string, SiblingStat>();
+  if (asins.length === 0) return result;
+
+  const cleaned = Array.from(new Set(asins.map((a) => a.toUpperCase()))).filter((a) =>
+    /^[A-Z0-9]{10}$/.test(a),
+  );
+  if (cleaned.length === 0) return result;
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < cleaned.length; i += MAX_ASINS_PER_REQUEST) {
+    chunks.push(cleaned.slice(i, i + MAX_ASINS_PER_REQUEST));
+  }
+
+  for (const chunk of chunks) {
+    await withTracking<void>(
+      {
+        userId: opts.userId,
+        provider: 'keepa',
+        operation: 'fetch_sibling_stats',
+        model: 'keepa-product-v1',
+        metadata: { asinCount: chunk.length },
+        extractUsage: () => ({ costUsd: estimateKeepaCostUsd(chunk.length) }),
+      },
+      async () => {
+        const url =
+          `${KEEPA_BASE_URL}/product` +
+          `?key=${apiKey}` +
+          `&domain=${KEEPA_DOMAIN_US}` +
+          `&asin=${chunk.join(',')}` +
+          `&stats=180`;
+
+        const res = await fetch(url);
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          console.warn(`fetchSiblingStats: Keepa ${res.status}: ${text.slice(0, 200)}`);
+          return;
+        }
+        const data: any = await res.json();
+        const products: any[] = Array.isArray(data?.products) ? data.products : [];
+        for (const p of products) {
+          const asin = String(p?.asin ?? '').toUpperCase();
+          if (!asin) continue;
+          const cur: number[] = p?.stats?.current ?? [];
+          const bsr = typeof cur[3] === 'number' && cur[3] > 0 ? cur[3] : null;
+          const monthlySold =
+            typeof p?.monthlySold === 'number' && p.monthlySold > 0 ? p.monthlySold : null;
+          result.set(asin, { asin, monthlySold, bsr });
+        }
+      },
+    );
+  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Replaces the parent ÷ N equal-split with weighted attribution. Amazon's "X+ bought" bucket (Keepa monthlySold) is now used as a RELATIVE weight, never as the displayed value.
- Output is **smooth** by construction: `child_units = parent_total × (this_weight / sum_sibling_weights)`. Parent total comes from the corpus-calibrated BSR curve as before.
- Falls back to parent ÷ min(N, 5) equal-split when no siblings are passed (preserves current behavior for callers that haven't been wired yet).
- Sibling stats are batch-fetched from Keepa using `stats=180` only (~1 token/ASIN), so the cost increase is bounded.

## Worked example
Parent total = 1,071 units (from BSR + corpus calibration). 3 children with Keepa monthlySold buckets:
| Child | Bucket | Weight | Calc | Result |
|---|---|---|---|---|
| A | 500+ | 500 | 1,071 × (500/1000) | **536** |
| B | 300+ | 300 | 1,071 × (300/1000) | **321** |
| C | 200+ | 200 | 1,071 × (200/1000) | **214** |

Sum = 1,071 ✓ (preserves parent invariant). All numbers smooth (no 250s, no 350s, no 550s).

## What this fixes
- The reverted PR #80 displayed bucket midpoints (250 / 350 / 550) as the literal Monthly Sales value → multiple products in the same bucket showed identical round numbers.
- This PR uses the bucket as a WEIGHT only — the displayed value stays smooth (continuous from the parent total).

## Wiring
- `enrichedRow.ts` — accepts `opts.siblings: SiblingStat[]`, computes weighted attribution when provided
- `hydrateCompetitor.ts` — collects sibling ASINs from primary fetch, batch-fetches stats, passes to enriched-row builder. Used by `analyze-market` (vetting matrix path)
- `extension/enrich/route.ts` — same sibling-fetch pattern for the BloomLens drawer path

## Cost
- Sibling fetch is `stats=180` only — ~1 Keepa token per ASIN (vs ~5-7 for a full fetch)
- For a typical ~70-ASIN scan with avg 5 vars/parent: ~70 + 350 = 420 tokens vs ~70 today (~5× cost on cache misses)
- Existing keepa_lens_metrics cache covers the primary ASIN; subsequent re-scans of the same family hit cache → cost amortizes to ~1.2-1.5× over time
- **Future optimization (not in this PR)**: dedicated keepa_sibling_cache table with 7-day TTL — would cut steady-state cost back to ~1×

## Test plan (in-app `/vetting/[asin]` IS testable on preview)
- [ ] Open `/vetting/<any-asin>` on the preview deploy → click **Refresh Market Data** → matrix should now show smooth Monthly Sales numbers (e.g., 321, 536, 214 — NOT 250, 350, 550)
- [ ] Spot-check that variation families show the larger-badge child getting more units (e.g., 500+ child > 300+ child > 200+ child within the same parent)
- [ ] Spot-check that sum of children's Monthly Sales ≈ Parent Sales for each parent (within rounding)
- [ ] No nulls or NaN on products with no siblings (single-variation listings collapse to parent-level)

After in-app validation greenlights, promote to main → BloomLens drawer picks up the same logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)